### PR TITLE
Add include path files, instead of exclude, to azure pipelines definitions

### DIFF
--- a/pipelines/azure-pipelines-aosp.yml
+++ b/pipelines/azure-pipelines-aosp.yml
@@ -10,13 +10,21 @@ pr:
     - master
     - release_v*
   paths:
-    exclude:
-    - CODEOWNERS
-    - LICENCE
-    - preview/*
-    - README.md
-    - tdf-guidance.md
-    - THIRD PARTY CODE NOTICE
+    include:
+    - cmake/*
+    - lib/*
+    - pipelines/*
+    - resources/*
+    - samples/*
+    - src/*
+    - test/*
+    - CMakeLists.txt
+    - makeaosp.sh
+    - makeios.sh
+    - makelinux.sh
+    - makemac.sh
+    - makewin.cmd
+    - manifest.cmakein
 
 jobs:
 - job: AOSP

--- a/pipelines/azure-pipelines-ios.yml
+++ b/pipelines/azure-pipelines-ios.yml
@@ -10,13 +10,21 @@ pr:
     - master
     - release_v*
   paths:
-    exclude:
-    - CODEOWNERS
-    - LICENCE
-    - preview/*
-    - README.md
-    - tdf-guidance.md
-    - THIRD PARTY CODE NOTICE
+    include:
+    - cmake/*
+    - lib/*
+    - pipelines/*
+    - resources/*
+    - samples/*
+    - src/*
+    - test/*
+    - CMakeLists.txt
+    - makeaosp.sh
+    - makeios.sh
+    - makelinux.sh
+    - makemac.sh
+    - makewin.cmd
+    - manifest.cmakein
 
 jobs:
 - job: iOS

--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -10,13 +10,21 @@ pr:
     - master
     - release_v*
   paths:
-    exclude:
-    - CODEOWNERS
-    - LICENCE
-    - preview/*
-    - README.md
-    - tdf-guidance.md
-    - THIRD PARTY CODE NOTICE
+    include:
+    - cmake/*
+    - lib/*
+    - pipelines/*
+    - resources/*
+    - samples/*
+    - src/*
+    - test/*
+    - CMakeLists.txt
+    - makeaosp.sh
+    - makeios.sh
+    - makelinux.sh
+    - makemac.sh
+    - makewin.cmd
+    - manifest.cmakein
 
 jobs:
 - job: Linux

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -10,13 +10,21 @@ pr:
     - master
     - release_v*
   paths:
-    exclude:
-    - CODEOWNERS
-    - LICENCE
-    - preview/*
-    - README.md
-    - tdf-guidance.md
-    - THIRD PARTY CODE NOTICE
+    include:
+    - cmake/*
+    - lib/*
+    - pipelines/*
+    - resources/*
+    - samples/*
+    - src/*
+    - test/*
+    - CMakeLists.txt
+    - makeaosp.sh
+    - makeios.sh
+    - makelinux.sh
+    - makemac.sh
+    - makewin.cmd
+    - manifest.cmakein
 
 jobs:
 - job: macOS

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -10,14 +10,21 @@ pr:
     - master
     - release_v*
   paths:
-    exclude:
-    - CODEOWNERS
-    - LICENCE
-    - preview/*
-    - README.md
-    - tdf-guidance.md
-    - THIRD PARTY CODE NOTICE
-
+    include:
+    - cmake/*
+    - lib/*
+    - pipelines/*
+    - resources/*
+    - samples/*
+    - src/*
+    - test/*
+    - CMakeLists.txt
+    - makeaosp.sh
+    - makeios.sh
+    - makelinux.sh
+    - makemac.sh
+    - makewin.cmd
+    - manifest.cmakein
 jobs:
 - job: Windows
   pool:


### PR DESCRIPTION
A build will not start if any of the files in the exclude list is in a PR, even if the change contains a file that is not on the exclude list.

We don't want that, instead we should do the builds if any of the MSIX SDK files are present. 