### PR TITLE
[Win7MsixInstaller] Fix UI drawing when the dialog is minimized or partially out of the screen.

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
@@ -17,8 +17,6 @@
 using namespace std;
 #include <GdiPlus.h>
 
-Gdiplus::Image* g_image = nullptr;
-
 static const int g_width = 500;  // width of window
 static const int g_heigth = 400; // height of window
 
@@ -477,17 +475,15 @@ BOOL ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring messageT
     layoutRect.Y += 40;
     graphics.DrawString(messageText.c_str(), -1, &messageFont, layoutRect, &format, &blackBrush);
 
-    if (logoStream != nullptr)
-    {
-        // We shouldn't fail if the image can't be loaded, just don't show it.
-        g_image = Gdiplus::Image::FromStream(logoStream, FALSE);
-            
-    }
-        
-    if (g_image != nullptr)
-    {
-        Gdiplus::Status status = graphics.DrawImage(g_image, g_width - 200, 25);
-    }
+	if (logoStream != nullptr)
+	{
+		// We shouldn't fail if the image can't be loaded, just don't show it.
+		auto g_image = Gdiplus::Image::FromStream(logoStream, FALSE);
+		if (g_image != nullptr)
+		{
+			Gdiplus::Status status = graphics.DrawImage(g_image, g_width - 200, 25);
+		}
+	}
 
     EndPaint(parentHWnd, &paint);
 

--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
@@ -1,4 +1,4 @@
-// UI Functions
+    // UI Functions
 
 #include "InstallUI.hpp"
 #include <windows.h>
