### PR TITLE
 Automatically assign AppUserModelId to the shortcut created by win7msixinstaller to enable desktop toast notifications on Win8+

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.cpp
@@ -6,138 +6,138 @@
 
 HRESULT PackageInfo::SetExecutableAndAppIdFromManifestElement(IMsixElement* element)
 {
-	BOOL hc = FALSE;
-	ComPtr<IMsixElementEnumerator> applicationElementEnum;
-	RETURN_IF_FAILED(element->GetElements(
-		L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']",
-		&applicationElementEnum));
-	RETURN_IF_FAILED(applicationElementEnum->GetHasCurrent(&hc));
+    BOOL hc = FALSE;
+    ComPtr<IMsixElementEnumerator> applicationElementEnum;
+    RETURN_IF_FAILED(element->GetElements(
+        L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']",
+        &applicationElementEnum));
+    RETURN_IF_FAILED(applicationElementEnum->GetHasCurrent(&hc));
 
-	if (!hc)
-	{
-		TraceLoggingWrite(g_MsixTraceLoggingProvider,
-			"No Application Found",
-			TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
-		return E_NOT_SET;
-	}
+    if (!hc)
+    {
+        TraceLoggingWrite(g_MsixTraceLoggingProvider,
+            "No Application Found",
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+        return E_NOT_SET;
+    }
 
-	ComPtr<IMsixElement> applicationElement;
-	RETURN_IF_FAILED(applicationElementEnum->GetCurrent(&applicationElement));
+    ComPtr<IMsixElement> applicationElement;
+    RETURN_IF_FAILED(applicationElementEnum->GetCurrent(&applicationElement));
 
-	Text<wchar_t> executablePath;
-	Text<wchar_t> applicationId;
-	RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Executable", &executablePath));
-	RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Id", &applicationId));
-	m_executableFilePath = executablePath.Get();
-	m_applicationId = applicationId.Get();
+    Text<wchar_t> executablePath;
+    Text<wchar_t> applicationId;
+    RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Executable", &executablePath));
+    RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Id", &applicationId));
+    m_executableFilePath = executablePath.Get();
+    m_applicationId = applicationId.Get();
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT PackageInfo::SetDisplayNameFromManifestElement(IMsixElement* element)
 {
-	ComPtr<IMsixElementEnumerator> visualElementsEnum;
-	RETURN_IF_FAILED(element->GetElements(
-		L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
-		&visualElementsEnum));
-	BOOL hc = FALSE;
-	RETURN_IF_FAILED(visualElementsEnum->GetHasCurrent(&hc));
-	if (!hc)
-	{
-		TraceLoggingWrite(g_MsixTraceLoggingProvider,
-			"No DisplayName Found",
-			TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
-		return E_NOT_SET;
-	}
+    ComPtr<IMsixElementEnumerator> visualElementsEnum;
+    RETURN_IF_FAILED(element->GetElements(
+        L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
+        &visualElementsEnum));
+    BOOL hc = FALSE;
+    RETURN_IF_FAILED(visualElementsEnum->GetHasCurrent(&hc));
+    if (!hc)
+    {
+        TraceLoggingWrite(g_MsixTraceLoggingProvider,
+            "No DisplayName Found",
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+        return E_NOT_SET;
+    }
 
-	ComPtr<IMsixElement> visualElementsElement;
-	RETURN_IF_FAILED(visualElementsEnum->GetCurrent(&visualElementsElement));
+    ComPtr<IMsixElement> visualElementsElement;
+    RETURN_IF_FAILED(visualElementsEnum->GetCurrent(&visualElementsElement));
 
-	Text<wchar_t> displayName;
-	RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayName));
-	m_displayName = displayName.Get();
+    Text<wchar_t> displayName;
+    RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayName));
+    m_displayName = displayName.Get();
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT PackageInfo::MakeFromManifestReader(IAppxManifestReader * manifestReader, std::wstring msix7DirectoryPath, PackageInfo ** packageInfo)
 {
-	std::unique_ptr<PackageInfo> instance(new PackageInfo());
-	if (instance == nullptr)
-	{
-		return E_OUTOFMEMORY;
-	}
+    std::unique_ptr<PackageInfo> instance(new PackageInfo());
+    if (instance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
 
-	RETURN_IF_FAILED(instance->SetManifestReader(manifestReader, msix7DirectoryPath));
+    RETURN_IF_FAILED(instance->SetManifestReader(manifestReader, msix7DirectoryPath));
 
-	*packageInfo = instance.release();
+    *packageInfo = instance.release();
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT PackageInfo::MakeFromPackageReader(IAppxPackageReader * packageReader, std::wstring msix7DirectoryPath, PackageInfo ** packageInfo)
 {
-	std::unique_ptr<PackageInfo> instance(new PackageInfo());
-	if (instance == nullptr)
-	{
-		return E_OUTOFMEMORY;
-	}
+    std::unique_ptr<PackageInfo> instance(new PackageInfo());
+    if (instance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
 
-	instance->m_packageReader = packageReader;
+    instance->m_packageReader = packageReader;
 
-	ComPtr<IAppxManifestReader> manifestReader;
-	RETURN_IF_FAILED(packageReader->GetManifest(&manifestReader));
-	RETURN_IF_FAILED(instance->SetManifestReader(manifestReader.Get(), msix7DirectoryPath));
+    ComPtr<IAppxManifestReader> manifestReader;
+    RETURN_IF_FAILED(packageReader->GetManifest(&manifestReader));
+    RETURN_IF_FAILED(instance->SetManifestReader(manifestReader.Get(), msix7DirectoryPath));
 
-	// Get the number of payload files
-	DWORD numberOfPayloadFiles = 0;
-	ComPtr<IAppxFilesEnumerator> fileEnum;
-	RETURN_IF_FAILED(packageReader->GetPayloadFiles(&fileEnum));
+    // Get the number of payload files
+    DWORD numberOfPayloadFiles = 0;
+    ComPtr<IAppxFilesEnumerator> fileEnum;
+    RETURN_IF_FAILED(packageReader->GetPayloadFiles(&fileEnum));
 
-	BOOL hc = FALSE;
-	RETURN_IF_FAILED(fileEnum->GetHasCurrent(&hc));
-	while (hc)
-	{
-		numberOfPayloadFiles++;
-		RETURN_IF_FAILED(fileEnum->MoveNext(&hc));
-	}
-	instance->m_numberOfPayloadFiles = numberOfPayloadFiles;
+    BOOL hc = FALSE;
+    RETURN_IF_FAILED(fileEnum->GetHasCurrent(&hc));
+    while (hc)
+    {
+        numberOfPayloadFiles++;
+        RETURN_IF_FAILED(fileEnum->MoveNext(&hc));
+    }
+    instance->m_numberOfPayloadFiles = numberOfPayloadFiles;
 
-	*packageInfo = instance.release();
+    *packageInfo = instance.release();
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT PackageInfo::SetManifestReader(IAppxManifestReader * manifestReader, std::wstring msix7DirectoryPath)
 {
-	m_manifestReader = manifestReader;
+    m_manifestReader = manifestReader;
 
-	// Also fill other fields that come from the manifest reader
-	ComPtr<IAppxManifestPackageId> manifestId;
-	RETURN_IF_FAILED(manifestReader->GetPackageId(&manifestId));
-	RETURN_IF_FAILED(manifestId->GetPublisher(&m_publisher));
-	RETURN_IF_FAILED(manifestId->GetVersion(&m_version));
+    // Also fill other fields that come from the manifest reader
+    ComPtr<IAppxManifestPackageId> manifestId;
+    RETURN_IF_FAILED(manifestReader->GetPackageId(&manifestId));
+    RETURN_IF_FAILED(manifestId->GetPublisher(&m_publisher));
+    RETURN_IF_FAILED(manifestId->GetVersion(&m_version));
 
-	Text<WCHAR> packageFullName;
-	RETURN_IF_FAILED(manifestId->GetPackageFullName(&packageFullName));
-	m_packageFullName = packageFullName.Get();
-	m_packageDirectoryPath = msix7DirectoryPath + packageFullName.Get();
+    Text<WCHAR> packageFullName;
+    RETURN_IF_FAILED(manifestId->GetPackageFullName(&packageFullName));
+    m_packageFullName = packageFullName.Get();
+    m_packageDirectoryPath = msix7DirectoryPath + packageFullName.Get();
 
-	ComPtr<IMsixDocumentElement> domElement;
-	RETURN_IF_FAILED(manifestReader->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
+    ComPtr<IMsixDocumentElement> domElement;
+    RETURN_IF_FAILED(manifestReader->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
 
-	ComPtr<IMsixElement> element;
-	RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
+    ComPtr<IMsixElement> element;
+    RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
 
-	RETURN_IF_FAILED(SetExecutableAndAppIdFromManifestElement(element.Get()));
+    RETURN_IF_FAILED(SetExecutableAndAppIdFromManifestElement(element.Get()));
 
-	RETURN_IF_FAILED(SetDisplayNameFromManifestElement(element.Get()));
+    RETURN_IF_FAILED(SetDisplayNameFromManifestElement(element.Get()));
 
-	Text<WCHAR> packageFamilyName;
-	RETURN_IF_FAILED(manifestId->GetPackageFamilyName(&packageFamilyName));
-	if (!m_applicationId.empty() && packageFamilyName.Get() != NULL)
-	{
-		m_appUserModelId = std::wstring(packageFamilyName.Get()) + L"!" + m_applicationId;
-	}
-	return S_OK;
+    Text<WCHAR> packageFamilyName;
+    RETURN_IF_FAILED(manifestId->GetPackageFamilyName(&packageFamilyName));
+    if (!m_applicationId.empty() && packageFamilyName.Get() != NULL)
+    {
+        m_appUserModelId = std::wstring(packageFamilyName.Get()) + L"!" + m_applicationId;
+    }
+    return S_OK;
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.cpp
@@ -4,131 +4,140 @@
 #include "GeneralUtil.hpp"
 #include <TraceLoggingProvider.h>
 
-HRESULT PackageInfo::SetExecutableFromManifestElement(IMsixElement* element)
+HRESULT PackageInfo::SetExecutableAndAppIdFromManifestElement(IMsixElement* element)
 {
-    BOOL hc = FALSE;
-    ComPtr<IMsixElementEnumerator> applicationElementEnum;
-    RETURN_IF_FAILED(element->GetElements(
-        L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']",
-        &applicationElementEnum));
-    RETURN_IF_FAILED(applicationElementEnum->GetHasCurrent(&hc));
+	BOOL hc = FALSE;
+	ComPtr<IMsixElementEnumerator> applicationElementEnum;
+	RETURN_IF_FAILED(element->GetElements(
+		L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']",
+		&applicationElementEnum));
+	RETURN_IF_FAILED(applicationElementEnum->GetHasCurrent(&hc));
 
-    if (!hc)
-    {
-        TraceLoggingWrite(g_MsixTraceLoggingProvider, 
-            "No Application Found", 
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
-        return E_NOT_SET;
-    }
+	if (!hc)
+	{
+		TraceLoggingWrite(g_MsixTraceLoggingProvider,
+			"No Application Found",
+			TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+		return E_NOT_SET;
+	}
 
-    ComPtr<IMsixElement> applicationElement;
-    RETURN_IF_FAILED(applicationElementEnum->GetCurrent(&applicationElement));
+	ComPtr<IMsixElement> applicationElement;
+	RETURN_IF_FAILED(applicationElementEnum->GetCurrent(&applicationElement));
 
-    Text<wchar_t> executablePath;
-    RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Executable", &executablePath));
-    m_executableFilePath = executablePath.Get();
+	Text<wchar_t> executablePath;
+	Text<wchar_t> applicationId;
+	RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Executable", &executablePath));
+	RETURN_IF_FAILED(applicationElement->GetAttributeValue(L"Id", &applicationId));
+	m_executableFilePath = executablePath.Get();
+	m_applicationId = applicationId.Get();
 
-    return S_OK;
+	return S_OK;
 }
 
 HRESULT PackageInfo::SetDisplayNameFromManifestElement(IMsixElement* element)
 {
-    ComPtr<IMsixElementEnumerator> visualElementsEnum;
-    RETURN_IF_FAILED(element->GetElements(
-        L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
-        &visualElementsEnum));
-    BOOL hc = FALSE;
-    RETURN_IF_FAILED(visualElementsEnum->GetHasCurrent(&hc));
-    if (!hc)
-    {
-        TraceLoggingWrite(g_MsixTraceLoggingProvider, 
-            "No DisplayName Found",
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
-        return E_NOT_SET;
-    }
+	ComPtr<IMsixElementEnumerator> visualElementsEnum;
+	RETURN_IF_FAILED(element->GetElements(
+		L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
+		&visualElementsEnum));
+	BOOL hc = FALSE;
+	RETURN_IF_FAILED(visualElementsEnum->GetHasCurrent(&hc));
+	if (!hc)
+	{
+		TraceLoggingWrite(g_MsixTraceLoggingProvider,
+			"No DisplayName Found",
+			TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+		return E_NOT_SET;
+	}
 
-    ComPtr<IMsixElement> visualElementsElement;
-    RETURN_IF_FAILED(visualElementsEnum->GetCurrent(&visualElementsElement));
+	ComPtr<IMsixElement> visualElementsElement;
+	RETURN_IF_FAILED(visualElementsEnum->GetCurrent(&visualElementsElement));
 
-    Text<wchar_t> displayName;
-    RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayName));
-    m_displayName = displayName.Get();
+	Text<wchar_t> displayName;
+	RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayName));
+	m_displayName = displayName.Get();
 
-    return S_OK;
+	return S_OK;
 }
 
 HRESULT PackageInfo::MakeFromManifestReader(IAppxManifestReader * manifestReader, std::wstring msix7DirectoryPath, PackageInfo ** packageInfo)
 {
-    std::unique_ptr<PackageInfo> instance(new PackageInfo());
-    if (instance == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
+	std::unique_ptr<PackageInfo> instance(new PackageInfo());
+	if (instance == nullptr)
+	{
+		return E_OUTOFMEMORY;
+	}
 
-    RETURN_IF_FAILED(instance->SetManifestReader(manifestReader, msix7DirectoryPath));
+	RETURN_IF_FAILED(instance->SetManifestReader(manifestReader, msix7DirectoryPath));
 
-    *packageInfo = instance.release();
+	*packageInfo = instance.release();
 
-    return S_OK;
+	return S_OK;
 }
 
 HRESULT PackageInfo::MakeFromPackageReader(IAppxPackageReader * packageReader, std::wstring msix7DirectoryPath, PackageInfo ** packageInfo)
 {
-    std::unique_ptr<PackageInfo> instance(new PackageInfo());
-    if (instance == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
+	std::unique_ptr<PackageInfo> instance(new PackageInfo());
+	if (instance == nullptr)
+	{
+		return E_OUTOFMEMORY;
+	}
 
-    instance->m_packageReader = packageReader;
+	instance->m_packageReader = packageReader;
 
-    ComPtr<IAppxManifestReader> manifestReader;
-    RETURN_IF_FAILED(packageReader->GetManifest(&manifestReader));
-    RETURN_IF_FAILED(instance->SetManifestReader(manifestReader.Get(), msix7DirectoryPath));
+	ComPtr<IAppxManifestReader> manifestReader;
+	RETURN_IF_FAILED(packageReader->GetManifest(&manifestReader));
+	RETURN_IF_FAILED(instance->SetManifestReader(manifestReader.Get(), msix7DirectoryPath));
 
-    // Get the number of payload files
-    DWORD numberOfPayloadFiles = 0;
-    ComPtr<IAppxFilesEnumerator> fileEnum;
-    RETURN_IF_FAILED(packageReader->GetPayloadFiles(&fileEnum));
+	// Get the number of payload files
+	DWORD numberOfPayloadFiles = 0;
+	ComPtr<IAppxFilesEnumerator> fileEnum;
+	RETURN_IF_FAILED(packageReader->GetPayloadFiles(&fileEnum));
 
-    BOOL hc = FALSE;
-    RETURN_IF_FAILED(fileEnum->GetHasCurrent(&hc));
-    while (hc)
-    {
-        numberOfPayloadFiles++;
-        RETURN_IF_FAILED(fileEnum->MoveNext(&hc));
-    }
-    instance->m_numberOfPayloadFiles = numberOfPayloadFiles;
-    
-    *packageInfo = instance.release();
+	BOOL hc = FALSE;
+	RETURN_IF_FAILED(fileEnum->GetHasCurrent(&hc));
+	while (hc)
+	{
+		numberOfPayloadFiles++;
+		RETURN_IF_FAILED(fileEnum->MoveNext(&hc));
+	}
+	instance->m_numberOfPayloadFiles = numberOfPayloadFiles;
 
-    return S_OK;
+	*packageInfo = instance.release();
+
+	return S_OK;
 }
 
 HRESULT PackageInfo::SetManifestReader(IAppxManifestReader * manifestReader, std::wstring msix7DirectoryPath)
 {
-    m_manifestReader = manifestReader;
-    
-    // Also fill other fields that come from the manifest reader
-    ComPtr<IAppxManifestPackageId> manifestId;
-    RETURN_IF_FAILED(manifestReader->GetPackageId(&manifestId));
-    RETURN_IF_FAILED(manifestId->GetPublisher(&m_publisher));
-    RETURN_IF_FAILED(manifestId->GetVersion(&m_version));
+	m_manifestReader = manifestReader;
 
-    Text<WCHAR> packageFullName;
-    RETURN_IF_FAILED(manifestId->GetPackageFullName(&packageFullName));
-    m_packageFullName = packageFullName.Get();
-    m_packageDirectoryPath = msix7DirectoryPath + packageFullName.Get();
+	// Also fill other fields that come from the manifest reader
+	ComPtr<IAppxManifestPackageId> manifestId;
+	RETURN_IF_FAILED(manifestReader->GetPackageId(&manifestId));
+	RETURN_IF_FAILED(manifestId->GetPublisher(&m_publisher));
+	RETURN_IF_FAILED(manifestId->GetVersion(&m_version));
 
-    ComPtr<IMsixDocumentElement> domElement;
-    RETURN_IF_FAILED(manifestReader->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
+	Text<WCHAR> packageFullName;
+	RETURN_IF_FAILED(manifestId->GetPackageFullName(&packageFullName));
+	m_packageFullName = packageFullName.Get();
+	m_packageDirectoryPath = msix7DirectoryPath + packageFullName.Get();
 
-    ComPtr<IMsixElement> element;
-    RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
+	ComPtr<IMsixDocumentElement> domElement;
+	RETURN_IF_FAILED(manifestReader->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
 
-    RETURN_IF_FAILED(SetExecutableFromManifestElement(element.Get()));
+	ComPtr<IMsixElement> element;
+	RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
 
-    RETURN_IF_FAILED(SetDisplayNameFromManifestElement(element.Get()));
-    
-    return S_OK;
+	RETURN_IF_FAILED(SetExecutableAndAppIdFromManifestElement(element.Get()));
+
+	RETURN_IF_FAILED(SetDisplayNameFromManifestElement(element.Get()));
+
+	Text<WCHAR> packageFamilyName;
+	RETURN_IF_FAILED(manifestId->GetPackageFamilyName(&packageFamilyName));
+	if (!m_applicationId.empty() && packageFamilyName.Get() != NULL)
+	{
+		m_appUserModelId = std::wstring(packageFamilyName.Get()) + L"!" + m_applicationId;
+	}
+	return S_OK;
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.hpp
@@ -11,9 +11,9 @@ private:
     std::wstring m_packageDirectoryPath;
     std::wstring m_executableFilePath;
     std::wstring m_displayName;
-	std::wstring m_appUserModelId;
-	std::wstring m_applicationId;
-	UINT64 m_version = 0;
+    std::wstring m_appUserModelId;
+    std::wstring m_applicationId;
+    UINT64 m_version = 0;
     Text<WCHAR> m_publisher;
 
     /// PackageReader and payloadFiles are available on Add, but not Remove because it's created off the original package itself which is no longer available once it's been installed.
@@ -27,14 +27,14 @@ private:
     /// @param msix7DirectoryPath - the root msix7 directory path, which is the parent directory of the package directory.
     HRESULT SetManifestReader(IAppxManifestReader* manifestReader, std::wstring msix7DirectoryPath);
 
-	/// Sets the executable path by reading it from the manifest element
-	HRESULT SetExecutableAndAppIdFromManifestElement(IMsixElement * element);
+    /// Sets the executable path by reading it from the manifest element
+    HRESULT SetExecutableAndAppIdFromManifestElement(IMsixElement * element);
 
     /// Sets the display name by reading it from the manifest element
     HRESULT SetDisplayNameFromManifestElement(IMsixElement * element);
 
-	/// Sets the application model user id from the manifest reader
-	HRESULT SetApplicationUserModelIdFromManifestElement(IAppxManifestReader* manifestReader);
+    /// Sets the application model user id from the manifest reader
+    HRESULT SetApplicationUserModelIdFromManifestElement(IAppxManifestReader* manifestReader);
 
 public:
     /// Create a PackageInfo using the manifest reader and directory path. This is intended for Remove scenarios where
@@ -56,9 +56,9 @@ public:
     std::wstring GetPackageDirectoryPath() { return m_packageDirectoryPath; }
     std::wstring GetExecutableFilePath() { return m_executableFilePath; }
     std::wstring GetDisplayName() { return m_displayName;  }
-	std::wstring GetAppModelUserId() { return m_appUserModelId; }
-	UINT64 GetVersion() { return m_version; }
-	PCWSTR GetPublisher() { return m_publisher.Get(); }
+    std::wstring GetAppModelUserId() { return m_appUserModelId; }
+    UINT64 GetVersion() { return m_version; }
+    PCWSTR GetPublisher() { return m_publisher.Get(); }
 
     /// This is meant only to be called when deleting the manifest file; the reader needs to first be released so it can be deleted
     void ReleaseManifest() { m_manifestReader.Release(); }

--- a/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/PackageInfo.hpp
@@ -11,7 +11,9 @@ private:
     std::wstring m_packageDirectoryPath;
     std::wstring m_executableFilePath;
     std::wstring m_displayName;
-    UINT64 m_version = 0;
+	std::wstring m_appUserModelId;
+	std::wstring m_applicationId;
+	UINT64 m_version = 0;
     Text<WCHAR> m_publisher;
 
     /// PackageReader and payloadFiles are available on Add, but not Remove because it's created off the original package itself which is no longer available once it's been installed.
@@ -25,11 +27,14 @@ private:
     /// @param msix7DirectoryPath - the root msix7 directory path, which is the parent directory of the package directory.
     HRESULT SetManifestReader(IAppxManifestReader* manifestReader, std::wstring msix7DirectoryPath);
 
-    /// Sets the executable path by reading it from the manifest element
-    HRESULT SetExecutableFromManifestElement(IMsixElement * element);
+	/// Sets the executable path by reading it from the manifest element
+	HRESULT SetExecutableAndAppIdFromManifestElement(IMsixElement * element);
 
     /// Sets the display name by reading it from the manifest element
     HRESULT SetDisplayNameFromManifestElement(IMsixElement * element);
+
+	/// Sets the application model user id from the manifest reader
+	HRESULT SetApplicationUserModelIdFromManifestElement(IAppxManifestReader* manifestReader);
 
 public:
     /// Create a PackageInfo using the manifest reader and directory path. This is intended for Remove scenarios where
@@ -51,8 +56,9 @@ public:
     std::wstring GetPackageDirectoryPath() { return m_packageDirectoryPath; }
     std::wstring GetExecutableFilePath() { return m_executableFilePath; }
     std::wstring GetDisplayName() { return m_displayName;  }
-    UINT64 GetVersion() { return m_version; }
-    PCWSTR GetPublisher() { return m_publisher.Get(); }
+	std::wstring GetAppModelUserId() { return m_appUserModelId; }
+	UINT64 GetVersion() { return m_version; }
+	PCWSTR GetPublisher() { return m_publisher.Get(); }
 
     /// This is meant only to be called when deleting the manifest file; the reader needs to first be released so it can be deleted
     void ReleaseManifest() { m_manifestReader.Release(); }

--- a/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.cpp
@@ -14,67 +14,67 @@ const PCWSTR StartMenuLink::HandlerName = L"StartMenuLink";
 
 HRESULT StartMenuLink::CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description, PCWSTR appUserModelId)
 {
-	TraceLoggingWrite(g_MsixTraceLoggingProvider,
-		"Creating Link",
-		TraceLoggingValue(targetFilePath, "TargetFilePath"),
-		TraceLoggingValue(linkFilePath, "LinkFilePath"),
-		TraceLoggingValue(appUserModelId, "AppUserModelId"));
+    TraceLoggingWrite(g_MsixTraceLoggingProvider,
+        "Creating Link",
+        TraceLoggingValue(targetFilePath, "TargetFilePath"),
+        TraceLoggingValue(linkFilePath, "LinkFilePath"),
+        TraceLoggingValue(appUserModelId, "AppUserModelId"));
 
-	ComPtr<IShellLink> shellLink;
-	RETURN_IF_FAILED(CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink)));
-	RETURN_IF_FAILED(shellLink->SetPath(targetFilePath));
-	RETURN_IF_FAILED(shellLink->SetArguments(L""));
+    ComPtr<IShellLink> shellLink;
+    RETURN_IF_FAILED(CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink)));
+    RETURN_IF_FAILED(shellLink->SetPath(targetFilePath));
+    RETURN_IF_FAILED(shellLink->SetArguments(L""));
 
-	if (appUserModelId != NULL && appUserModelId[0] != 0)
-	{
-		ComPtr<IPropertyStore> propertyStore;
-		PROPVARIANT appIdPropVar;
-		RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPropertyStore, reinterpret_cast<LPVOID*>(&propertyStore)));
-		RETURN_IF_FAILED(InitPropVariantFromString(appUserModelId, &appIdPropVar));
-		RETURN_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar));
-		RETURN_IF_FAILED(propertyStore->Commit());
-		PropVariantClear(&appIdPropVar);
-	}
+    if (appUserModelId != NULL && appUserModelId[0] != 0)
+    {
+        ComPtr<IPropertyStore> propertyStore;
+        PROPVARIANT appIdPropVar;
+        RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPropertyStore, reinterpret_cast<LPVOID*>(&propertyStore)));
+        RETURN_IF_FAILED(InitPropVariantFromString(appUserModelId, &appIdPropVar));
+        RETURN_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar));
+        RETURN_IF_FAILED(propertyStore->Commit());
+        PropVariantClear(&appIdPropVar);
+    }
 
-	RETURN_IF_FAILED(shellLink->SetDescription(description));
+    RETURN_IF_FAILED(shellLink->SetDescription(description));
 
-	ComPtr<IPersistFile> persistFile;
-	RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile)));
-	RETURN_IF_FAILED(persistFile->Save(linkFilePath, TRUE));
-	return S_OK;
+    ComPtr<IPersistFile> persistFile;
+    RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile)));
+    RETURN_IF_FAILED(persistFile->Save(linkFilePath, TRUE));
+    return S_OK;
 }
 
 HRESULT StartMenuLink::ExecuteForAddRequest()
 {
-	PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
+    PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
 
-	std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
+    std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
 
-	std::wstring resolvedExecutableFullPath = m_msixRequest->GetFilePathMappings()->GetExecutablePath(packageInfo->GetExecutableFilePath(), packageInfo->GetPackageFullName().c_str());
-	std::wstring appUserModelId = m_msixRequest->GetPackageInfo()->GetAppModelUserId();
-	RETURN_IF_FAILED(CreateLink(resolvedExecutableFullPath.c_str(), filePath.c_str(), L"", appUserModelId.c_str()));
+    std::wstring resolvedExecutableFullPath = m_msixRequest->GetFilePathMappings()->GetExecutablePath(packageInfo->GetExecutableFilePath(), packageInfo->GetPackageFullName().c_str());
+    std::wstring appUserModelId = m_msixRequest->GetPackageInfo()->GetAppModelUserId();
+    RETURN_IF_FAILED(CreateLink(resolvedExecutableFullPath.c_str(), filePath.c_str(), L"", appUserModelId.c_str()));
 
-	return S_OK;
+    return S_OK;
 }
 
 HRESULT StartMenuLink::ExecuteForRemoveRequest()
 {
-	PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
+    PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
 
-	std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
+    std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
 
-	RETURN_IF_FAILED(DeleteFile(filePath.c_str()));
-	return S_OK;
+    RETURN_IF_FAILED(DeleteFile(filePath.c_str()));
+    return S_OK;
 }
 
 HRESULT StartMenuLink::CreateHandler(MsixRequest * msixRequest, IPackageHandler ** instance)
 {
-	std::unique_ptr<StartMenuLink> localInstance(new StartMenuLink(msixRequest));
-	if (localInstance == nullptr)
-	{
-		return E_OUTOFMEMORY;
-	}
-	*instance = localInstance.release();
+    std::unique_ptr<StartMenuLink> localInstance(new StartMenuLink(msixRequest));
+    if (localInstance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+    *instance = localInstance.release();
 
-	return S_OK;
+    return S_OK;
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.cpp
@@ -2,6 +2,8 @@
 
 #include <shlobj_core.h>
 #include <CommCtrl.h>
+#include <propvarutil.h>
+#include <propkey.h>
 
 #include "FilePaths.hpp"
 #include "StartMenuLink.hpp"
@@ -10,54 +12,69 @@
 
 const PCWSTR StartMenuLink::HandlerName = L"StartMenuLink";
 
-HRESULT StartMenuLink::CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description)
+HRESULT StartMenuLink::CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description, PCWSTR appUserModelId)
 {
-    TraceLoggingWrite(g_MsixTraceLoggingProvider,
-        "Creating Link",
-        TraceLoggingValue(targetFilePath, "TargetFilePath"),
-        TraceLoggingValue(linkFilePath, "LinkFilePath"));
+	TraceLoggingWrite(g_MsixTraceLoggingProvider,
+		"Creating Link",
+		TraceLoggingValue(targetFilePath, "TargetFilePath"),
+		TraceLoggingValue(linkFilePath, "LinkFilePath"),
+		TraceLoggingValue(appUserModelId, "AppUserModelId"));
 
-    ComPtr<IShellLink> shellLink;
-    RETURN_IF_FAILED(CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink)));
-    RETURN_IF_FAILED(shellLink->SetPath(targetFilePath));
-    RETURN_IF_FAILED(shellLink->SetDescription(description));
+	ComPtr<IShellLink> shellLink;
+	RETURN_IF_FAILED(CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, reinterpret_cast<LPVOID*>(&shellLink)));
+	RETURN_IF_FAILED(shellLink->SetPath(targetFilePath));
+	RETURN_IF_FAILED(shellLink->SetArguments(L""));
 
