### PR TITLE
[Win7MsixInstaller] Support High Contrasts for accessibility

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
@@ -458,11 +458,13 @@ BOOL ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring messageT
     Gdiplus::Font messageFont(L"Arial", 10);
     Gdiplus::StringFormat format;
     format.SetAlignment(Gdiplus::StringAlignmentNear);
-    Gdiplus::SolidBrush blackBrush(Gdiplus::Color(255, 0, 0, 0));
+	auto windowsTextColor = Gdiplus::Color();
+	windowsTextColor.SetFromCOLORREF(GetSysColor(COLOR_WINDOWTEXT));
+	Gdiplus::SolidBrush textBrush(windowsTextColor);
 
-    graphics.DrawString(displayName.c_str(), -1, &displayNameFont, layoutRect, &format, &blackBrush);
+    graphics.DrawString(displayName.c_str(), -1, &displayNameFont, layoutRect, &format, &textBrush);
     layoutRect.Y += 40;
-    graphics.DrawString(messageText.c_str(), -1, &messageFont, layoutRect, &format, &blackBrush);
+    graphics.DrawString(messageText.c_str(), -1, &messageFont, layoutRect, &format, &textBrush);
 
     if (logoStream != nullptr)
     {


### PR DESCRIPTION
We should not force the color of the textblock to black, instead, we should use the WINDOWS_TEXT color to make the win7msixInstaller accessible (high-contrast support)


**Before:**
![aa4](https://user-images.githubusercontent.com/1226538/53680815-4c55dd00-3c95-11e9-8472-7fef46a80458.PNG)


**After:**
(High-contrast #1)
![image](https://user-images.githubusercontent.com/1226538/53680877-f9c8f080-3c95-11e9-80de-dabefeb75264.png)
(High-contrast Black)
![aa](https://user-images.githubusercontent.com/1226538/53680816-511a9100-3c95-11e9-8db2-30ffc545865a.PNG)
(high-contrast #2)
![aa1](https://user-images.githubusercontent.com/1226538/53680817-54ae1800-3c95-11e9-829c-7144be3ef711.PNG)