@@ -63,20 +63,20 @@ HRESULT GetStreamFromFile(IAppxPackageReader* package, LPCWCHAR name, IStream** 
 
 HRESULT UI::DrawPackageInfo(HWND hWnd, RECT windowRect)
 {
-	if (SUCCEEDED(m_loadingPackageInfoCode))
-	{
-		auto displayText = L"Install " + m_displayName + L"?";
-		auto messageText = L"Publisher: " + m_publisherCommonName + L"\nVersion: " + m_version;
-		ChangeText(hWnd, displayText, messageText, m_logoStream.Get());
-		ChangeText(hWnd, GetStringResource(IDS_STRING_UI_INSTALL_COMPLETE), GetStringResource(IDS_STRING_UI_COMPLETION_MESSAGE));
-	}
-	else
-	{
-		std::wstringstream wstringstream;
-		wstringstream << L"Failed getting package information with: 0x" << std::hex << m_loadingPackageInfoCode;
-		auto g_messageText = wstringstream.str();
-		ChangeText(hWnd, L"Loading Package failed", g_messageText);
-	}
+    if (SUCCEEDED(m_loadingPackageInfoCode))
+    {
+        auto displayText = L"Install " + m_displayName + L"?";
+        auto messageText = L"Publisher: " + m_publisherCommonName + L"\nVersion: " + m_version;
+        ChangeText(hWnd, displayText, messageText, m_logoStream.Get());
+        ChangeText(hWnd, GetStringResource(IDS_STRING_UI_INSTALL_COMPLETE), GetStringResource(IDS_STRING_UI_COMPLETION_MESSAGE));
+    }
+    else
+    {
+        std::wstringstream wstringstream;
+        wstringstream << L"Failed getting package information with: 0x" << std::hex << m_loadingPackageInfoCode;
+        auto g_messageText = wstringstream.str();
+        ChangeText(hWnd, L"Loading Package failed", g_messageText);
+    }
     return S_OK;
 }
 
@@ -97,34 +97,34 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     case WM_CREATE:
         LaunchButton(hWnd, windowRect);
         CreateCheckbox(hWnd, windowRect);
-		break;
+        break;
     case WM_PAINT:
     {
-		if (ui != NULL)
-		{
-			ui->DrawPackageInfo(hWnd, windowRect);
-		}
+        if (ui != NULL)
+        {
+            ui->DrawPackageInfo(hWnd, windowRect);
+        }
         break;
     }
     case WM_COMMAND:
         switch (LOWORD(wParam)) 
         {
             case IDC_INSTALLBUTTON:
-            {				
+            {                
                 if (!g_installed)
                 {
                     DestroyWindow(g_buttonHWnd);
                     CreateCancelButton(hWnd, windowRect);
                     UpdateWindow(hWnd);
-					if (ui != NULL)
-					{
-						CreateProgressBar(hWnd, windowRect, ui->GetNumberOfFiles());
-					}
-					ShowWindow(g_progressHWnd, SW_SHOW); //Show progress bar only when install is clicked
-					if (ui != NULL)
-					{
-						ui->SetButtonClicked();
-					}
+                    if (ui != NULL)
+                    {
+                        CreateProgressBar(hWnd, windowRect, ui->GetNumberOfFiles());
+                    }
+                    ShowWindow(g_progressHWnd, SW_SHOW); //Show progress bar only when install is clicked
+                    if (ui != NULL)
+                    {
+                        ui->SetButtonClicked();
+                    }
                 }
                 else
                 {
@@ -222,58 +222,58 @@ void StartUIThread(UI* ui)
     Gdiplus::GdiplusStartupInput gdiplusStartupInput;
     ULONG_PTR gdiplusToken;
     Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
-	ui->CreateInitWindow(hInstance, SW_SHOWNORMAL, windowClass, title);
-	Gdiplus::GdiplusShutdown(gdiplusToken);
+    ui->CreateInitWindow(hInstance, SW_SHOWNORMAL, windowClass, title);
+    Gdiplus::GdiplusShutdown(gdiplusToken);
 
 }
 
 void UI::LoadInfo()
 {
-	m_loadingPackageInfoCode = ParseInfoFromPackage();
+    m_loadingPackageInfoCode = ParseInfoFromPackage();
 }
 
 HRESULT UI::ParseInfoFromPackage() 
 {
-	PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
+    PackageInfo* packageInfo = m_msixRequest->GetPackageInfo();
 
-	ComPtr<IMsixDocumentElement> domElement;
-	RETURN_IF_FAILED(packageInfo->GetManifestReader()->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
+    ComPtr<IMsixDocumentElement> domElement;
+    RETURN_IF_FAILED(packageInfo->GetManifestReader()->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
 
-	ComPtr<IMsixElement> element;
-	RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
+    ComPtr<IMsixElement> element;
+    RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
 
-	// Obtain the Display Name and Logo
-	ComPtr<IMsixElementEnumerator> veElementEnum;
-	RETURN_IF_FAILED(element->GetElements(
-		L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
-		&veElementEnum));
+    // Obtain the Display Name and Logo
+    ComPtr<IMsixElementEnumerator> veElementEnum;
+    RETURN_IF_FAILED(element->GetElements(
+        L"/*[local-name()='Package']/*[local-name()='Applications']/*[local-name()='Application']/*[local-name()='VisualElements']",
+        &veElementEnum));
 
-	// Obtain publisher name
-	auto wpublisher = std::wstring(packageInfo->GetPublisher());
-	m_publisherCommonName = wpublisher.substr(wpublisher.find_first_of(L"=") + 1,
-		wpublisher.find_first_of(L",") - wpublisher.find_first_of(L"=") - 1);
+    // Obtain publisher name
+    auto wpublisher = std::wstring(packageInfo->GetPublisher());
+    m_publisherCommonName = wpublisher.substr(wpublisher.find_first_of(L"=") + 1,
+        wpublisher.find_first_of(L",") - wpublisher.find_first_of(L"=") - 1);
 
-	// Obtain version number
-	ConvertVersionToString(packageInfo->GetVersion());
+    // Obtain version number
+    ConvertVersionToString(packageInfo->GetVersion());
 
-	//Obtain the number of files
-	m_numberOfFiles = packageInfo->GetNumberOfPayloadFiles();
+    //Obtain the number of files
+    m_numberOfFiles = packageInfo->GetNumberOfPayloadFiles();
 
-	// Obtain logo
-	BOOL hc = FALSE;
-	RETURN_IF_FAILED(veElementEnum->GetHasCurrent(&hc));
-	if (hc)
-	{
-		ComPtr<IMsixElement> visualElementsElement;
-		Text<WCHAR> displayNameValue;
-		RETURN_IF_FAILED(veElementEnum->GetCurrent(&visualElementsElement));
-		RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayNameValue));
-		m_displayName = std::wstring(displayNameValue.Get());
-		Text<WCHAR> logo;
-		RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"Square150x150Logo", &logo));
-		RETURN_IF_FAILED(GetStreamFromFile(packageInfo->GetPackageReader(), logo.Get(), &m_logoStream));
-	}
-	return S_OK;
+    // Obtain logo
+    BOOL hc = FALSE;
+    RETURN_IF_FAILED(veElementEnum->GetHasCurrent(&hc));
+    if (hc)
+    {
+        ComPtr<IMsixElement> visualElementsElement;
+        Text<WCHAR> displayNameValue;
+        RETURN_IF_FAILED(veElementEnum->GetCurrent(&visualElementsElement));
+        RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"DisplayName", &displayNameValue));
+        m_displayName = std::wstring(displayNameValue.Get());
+        Text<WCHAR> logo;
+        RETURN_IF_FAILED(visualElementsElement->GetAttributeValue(L"Square150x150Logo", &logo));
+        RETURN_IF_FAILED(GetStreamFromFile(packageInfo->GetPackageReader(), logo.Get(), &m_logoStream));
+    }
+    return S_OK;
 }
 
 HRESULT UI::ShowUI()
