### PR TITLE
Fix memory corruption due to TOKEN_PRIVILEGES not allocating enough memory

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
@@ -23,7 +23,7 @@ HRESULT RegistryDevirtualizer::Run(_In_ bool remove)
 {
     std::wstring rootPath = m_loadedHiveKeyName + L"\\Registry";
     RETURN_IF_FAILED(m_rootKey.Open(HKEY_USERS, rootPath.c_str(), KEY_READ));
-    
+
     for (auto mapping : mappings)
     {
         TraceLoggingWrite(g_MsixTraceLoggingProvider,
@@ -62,7 +62,7 @@ HRESULT RegistryDevirtualizer::Run(_In_ bool remove)
 
 bool RegistryDevirtualizer::IsExcludeKey(RegistryKey* realKey)
 {
-    const std::wstring excludeKeys[] = 
+    const std::wstring excludeKeys[] =
     {
         uninstallKeySubPath,   // uninstall key will be written by MsixInstaller itself, no need to copy from package
     };
@@ -122,7 +122,7 @@ HRESULT RegistryDevirtualizer::CopyAndDevirtualizeRegistryTree(RegistryKey* virt
         RETURN_IF_FAILED(CopyAndDevirtualizeRegistryTree(&sourceSubKey, &destinationSubKey));
         return S_OK;
     }));
-    
+
     DWORD valuesCount = 0;
     DWORD valueNameMaxLength = 0;
     DWORD valueDataMaxLength = 0;
@@ -326,7 +326,7 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
     {
         RETURN_IF_FAILED(E_OUTOFMEMORY);
     }
-    
+
     HANDLE userToken = nullptr;
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &userToken))
     {
@@ -353,32 +353,42 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
         RETURN_IF_FAILED(HRESULT_FROM_WIN32(GetLastError()));
     }
 
-    TOKEN_PRIVILEGES tokenPrivileges{};
+    PTOKEN_PRIVILEGES pTokenPrivileges;
     TOKEN_PRIVILEGES oldTokenPrivileges{};
     DWORD oldTokenPrivilegesSize = sizeof(TOKEN_PRIVILEGES);
 
-    tokenPrivileges.PrivilegeCount = 2;
-    tokenPrivileges.Privileges[0].Luid = seRestoreLuid;
-    tokenPrivileges.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-    tokenPrivileges.Privileges[1].Luid = seBackupLuid;
-    tokenPrivileges.Privileges[1].Attributes = SE_PRIVILEGE_ENABLED;
+    // be sure we allocate enought space for 2 LUID_AND_ATTRIBUTES
+    // by default TOKEN_PRIVILEGES allocates space for only 1 LUID_AND_ATTRIBUTES.
+    pTokenPrivileges = (PTOKEN_PRIVILEGES)LocalAlloc(LMEM_FIXED, sizeof(TOKEN_PRIVILEGES) +
+        (sizeof(LUID_AND_ATTRIBUTES) * 2));
+
+    pTokenPrivileges->PrivilegeCount = 2;
+    pTokenPrivileges->Privileges[0].Luid = seRestoreLuid;
+    pTokenPrivileges->Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+    pTokenPrivileges->Privileges[1].Luid = seBackupLuid;
+    pTokenPrivileges->Privileges[1].Attributes = SE_PRIVILEGE_ENABLED;
 
     if (!(AdjustTokenPrivileges(
         userToken,
         FALSE,
-        &tokenPrivileges,
+        pTokenPrivileges,
         sizeof(TOKEN_PRIVILEGES),
         &oldTokenPrivileges,
         &oldTokenPrivilegesSize)))
     {
-        RETURN_IF_FAILED(HRESULT_FROM_WIN32(GetLastError()));
+        auto lastError = HRESULT_FROM_WIN32(GetLastError());
+        if (FAILED(lastError))
+        {
+            LocalFree(pTokenPrivileges);
+            return lastError;
+        }
     }
 
-    RETURN_IF_FAILED(CreateTempKeyName(localInstance->m_loadedHiveKeyName));
+	LocalFree(pTokenPrivileges);
+	RETURN_IF_FAILED(CreateTempKeyName(localInstance->m_loadedHiveKeyName));
     RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegLoadKey(HKEY_USERS, localInstance->m_loadedHiveKeyName.c_str(), localInstance->m_registryHiveFileName.c_str())));
 
     *instance = localInstance.release();
-    
     return S_OK;
 }
 
@@ -408,5 +418,5 @@ RegistryDevirtualizer::~RegistryDevirtualizer()
             TraceLoggingValue(status, "Error LSTATUS"),
             TraceLoggingValue(m_loadedHiveKeyName.c_str(), "Hive key name"));
     }
-    
+
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
@@ -354,8 +354,6 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
     }
 
     PTOKEN_PRIVILEGES pTokenPrivileges = NULL;
-    TOKEN_PRIVILEGES oldTokenPrivileges{};
-    DWORD oldTokenPrivilegesSize = sizeof(TOKEN_PRIVILEGES);
 
     // be sure we allocate enought space for 2 LUID_AND_ATTRIBUTES
     // by default TOKEN_PRIVILEGES allocates space for only 1 LUID_AND_ATTRIBUTES.
@@ -366,9 +364,9 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
     pTokenPrivileges->Privileges[1].Luid = seBackupLuid;
     pTokenPrivileges->Privileges[1].Attributes = SE_PRIVILEGE_ENABLED;
 
-    auto success = AdjustTokenPrivileges(userToken, FALSE, pTokenPrivileges, sizeof(TOKEN_PRIVILEGES), &oldTokenPrivileges, &oldTokenPrivilegesSize);
+    auto success = AdjustTokenPrivileges(userToken, FALSE, pTokenPrivileges, sizeof(TOKEN_PRIVILEGES), NULL, NULL);
     LocalFree(pTokenPrivileges);
-    pTokenPrivileges = NULL;
+	pTokenPrivileges = NULL;
     if (!success)
     {
         RETURN_IF_FAILED(HRESULT_FROM_WIN32(GetLastError()));

--- a/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/RegistryDevirtualizer.cpp
@@ -359,9 +359,7 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
 
     // be sure we allocate enought space for 2 LUID_AND_ATTRIBUTES
     // by default TOKEN_PRIVILEGES allocates space for only 1 LUID_AND_ATTRIBUTES.
-    pTokenPrivileges = (PTOKEN_PRIVILEGES)LocalAlloc(LMEM_FIXED, sizeof(TOKEN_PRIVILEGES) +
-        (sizeof(LUID_AND_ATTRIBUTES) * 2));
-
+    pTokenPrivileges = (PTOKEN_PRIVILEGES)LocalAlloc(LMEM_FIXED, sizeof(TOKEN_PRIVILEGES) + (sizeof(LUID_AND_ATTRIBUTES) * 2));
     pTokenPrivileges->PrivilegeCount = 2;
     pTokenPrivileges->Privileges[0].Luid = seRestoreLuid;
     pTokenPrivileges->Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;


### PR DESCRIPTION
By default, `TOKEN_PRIVILEGES` can only host 1 `LUID_AND_ATTRIBUTES`, but Win7MsixInstaller writes 2 of them, overwriting the 12 following bytes.

See documentation:

> Important  The constant ANYSIZE_ARRAY is defined as 1 in the public header Winnt.h. To create this array with more than one element, you must allocate sufficient memory for the structure to take into account additional elements.

https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-_token_privileges