### PR TITLE
PackageWriter skeleton

### DIFF
--- a/src/inc/AppxPackageWriter.hpp
+++ b/src/inc/AppxPackageWriter.hpp
@@ -1,0 +1,71 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#pragma once
+
+#include "AppxPackaging.hpp"
+#include "ComHelper.hpp"
+#include "DirectoryObject.hpp"
+
+#include <map>
+
+// internal interface
+// {32e89da5-7cbb-4443-8cf0-b84eedb51d0a}
+#ifndef WIN32
+interface IPackageWriter : public IUnknown
+#else
+#include "Unknwn.h"
+#include "Objidl.h"
+class IPackageWriter : public IUnknown
+#endif
+{
+public:
+    // TODO: add options if needed
+    virtual void Pack(const MSIX::ComPtr<IDirectoryObject>& from) = 0;
+};
+MSIX_INTERFACE(IPackageWriter, 0x32e89da5,0x7cbb,0x4443,0x8c,0xf0,0xb8,0x4e,0xed,0xb5,0x1d,0x0a);
+
+namespace MSIX {
+
+    class AppxPackageWriter final : public ComClass<AppxPackageWriter, IPackageWriter, IAppxPackageWriter,
+        IAppxPackageWriterUtf8, IAppxPackageWriter3, IAppxPackageWriter3Utf8>
+    {
+    public:
+        AppxPackageWriter(IStream* outputStream);
+        ~AppxPackageWriter() {};
+
+        // IPackageWriter
+        void Pack(const ComPtr<IDirectoryObject>& from) override;
+
+        // IAppxPackageWriter
+        HRESULT STDMETHODCALLTYPE AddPayloadFile(LPCWSTR fileName, LPCWSTR contentType,
+            APPX_COMPRESSION_OPTION compressionOption, IStream *inputStream) noexcept override;
+        HRESULT STDMETHODCALLTYPE Close(IStream *manifest) noexcept override;
+
+        // IAppxPackageWriterUtf8
+        HRESULT STDMETHODCALLTYPE AddPayloadFile(LPCSTR fileName, LPCSTR contentType,
+            APPX_COMPRESSION_OPTION compressionOption, IStream* inputStream) noexcept override;
+
+        // IAppxPackageWriter3
+        HRESULT STDMETHODCALLTYPE AddPayloadFiles(UINT32 fileCount, APPX_PACKAGE_WRITER_PAYLOAD_STREAM* payloadFiles,
+            UINT64 memoryLimit) noexcept override;
+
+        // IAppxPackageWriter3Utf8
+        HRESULT STDMETHODCALLTYPE AddPayloadFiles(UINT32 fileCount, APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8* payloadFiles,
+            UINT64 memoryLimit) noexcept override;
+
+    protected:
+        typedef enum
+        {
+            Open = 1,
+            Closed = 2,
+            Failed = 3
+        }
+        WriterState;
+
+        WriterState m_state;
+        ComPtr<IStream> m_outputStream;
+    };
+}
+

