### PR TITLE
Add .editorconfig to override VS settings to use spaces to indent

### DIFF
--- a/preview/Win7Msix/.editorconfig
+++ b/preview/Win7Msix/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{cpp,h,hpp}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/preview/Win7Msix/Win7MSIXInstaller.sln
+++ b/preview/Win7Msix/Win7MSIXInstaller.sln
@@ -7,6 +7,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Win7MSIXInstaller", "Win7MS
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "Win7MSIXInstallerSetup", "Win7MSIXInstallerSetup\Win7MSIXInstallerSetup.vdproj", "{C79C79A4-00CE-40C8-BCCE-A5C8F28A4E8D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B0C6E315-832B-4665-B979-4111A8C2F93B}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64


### PR DESCRIPTION
This project uses space indentations, we should override global VS settings so every contributors will use spaces when they work on win7msixinstaller.