### PR TITLE
[Win7MsixInstaller] Make the background of the checkbox transparent

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
@@ -193,6 +193,21 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         PostQuitMessage(0);
         exit(0);
         break;
+	case WM_CTLCOLORSTATIC:
+	{
+		switch (::GetDlgCtrlID((HWND)lParam))
+		{
+			case IDC_LAUNCHCHECKBOX:
+			{
+				HBRUSH hbr = (HBRUSH)DefWindowProc(hWnd, message, wParam, lParam);
+				::DeleteObject(hbr);
+				SetBkMode((HDC)wParam, TRANSPARENT);
+				return (LRESULT)::GetStockObject(NULL_BRUSH);
+			}
+		}
+
+		break;
+	}
     default:
         return DefWindowProc(hWnd, message, wParam, lParam);
         break;


### PR DESCRIPTION
Not sure if it was by design, but in case it wasn't, here is a small diff to remove the gray background of the checkbox.

**Before:**
![image](https://user-images.githubusercontent.com/1226538/53680777-e0737480-3c94-11e9-8df5-79a04ba6e794.png)

**After:**
![image](https://user-images.githubusercontent.com/1226538/53680792-fd0fac80-3c94-11e9-9042-b8188bc2b73a.png)
