### PR TITLE
Android BVTs failing for newer android systems.

### DIFF
--- a/src/msix/PAL/XML/AOSP/XmlObject.cpp
+++ b/src/msix/PAL/XML/AOSP/XmlObject.cpp
@@ -199,7 +199,6 @@ public:
         m_env->SetByteArrayRegion(byteArray.get(), (jsize) 0, (jsize) buffer.size(), (jbyte*) buffer.data());
         jmethodID initializeFunc = m_env->GetMethodID(xmlDomClass.get(), "InitializeDocument", "([B)V");
         m_env->CallVoidMethod(m_javaXmlDom.get(), initializeFunc, byteArray.get());
-        m_env->ReleaseByteArrayElements(byteArray.get(), (jbyte*) buffer.data(), JNI_ABORT);
 
         // android does not include any schema validation parsers. We can only support xml validation.
         // If schema validation is required, then use xerces as the xml parser.


### PR DESCRIPTION
Running our BVTs targeting a newer android emulator fail. This is due to an unnecessary call to ReleaseByteArrayElements() while parsing any xml using the inbox java parser. 

ReleaseByteArrayElements() should only be called with a corresponding GetByteArrayElements(). [See Release<PrimitiveType>ArrayElements doc](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#Release_PrimitiveType_ArrayElements_routines)

Using SetByteArrayRegion and deleting the local reference (via JObjectDeleter) should be sufficient.

Repro: ./testasoponmac.sh -c "system-images;android-26;google_apis;x86" -i