### PR TITLE
FindPackage returns 'Package not found' error

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/MsixRequest.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/MsixRequest.cpp
@@ -122,13 +122,21 @@ HRESULT MsixRequest::DisplayPackageInfo()
 {
     AutoPtr<IPackageHandler> handler;
     RETURN_IF_FAILED(PopulatePackageInfo::CreateHandler(this, &handler));
-    RETURN_IF_FAILED(handler->ExecuteForRemoveRequest());
+    HRESULT packageFoundResult = handler->ExecuteForRemoveRequest();
 
-    std::wcout << std::endl;
-    std::wcout << L"PackageFullName: " << m_packageInfo->GetPackageFullName().c_str() << std::endl;
-    std::wcout << L"DisplayName: " << m_packageInfo->GetDisplayName().c_str() << std::endl;
-    std::wcout << L"DirectoryPath: " << m_packageInfo->GetPackageDirectoryPath().c_str() << std::endl;
-    std::wcout << std::endl;
+    if (packageFoundResult == S_OK)
+    {
+        std::wcout << std::endl;
+        std::wcout << L"PackageFullName: " << m_packageInfo->GetPackageFullName().c_str() << std::endl;
+        std::wcout << L"DisplayName: " << m_packageInfo->GetDisplayName().c_str() << std::endl;
+        std::wcout << L"DirectoryPath: " << m_packageInfo->GetPackageDirectoryPath().c_str() << std::endl;
+        std::wcout << std::endl;
+    }
+    else
+    {
+        std::wcout << std::endl;
+        std::wcout << L"Package not found " << std::endl;
+    }
 
     return S_OK;
 }

--- a/preview/Win7Msix/Win7MSIXInstaller/PopulatePackageInfo.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/PopulatePackageInfo.cpp
@@ -55,7 +55,7 @@ HRESULT PopulatePackageInfo::ExecuteForRemoveRequest()
             TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
             TraceLoggingValue(m_msixRequest->GetPackageFullName(), "PackageFullName"),
             TraceLoggingValue(directory.c_str(), "PackageDirectoryPath"));
-        RETURN_IF_FAILED(E_NOT_SET);
+        return E_NOT_SET;
     }
 
     std::wstring manifestPath = packageDirectoryPath + manifestFile;


### PR DESCRIPTION
On running, Win7msixInstaller.exe -FindPackage (packagefullname), if the package is not installed on the machine, it currently returns, 'Failed to process request 80070490'. Modifying this to return, 'Package not found'.