### PR TITLE
Show the version number of the package in the UI

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
+++ b/preview/Win7Msix/Win7MSIXInstaller/InstallUI.cpp
@@ -313,7 +313,7 @@ HRESULT UI::ParseInfoFromPackage()
         wpublisher.find_first_of(L",") - wpublisher.find_first_of(L"=") - 1);
 
     // Obtain version number
-    ConvertVersionToString(packageInfo->GetVersion());
+    m_version = ConvertVersionToString(packageInfo->GetVersion());
 
     //Obtain the number of files
     m_numberOfFiles = packageInfo->GetNumberOfPayloadFiles();


### PR DESCRIPTION
Fix a little issue due a previous PR: display the version number of the package in the dialog.