@@ -295,7 +295,7 @@ HRESULT CreateAndShowUI::ExecuteForAddRequest()
 
     AutoPtr<UI> ui;
     RETURN_IF_FAILED(UI::Make(m_msixRequest, &ui));
-	ui->LoadInfo();
+    ui->LoadInfo();
 
     m_msixRequest->SetUI(ui.Detach());
     RETURN_IF_FAILED(m_msixRequest->GetUI()->ShowUI());
@@ -392,7 +392,7 @@ BOOL LaunchButton(HWND parentHWnd, RECT parentRect) {
 // parentRect: the specs of the parent window
 BOOL CreateCheckbox(HWND parentHWnd, RECT parentRect)
 {
-	g_checkboxHWnd = CreateWindowEx(
+    g_checkboxHWnd = CreateWindowEx(
         WS_EX_LEFT, // extended window style
         L"BUTTON",
         L"Launch when ready",  // text
@@ -406,9 +406,9 @@ BOOL CreateCheckbox(HWND parentHWnd, RECT parentRect)
         reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
         NULL);
 
-	//Set default checkbox state to checked
-	SendMessage(g_checkboxHWnd, BM_SETCHECK, BST_CHECKED, 0);
-	return TRUE;
+    //Set default checkbox state to checked
+    SendMessage(g_checkboxHWnd, BM_SETCHECK, BST_CHECKED, 0);
+    return TRUE;
 }
 
 // FUNCTION: CancelButton(HWND parentHWnd, RECT parentRect)
@@ -418,21 +418,21 @@ BOOL CreateCheckbox(HWND parentHWnd, RECT parentRect)
 // parentHWnd: the HWND of the window to add the button to
 // parentRect: the specs of the parent window
 BOOL CreateCancelButton(HWND parentHWnd, RECT parentRect) {
-	LPVOID buttonPointer = nullptr;
-	g_CancelbuttonHWnd = CreateWindowEx(
-		WS_EX_LEFT, // extended window style
-		L"BUTTON",
-		L"Cancel",  // text
-		WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON | BS_FLAT, // style
-		parentRect.right - 100 - 50, // x coord
-		parentRect.bottom - 60,  // y coord
-		120,  // width
-		35,  // height
-		parentHWnd,  // parent
-		(HMENU)IDC_CANCELBUTTON, // menu
-		reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
-		buttonPointer); // pointer to button
-	return TRUE;
+    LPVOID buttonPointer = nullptr;
+    g_CancelbuttonHWnd = CreateWindowEx(
+        WS_EX_LEFT, // extended window style
+        L"BUTTON",
+        L"Cancel",  // text
+        WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON | BS_FLAT, // style
+        parentRect.right - 100 - 50, // x coord
+        parentRect.bottom - 60,  // y coord
+        120,  // width
+        35,  // height
+        parentHWnd,  // parent
+        (HMENU)IDC_CANCELBUTTON, // menu
+        reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
+        buttonPointer); // pointer to button
+    return TRUE;
 }
 
 // FUNCTION: ChangeButtonText(LPARAM newMessage)
@@ -475,15 +475,16 @@ BOOL ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring messageT
     layoutRect.Y += 40;
     graphics.DrawString(messageText.c_str(), -1, &messageFont, layoutRect, &format, &blackBrush);
 
-	if (logoStream != nullptr)
-	{
-		// We shouldn't fail if the image can't be loaded, just don't show it.
-		auto g_image = Gdiplus::Image::FromStream(logoStream, FALSE);
-		if (g_image != nullptr)
-		{
-			Gdiplus::Status status = graphics.DrawImage(g_image, g_width - 200, 25);
-		}
-	}
+    if (logoStream != nullptr)
+    {
+        // We shouldn't fail if the image can't be loaded, just don't show it.
+        auto image = Gdiplus::Image::FromStream(logoStream, FALSE);
+        if (image != nullptr)
+        {
+            Gdiplus::Status status = graphics.DrawImage(image, g_width - 200, 25);
+            delete image;
+        }
+    }
 
     EndPaint(parentHWnd, &paint);
 
@@ -497,7 +498,7 @@ BOOL ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring messageT
 // windowTitle: the window title
 int UI::CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& windowClass, const std::wstring& title)
 {
-	HWND hWnd = CreateWindow(
+    HWND hWnd = CreateWindow(
         const_cast<wchar_t*>(windowClass.c_str()),
         const_cast<wchar_t*>(title.c_str()),
         WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU,

--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
@@ -17,8 +17,6 @@ static HWND g_checkboxHWnd = NULL;
 static HWND g_progressHWnd = NULL;
 static HWND g_CancelbuttonHWnd = NULL;
 static bool g_installed = false;
-static bool g_displayInfo = false;
-static bool g_displayCompleteText = false;
 static bool g_launchCheckBoxState = true; // launch checkbox is checked by default
 
 class UI
@@ -32,13 +30,18 @@ private:
     MsixRequest* m_msixRequest = nullptr;
 
     HANDLE m_buttonClickedEvent;
+	std::wstring m_displayName = L"";
+	std::wstring m_publisherCommonName = L"";
+	ComPtr<IStream> m_logoStream;
+	std::wstring m_version = L"";
+	int m_numberOfFiles = 0;
 
     UI() {}
     UI(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) { m_buttonClickedEvent = CreateEvent(NULL, FALSE, FALSE, NULL); }
-    
 public:
-    HRESULT DisplayPackageInfo(HWND hWnd, RECT windowRect, std::wstring& displayText, std::wstring& messageText);
-    int CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& windowClass, const std::wstring& title);
+    HRESULT DisplayPackageInfo(HWND hWnd, RECT windowRect);
+	int CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& windowClass, const std::wstring& title);
+	HRESULT LoadInfo();
 
     void SetButtonClicked() { SetEvent(m_buttonClickedEvent); }
 };

--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
@@ -61,7 +61,6 @@ private:
 
     CreateAndShowUI() {}
     CreateAndShowUI(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}
-
 };
 
 