-    ComPtr<IPersistFile> persistFile;
-    RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile)));
-    RETURN_IF_FAILED(persistFile->Save(linkFilePath, TRUE));
-    return S_OK;
+	if (appUserModelId != NULL && appUserModelId[0] != 0)
+	{
+		ComPtr<IPropertyStore> propertyStore;
+		PROPVARIANT appIdPropVar;
+		RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPropertyStore, reinterpret_cast<LPVOID*>(&propertyStore)));
+		RETURN_IF_FAILED(InitPropVariantFromString(appUserModelId, &appIdPropVar));
+		RETURN_IF_FAILED(propertyStore->SetValue(PKEY_AppUserModel_ID, appIdPropVar));
+		RETURN_IF_FAILED(propertyStore->Commit());
+		PropVariantClear(&appIdPropVar);
+	}
+
+	RETURN_IF_FAILED(shellLink->SetDescription(description));
+
+	ComPtr<IPersistFile> persistFile;
+	RETURN_IF_FAILED(shellLink->QueryInterface(IID_IPersistFile, reinterpret_cast<LPVOID*>(&persistFile)));
+	RETURN_IF_FAILED(persistFile->Save(linkFilePath, TRUE));
+	return S_OK;
 }
 
 HRESULT StartMenuLink::ExecuteForAddRequest()
 {
-    PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
+	PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
 
-    std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
+	std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
 
-    std::wstring resolvedExecutableFullPath = m_msixRequest->GetFilePathMappings()->GetExecutablePath(packageInfo->GetExecutableFilePath(), packageInfo->GetPackageFullName().c_str());
-    RETURN_IF_FAILED(CreateLink(resolvedExecutableFullPath.c_str(), filePath.c_str(), L""));
+	std::wstring resolvedExecutableFullPath = m_msixRequest->GetFilePathMappings()->GetExecutablePath(packageInfo->GetExecutableFilePath(), packageInfo->GetPackageFullName().c_str());
+	std::wstring appUserModelId = m_msixRequest->GetPackageInfo()->GetAppModelUserId();
+	RETURN_IF_FAILED(CreateLink(resolvedExecutableFullPath.c_str(), filePath.c_str(), L"", appUserModelId.c_str()));
 
-    return S_OK;
+	return S_OK;
 }
 
 HRESULT StartMenuLink::ExecuteForRemoveRequest()
 {
-    PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
+	PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
 
-    std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
+	std::wstring filePath = m_msixRequest->GetFilePathMappings()->GetMap()[L"Common Programs"] + L"\\" + packageInfo->GetDisplayName() + L".lnk";
 
-    RETURN_IF_FAILED(DeleteFile(filePath.c_str()));
-    return S_OK;
+	RETURN_IF_FAILED(DeleteFile(filePath.c_str()));
+	return S_OK;
 }
 
 HRESULT StartMenuLink::CreateHandler(MsixRequest * msixRequest, IPackageHandler ** instance)
 {
-    std::unique_ptr<StartMenuLink> localInstance(new StartMenuLink(msixRequest));
-    if (localInstance == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-    *instance = localInstance.release();
+	std::unique_ptr<StartMenuLink> localInstance(new StartMenuLink(msixRequest));
+	if (localInstance == nullptr)
+	{
+		return E_OUTOFMEMORY;
+	}
+	*instance = localInstance.release();
 
-    return S_OK;
+	return S_OK;
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.hpp
@@ -27,7 +27,7 @@ private:
     /// to create and store a shortcut to the specified object.
     /// @param targetFilePath - full file path to the application exe
     /// @param linkFilePath - full file path to the shortcut .lnk file
-    /// @description - description of the Shell link, stored in the Comment field of the link
-    ///                properties.
-    HRESULT CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description);
+	/// @param description - description of the Shell link, stored in the Comment field of the link properties.
+	/// @param appUserModelId- Application User Model ID, needed to display toasts.
+	HRESULT CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description, PCWSTR appUserModelId = NULL);
 };

--- a/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/StartMenuLink.hpp
@@ -27,7 +27,7 @@ private:
     /// to create and store a shortcut to the specified object.
     /// @param targetFilePath - full file path to the application exe
     /// @param linkFilePath - full file path to the shortcut .lnk file
-	/// @param description - description of the Shell link, stored in the Comment field of the link properties.
-	/// @param appUserModelId- Application User Model ID, needed to display toasts.
-	HRESULT CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description, PCWSTR appUserModelId = NULL);
+    /// @param description - description of the Shell link, stored in the Comment field of the link properties.
+    /// @param appUserModelId- Application User Model ID, needed to display toasts.
+    HRESULT CreateLink(PCWSTR targetFilePath, PCWSTR linkFilePath, PCWSTR description, PCWSTR appUserModelId = NULL);
 };


### PR DESCRIPTION
Classic Win32 applications (out of Desktop Bridge) have to declare the Application User Model ID (AUMID) on the app's shortcut in Start in order to enable toast notifications. 

The diff will automatically assign the `Application Model User Id` of the .msix installed by `win7msixInstaller`.