--- a/src/inc/DirectoryObject.hpp
+++ b/src/inc/DirectoryObject.hpp
@@ -46,7 +46,12 @@ namespace MSIX {
 
         // IStorageObject methods
         std::vector<std::string> GetFileNames(FileNameOptions options) override;
-        ComPtr<IStream> GetFile(const std::string& fileName) override;
+        ComPtr<IStream> GetFile(const std::string& fileName) override
+        {
+            std::string file = m_root + GetPathSeparator() + fileName;
+            auto fileStream = ComPtr<IStream>::Make<FileStream>(file, FileStream::Mode::READ);
+            return fileStream;
+        }
         std::string GetFileName() override { return m_root; }
 
         // IDirectoryObject

--- a/src/inc/MsixErrors.hpp
+++ b/src/inc/MsixErrors.hpp
@@ -24,6 +24,7 @@ namespace MSIX {
         NotSupported                = 0x80070032,
         InvalidParameter            = 0x80070057,
         Stg_E_Invalidpointer        = 0x80030009,
+        InvalidState                = 0x804d0003,
 
         //
         // msix specific error codes

--- a/src/inc/ScopeExit.hpp
+++ b/src/inc/ScopeExit.hpp
@@ -15,31 +15,31 @@ namespace MSIX {
             lambda_call& operator=(const lambda_call&) = delete;
             lambda_call& operator=(lambda_call&& other) = delete;
 
-            explicit lambda_call(TLambda&& lambda) : m_lambda(std::move(lambda))
+            explicit lambda_call(TLambda&& lambda) noexcept : m_lambda(std::move(lambda))
             {
                 static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas must not have a return value");
                 static_assert(!std::is_lvalue_reference<TLambda>::value && !std::is_rvalue_reference<TLambda>::value,
                     "scope_exit should only be directly used with a lambda");
             }
 
-            lambda_call(lambda_call&& other) : m_lambda(std::move(other.m_lambda)), m_call(other.m_call)
+            lambda_call(lambda_call&& other) noexcept : m_lambda(std::move(other.m_lambda)), m_call(other.m_call)
             {
                 other.m_call = false;
             }
 
-            ~lambda_call()
+            ~lambda_call() noexcept
             {
                 reset();
             }
 
             // Ensures the scope_exit lambda will not be called
-            void release()
+            void release() noexcept
             {
                 m_call = false;
             }
 
             // Executes the scope_exit lambda immediately if not yet run; ensures it will not run again
-            void reset()
+            void reset() noexcept
             {
                 if (m_call)
                 {
@@ -49,7 +49,7 @@ namespace MSIX {
             }
 
             // Returns true if the scope_exit lambda is still going to be executed
-            explicit operator bool() const
+            explicit operator bool() const noexcept
             {
                 return m_call;
             }
@@ -64,7 +64,7 @@ namespace MSIX {
     // Capture the object with 'auto'; use reset() to execute the lambda early or release() to avoid
     // execution.
     template <typename TLambda>
-    inline auto scope_exit(TLambda&& lambda)
+    inline auto scope_exit(TLambda&& lambda) noexcept
     {
         return details::lambda_call<TLambda>(std::forward<TLambda>(lambda));
     }

--- a/src/inc/ScopeExit.hpp
+++ b/src/inc/ScopeExit.hpp
@@ -62,7 +62,7 @@ namespace MSIX {
 
     // Returns an object that executes the given lambda when destroyed.
     // Capture the object with 'auto'; use reset() to execute the lambda early or release() to avoid
-    // execution.  Exceptions thrown in the lambda will fail-fast; use scope_exit_log to avoid.
+    // execution.
     template <typename TLambda>
     inline auto scope_exit(TLambda&& lambda)
     {

--- a/src/inc/ScopeExit.hpp
+++ b/src/inc/ScopeExit.hpp
@@ -1,0 +1,71 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#pragma once
+
+namespace MSIX {
+    namespace details {
+
+        template <typename TLambda>
+        class lambda_call
+        {
+        public:
+            lambda_call(const lambda_call&) = delete;
+            lambda_call& operator=(const lambda_call&) = delete;
+            lambda_call& operator=(lambda_call&& other) = delete;
+
+            explicit lambda_call(TLambda&& lambda) : m_lambda(std::move(lambda))
+            {
+                static_assert(std::is_same<decltype(lambda()), void>::value, "scope_exit lambdas must not have a return value");
+                static_assert(!std::is_lvalue_reference<TLambda>::value && !std::is_rvalue_reference<TLambda>::value,
+                    "scope_exit should only be directly used with a lambda");
+            }
+
+            lambda_call(lambda_call&& other) : m_lambda(std::move(other.m_lambda)), m_call(other.m_call)
+            {
+                other.m_call = false;
+            }
+
+            ~lambda_call()
+            {
+                reset();
+            }
+
+            // Ensures the scope_exit lambda will not be called
+            void release()
+            {
+                m_call = false;
+            }
+
+            // Executes the scope_exit lambda immediately if not yet run; ensures it will not run again
+            void reset()
+            {
+                if (m_call)
+                {
+                    m_call = false;
+                    m_lambda();
+                }
+            }
+
+            // Returns true if the scope_exit lambda is still going to be executed
+            explicit operator bool() const
+            {
+                return m_call;
+            }
+
+        protected:
+            TLambda m_lambda;
+            bool m_call = true;
+        };
+    } // details
+
+    // Returns an object that executes the given lambda when destroyed.
+    // Capture the object with 'auto'; use reset() to execute the lambda early or release() to avoid
+    // execution.  Exceptions thrown in the lambda will fail-fast; use scope_exit_log to avoid.
+    template <typename TLambda>
+    inline auto scope_exit(TLambda&& lambda)
+    {
+        return details::lambda_call<TLambda>(std::forward<TLambda>(lambda));
+    }
+}

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -217,11 +217,16 @@ list(APPEND UnpackSrc
     ${BundleSources}
 )
 
+list(APPEND PackSrc
+    pack/AppxPackageWriter.cpp
+)
+
 # Define the library
 add_library(${PROJECT_NAME} SHARED 
     msix.cpp
     ${CommonSrc}
     ${UnpackSrc}
+    ${PackSrc}
 )
 
 # Copy out public headers to <binary dir>/src/unpack

--- a/src/msix/PAL/FileSystem/POSIX/DirectoryObject.cpp
+++ b/src/msix/PAL/FileSystem/POSIX/DirectoryObject.cpp
@@ -54,12 +54,6 @@ namespace MSIX {
         // TODO: Implement when standing-up the pack side for test validation purposes
         NOTIMPLEMENTED;
     }
-    
-    ComPtr<IStream> DirectoryObject::GetFile(const std::string& fileName)
-    {
-        // TODO: Implement when standing-up the pack side for test validation purposes
-        NOTIMPLEMENTED;
-    }
 
     #define DEFAULT_MODE S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
     void mkdirp(std::string& path, mode_t mode = DEFAULT_MODE)

--- a/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
+++ b/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
@@ -113,12 +113,6 @@ namespace MSIX {
         NOTIMPLEMENTED;
     }
 
-    ComPtr<IStream> DirectoryObject::GetFile(const std::string& fileName)
-    {
-        // TODO: Implement when standing-up the pack side for test validation purposes.
-        NOTIMPLEMENTED;
-    }
-
     // IDirectoryObject
     ComPtr<IStream> DirectoryObject::OpenFile(const std::string& fileName, FileStream::Mode mode)
     {

--- a/src/msix/common/AppxFactory.cpp
+++ b/src/msix/common/AppxFactory.cpp
@@ -10,6 +10,7 @@
 #include "MSIXResource.hpp"
 #include "VectorStream.hpp"
 #include "MsixFeatureSelector.hpp"
+#include "AppxPackageWriter.hpp"
 
 namespace MSIX {
     // IAppxFactory

--- a/src/msix/common/AppxFactory.cpp
+++ b/src/msix/common/AppxFactory.cpp
@@ -16,10 +16,16 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE AppxFactory::CreatePackageWriter (
         IStream* outputStream,
         APPX_PACKAGE_SETTINGS* ,//settings, TODO: plumb this through
-        IAppxPackageWriter** packageWriter) noexcept
+        IAppxPackageWriter** packageWriter) noexcept try
     {
-        return static_cast<HRESULT>(Error::NotImplemented);
-    }
+        THROW_IF_PACK_NOT_ENABLED
+        ThrowErrorIf(Error::InvalidParameter, (outputStream == nullptr || *packageWriter != nullptr), "Invalid parameter");
+        // TODO: we problably will probably need the pass IMsixFactory to AppxPackageWriter constructor, but don't
+        // do it until is actually required.
+        auto result = ComPtr<IAppxPackageWriter>::Make<AppxPackageWriter>(outputStream);
+        *packageWriter = result.Detach();
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE AppxFactory::CreatePackageReader (
         IStream* inputStream,

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -16,6 +16,7 @@
 #include "DirectoryObject.hpp"
 #include "AppxPackageObject.hpp"
 #include "MsixFeatureSelector.hpp"
+#include "AppxPackageWriter.hpp"
 
 #ifndef WIN32
 // on non-win32 platforms, compile with -fvisibility=hidden
@@ -157,7 +158,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackPackageFromStream(
     ThrowHrIfFailed(factory->CreatePackageReader(stream, &reader));
 
     auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination);
-    reader.As<IPackage>()->Unpack(packUnpackOptions, to.Get());
+    reader.As<IPackage>()->Unpack(packUnpackOptions, to);
     return static_cast<HRESULT>(MSIX::Error::OK);
 } CATCH_RETURN();
 
@@ -202,7 +203,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackBundleFromStream(
     ThrowHrIfFailed(factory->CreateBundleReader(stream, &reader));
 
     auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination);
-    reader.As<IPackage>()->Unpack(packUnpackOptions, to.Get());
+    reader.As<IPackage>()->Unpack(packUnpackOptions, to);
     return static_cast<HRESULT>(MSIX::Error::OK);
 } CATCH_RETURN();
 
@@ -219,13 +220,22 @@ MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
         "Invalid parameters");
 
     auto from = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(directoryPath);
-    auto filesMap= from->GetFilesByLastModDate();
+    // If they are calling this API assume they included the AppxManifest.xml
+    // also do this before calling pack to fail earlier if not present
+    auto manifest = from.As<IStorageObject>()->GetFile("AppxManifest.xml");
 
-    // TODO:
-    // - get stream to manfiest
-    // - add new method to IPackage that takes a std::multimap with the files and stream of the manifest
+    MSIX::ComPtr<IStream> stream;
+    ThrowHrIfFailed(CreateStreamOnFile(outputPackage, false, &stream));
 
+    MSIX::ComPtr<IAppxFactory> factory;
+    // We don't need to use the caller's heap here because we're not marshalling any strings
+    // out to the caller.  So default to new / delete[] and be done with it!
+    ThrowHrIfFailed(CoCreateAppxFactoryWithHeap(InternalAllocate, InternalFree, validationOption, &factory));
 
+    MSIX::ComPtr<IAppxPackageWriter> writer;
+    ThrowHrIfFailed(factory->CreatePackageWriter(stream.Get(), nullptr, &writer));
+    writer.As<IPackageWriter>()->Pack(from);
+    ThrowHrIfFailed(writer->Close(manifest.Get()));
     return static_cast<HRESULT>(MSIX::Error::NotImplemented);
 } CATCH_RETURN();
 

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -221,8 +221,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
         "Invalid parameters");
 
     auto from = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(directoryPath);
-    // If they are calling this API assume they included the AppxManifest.xml
-    // also do this before calling pack to fail earlier if not present
+    // PackPackage assumes AppxManifest.xml to be in the directory provided.
     auto manifest = from.As<IStorageObject>()->GetFile("AppxManifest.xml");
 
     auto deleteFile = MSIX::scope_exit([&outputPackage]
@@ -234,8 +233,6 @@ MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
     ThrowHrIfFailed(CreateStreamOnFile(outputPackage, false, &stream));
 
     MSIX::ComPtr<IAppxFactory> factory;
-    // We don't need to use the caller's heap here because we're not marshalling any strings
-    // out to the caller.  So default to new / delete[] and be done with it!
     ThrowHrIfFailed(CoCreateAppxFactoryWithHeap(InternalAllocate, InternalFree, validationOption, &factory));
 
     MSIX::ComPtr<IAppxPackageWriter> writer;

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -22,7 +22,6 @@ namespace MSIX {
 
         for(const auto& file : fileMap)
         {
-            std::cout << file.first << " " << file.second << std::endl;
             // TODO: either create APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8s and call AddPayloadFiles
             // or make the blockmap/zip writer take the information and call it from here, AddPayloadFiles
             // and AddPayloadFile

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -4,6 +4,7 @@
 // 
 #include "AppxPackageWriter.hpp"
 #include "MsixErrors.hpp"
+#include "Exceptions.hpp"
 
 #include <string>
 
@@ -20,12 +21,8 @@ namespace MSIX {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         auto fileMap = from->GetFilesByLastModDate();
 
-        for(const auto& file : fileMap)
-        {
-            // TODO: either create APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8s and call AddPayloadFiles
-            // or make the blockmap/zip writer take the information and call it from here, AddPayloadFiles
-            // and AddPayloadFile
-        }
+        // TODO: start packing
+        NOTIMPLEMENTED
     }
 
     // IAppxPackageWriter
@@ -41,7 +38,7 @@ namespace MSIX {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         // TODO: implement
         m_state = WriterState::Closed;
-        return static_cast<HRESULT>(Error::OK);
+        NOTIMPLEMENTED
     } CATCH_RETURN();
 
     // IAppxPackageWriterUtf8
@@ -50,7 +47,7 @@ namespace MSIX {
     {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         // TODO: implement
-        return static_cast<HRESULT>(Error::OK);
+        NOTIMPLEMENTED
     } CATCH_RETURN();
 
     // IAppxPackageWriter3
@@ -59,7 +56,7 @@ namespace MSIX {
     {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         // TODO: implement
-        return static_cast<HRESULT>(Error::OK);
+        NOTIMPLEMENTED
     } CATCH_RETURN();
 
     // IAppxPackageWriter3Utf8
@@ -68,6 +65,6 @@ namespace MSIX {
     {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         // TODO: implement
-        return static_cast<HRESULT>(Error::OK);
+        NOTIMPLEMENTED
     } CATCH_RETURN();
 }

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -1,0 +1,74 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#include "AppxPackageWriter.hpp"
+#include "MsixErrors.hpp"
+
+#include <string>
+
+namespace MSIX {
+
+    AppxPackageWriter::AppxPackageWriter(IStream* outputStream) : m_outputStream(outputStream)
+    {
+        m_state = WriterState::Open;
+    }
+
+    // IPackageWriter
+    void AppxPackageWriter::Pack(const ComPtr<IDirectoryObject>& from)
+    {
+        ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
+        auto fileMap = from->GetFilesByLastModDate();
+
+        for(const auto& file : fileMap)
+        {
+            std::cout << file.first << " " << file.second << std::endl;
+            // TODO: either create APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8s and call AddPayloadFiles
+            // or make the blockmap/zip writer take the information and call it from here, AddPayloadFiles
+            // and AddPayloadFile
+        }
+    }
+
+    // IAppxPackageWriter
+    HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFile(LPCWSTR fileName, LPCWSTR contentType,
+        APPX_COMPRESSION_OPTION compressionOption, IStream *inputStream) noexcept try
+    {
+        return AddPayloadFile(wstring_to_utf8(fileName).c_str(), wstring_to_utf8(contentType).c_str(), 
+            compressionOption, inputStream);
+    } CATCH_RETURN();
+
+    HRESULT STDMETHODCALLTYPE AppxPackageWriter::Close(IStream *manifest) noexcept try
+    {
+        ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
+        // TODO: implement
+        m_state = WriterState::Closed;
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    // IAppxPackageWriterUtf8
+    HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFile(LPCSTR fileName, LPCSTR contentType,
+        APPX_COMPRESSION_OPTION compressionOption, IStream* inputStream) noexcept try
+    {
+        ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
+        // TODO: implement
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    // IAppxPackageWriter3
+    HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFiles(UINT32 fileCount,
+        APPX_PACKAGE_WRITER_PAYLOAD_STREAM* payloadFiles, UINT64 memoryLimit) noexcept try
+    {
+        ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
+        // TODO: implement
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    // IAppxPackageWriter3Utf8
+    HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFiles(UINT32 fileCount,
+        APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8* payloadFiles, UINT64 memoryLimit) noexcept try
+    {
+        ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
+        // TODO: implement
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+}


### PR DESCRIPTION
1. AppxPackageWriter class that will produce the package.
2. Add ScopeExit.hpp to help deleting a file when some error ocurred while producing a file. It can also be used for more purposes.

AppxPackageWriter implements an internal interfaces that will Pack given an IDirectoryObject. This will be only used for the PackPackage entrypoint. Eventually, Pack, AddPayloadFile and AddPayloadsFile will call the same writer internal methods. 

Next will be an xmlwriter to start producing the blockmap and content type files.