--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.hpp
@@ -35,14 +35,16 @@ private:
 	ComPtr<IStream> m_logoStream;
 	std::wstring m_version = L"";
 	int m_numberOfFiles = 0;
+	HRESULT m_loadingPackageInfoCode = 0;
 
     UI() {}
     UI(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) { m_buttonClickedEvent = CreateEvent(NULL, FALSE, FALSE, NULL); }
+	HRESULT ParseInfoFromPackage();
 public:
-    HRESULT DisplayPackageInfo(HWND hWnd, RECT windowRect);
+    HRESULT DrawPackageInfo(HWND hWnd, RECT windowRect);
 	int CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& windowClass, const std::wstring& title);
-	HRESULT LoadInfo();
-
+	void LoadInfo();
+	int GetNumberOfFiles() { return m_numberOfFiles; }
     void SetButtonClicked() { SetEvent(m_buttonClickedEvent); }
 };
 


### PR DESCRIPTION
The title, description as well as the application logo were never redraw when the window was partially out of the screen or after being minimized.

The fix splits `DisplayPackageInfo` into 2 parts:
- `LoadInfo`: called only one time, extracting application name, publisher name, version number and logo and caching them to improve performance.
- `DrawPackageInfo, called when the window receives the event `WM_PAINT`, redrawing textblocks and the logo

+ Load the progress bar only when we will display it.

**Before:**
![2019-03-02_0-32-52](https://user-images.githubusercontent.com/1226538/53679558-c7fa5e80-3c82-11e9-8f47-adfacd6fa206.gif)

**Fixed:**
![2019-03-02_0-33-55](https://user-images.githubusercontent.com/1226538/53679570-e95b4a80-3c82-11e9-9106-668629a79051.gif)
