### PR TITLE
Improve pipelines

### DIFF
--- a/pipelines/azure-pipelines-aosp.yml
+++ b/pipelines/azure-pipelines-aosp.yml
@@ -5,8 +5,10 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- master
-- release_v*
+  branches:
+    include:
+    - master
+    - release_v*
   paths:
     exclude:
     - CODEOWNERS

--- a/pipelines/azure-pipelines-aosp.yml
+++ b/pipelines/azure-pipelines-aosp.yml
@@ -1,10 +1,20 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- release_v*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- release_v*
+  paths:
+    exclude:
+    - CODEOWNERS
+    - LICENCE
+    - preview/*
+    - README.md
+    - tdf-guidance.md
+    - THIRD PARTY CODE NOTICE
 
 jobs:
 - job: AOSP

--- a/pipelines/azure-pipelines-ios.yml
+++ b/pipelines/azure-pipelines-ios.yml
@@ -1,10 +1,20 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- release_v*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- release_v*
+  paths:
+    exclude:
+    - CODEOWNERS
+    - LICENCE
+    - preview/*
+    - README.md
+    - tdf-guidance.md
+    - THIRD PARTY CODE NOTICE
 
 jobs:
 - job: iOS

--- a/pipelines/azure-pipelines-ios.yml
+++ b/pipelines/azure-pipelines-ios.yml
@@ -5,8 +5,10 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- master
-- release_v*
+  branches:
+    include:
+    - master
+    - release_v*
   paths:
     exclude:
     - CODEOWNERS

--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -1,10 +1,20 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- release_v*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- release_v*
+  paths:
+    exclude:
+    - CODEOWNERS
+    - LICENCE
+    - preview/*
+    - README.md
+    - tdf-guidance.md
+    - THIRD PARTY CODE NOTICE
 
 jobs:
 - job: Linux

--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -5,8 +5,10 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- master
-- release_v*
+  branches:
+    include:
+    - master
+    - release_v*
   paths:
     exclude:
     - CODEOWNERS

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -1,10 +1,20 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- release_v*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- release_v*
+  paths:
+    exclude:
+    - CODEOWNERS
+    - LICENCE
+    - preview/*
+    - README.md
+    - tdf-guidance.md
+    - THIRD PARTY CODE NOTICE
 
 jobs:
 - job: macOS

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -5,8 +5,10 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- master
-- release_v*
+  branches:
+    include:
+    - master
+    - release_v*
   paths:
     exclude:
     - CODEOWNERS

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -1,10 +1,20 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- release_v*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- release_v*
+  paths:
+    exclude:
+    - CODEOWNERS
+    - LICENCE
+    - preview/*
+    - README.md
+    - tdf-guidance.md
+    - THIRD PARTY CODE NOTICE
 
 jobs:
 - job: Windows

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -5,8 +5,10 @@ trigger:
 
 # Branches that trigger builds on PR
 pr:
-- master
-- release_v*
+  branches:
+    include:
+    - master
+    - release_v*
   paths:
     exclude:
     - CODEOWNERS


### PR DESCRIPTION
Adding exclude paths for files that don't affect the MSIX SDK and add release_v* branches as triggers.

This way we make sure to don't build the Win7Installer preview or any non-code affecting PRs.