### PR TITLE
Fix crash when ui used

### DIFF
--- a/preview/Win7Msix/Win7MSIXInstallerLib/PackageManager.cpp
+++ b/preview/Win7Msix/Win7MSIXInstallerLib/PackageManager.cpp
@@ -26,7 +26,7 @@ shared_ptr<IMsixResponse> PackageManager::AddPackageAsync(const wstring & packag
         impl->GetMsixResponse()->SetCallback(callback);
     }
 
-    auto t = thread([&impl](MsixRequest* msixRequest) {
+    auto t = thread([&](MsixRequest* msixRequest) {
         msixRequest->ProcessRequest();
         delete msixRequest;
         msixRequest = nullptr;
@@ -60,10 +60,11 @@ shared_ptr<IMsixResponse> PackageManager::RemovePackageAsync(const wstring & pac
         impl->GetMsixResponse()->SetCallback(callback);
     }
 
-    thread t([&impl]() {
-        impl->ProcessRequest();
-        impl = nullptr;
-        });
+    auto t = thread([&](MsixRequest* msixRequest) {
+        msixRequest->ProcessRequest();
+        delete msixRequest;
+        msixRequest = nullptr;
+    }, impl);
     t.detach();
     return impl->GetMsixResponse();
 }

--- a/preview/Win7Msix/Win7MSIXInstallerLib/PackageManager.cpp
+++ b/preview/Win7Msix/Win7MSIXInstallerLib/PackageManager.cpp
@@ -26,11 +26,11 @@ shared_ptr<IMsixResponse> PackageManager::AddPackageAsync(const wstring & packag
         impl->GetMsixResponse()->SetCallback(callback);
     }
 
-    auto t = thread([&impl]() {
-        impl->ProcessRequest();
-        delete impl;
-        impl = nullptr;
-        });
+    auto t = thread([&impl](MsixRequest* msixRequest) {
+        msixRequest->ProcessRequest();
+        delete msixRequest;
+        msixRequest = nullptr;
+        }, impl);
     t.detach();
     return impl->GetMsixResponse();
 }


### PR DESCRIPTION
I'm not the most familiar with lambdas, it does look like the lambda capture doesn't capture as i'd expect and that this is crashing because processRequest is called with no MsixRequest class.

Working around the issue for now by explicitly passing the msixRequest pointer as a parameter to the lambda, which verified works with the UI and installs work as expected.