### PR TITLE
1. Do not write REG_NONE into registry. default to REG_SZ

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.cpp
@@ -255,6 +255,11 @@ HRESULT RegistryDevirtualizer::DevirtualizeValue(RegistryKey* realKey, PCWSTR na
         TraceLoggingValue(type, "valueType"));
 
     DWORD actualType = (type & 0xff);
+    if (actualType == REG_NONE)
+    {
+        actualType = REG_SZ;
+    }
+
     if (actualType == REG_SZ)
     {
         std::wstring dataWString = reinterpret_cast<PWSTR>(&dataBuffer[0]);

--- a/preview/MsixCore/MsixCoreInstaller/RegistryKey.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/RegistryKey.cpp
@@ -104,6 +104,11 @@ HRESULT RegistryKey::SetValue(
 
 HRESULT RegistryKey::SetStringValue(PCWSTR name, const std::wstring& value)
 {
+    if (value.empty())
+    {
+        // Documentation for RegSetValueEx indicates that REG_SZ type the string must be null-terminated-- we can't just write nullptr here.
+        return SetValue(name, L"", 1, REG_SZ);
+    }
     return SetValue(name, value.c_str(), static_cast<DWORD>(value.size() * sizeof(WCHAR)), REG_SZ);
 }
 

--- a/preview/MsixCore/Tests/test.ps1
+++ b/preview/MsixCore/Tests/test.ps1
@@ -125,9 +125,9 @@ else
 ShowTestHeader("Re-installing package succeeds, and overwrites files it should")
 if (test-path $notepadDir)
 {
-	# notepad++ is higher version than nppshell_06, and uninstall.exe is unversioned
-	# if a higher version nppshell_06 exists, installing the package should not overwrite it.
-	copy $notepadDir\notepad++.exe $notepadDir\nppshell_06.dll
+	# notepad++ is higher version than scilexer, and uninstall.exe is unversioned
+	# if a higher version scilexer exists, installing the package should not overwrite it.
+	copy $notepadDir\notepad++.exe $notepadDir\scilexer.dll
 	# if an unversioned file exists, installing the package *should* overwrite it with a versioned file
 	copy $notepadDir\uninstall.exe $notepadDir\notepad++.exe
 	# if an unmodified, unversioned file exists, installing the package should overwrite it with another unversioned file
@@ -141,7 +141,7 @@ if (test-path $notepadDir)
 	(dir $notepadDir\change.log).LastWriteTime = (dir $notepadDir\change.log).CreationTime.AddHours(2)
 	
 	$beginNotepadExeSize = (dir $notepadDir\notepad++.exe).length
-	$beginNppShellSize = (dir $notepadDir\nppshell_06.dll).length
+	$beginSciLexerSize = (dir $notepadDir\scilexer.dll).length
 	$beginReadmeSize = (dir $notepadDir\readme.txt).length
 	$beginChangeLogSize = (dir $notepadDir\change.log).length
 	
@@ -149,12 +149,12 @@ if (test-path $notepadDir)
 	if ($output -eq $null)
 	{
 		$afterNotepadExeSize = (dir $notepadDir\notepad++.exe).length
-		$afterNppShellSize = (dir $notepadDir\nppshell_06.dll).length
+		$afterSciLexerSize = (dir $notepadDir\scilexer.dll).length
 		$afterReadmeSize = (dir $notepadDir\readme.txt).length
 		$afterChangeLogSize = (dir $notepadDir\change.log).length
 		
 		if (($beginNotepadExeSize -ne $afterNotepadExeSize) -and
-			($beginNppShellSize -eq $afterNppShellSize) -and
+			($beginSciLexerSize -eq $afterSciLexerSize) -and
 			($beginReadmeSize -ne $afterReadmeSize) -and
 			($beginChangeLogSize -eq $afterChangeLogSize))
 		{
@@ -164,7 +164,7 @@ if (test-path $notepadDir)
 		{
 			write-host ("Reinstall did not overwrite expected files")
 			write-host ("Notepad before/after (should Not equal): $beginNotepadExeSize $afterNotepadExeSize")
-			write-host ("NppShell before/after (should equal): $beginNppShellSize  $afterNppShellSize")
+			write-host ("SciLexer before/after (should equal): $beginSciLexerSize  $afterSciLexerSize")
 			write-host ("Readme before/after (should Not equal): $beginReadmeSize $afterReadmeSize")
 			write-host ("ChangeLog before/after (should equal): $beginChangeLogSize $afterChangeLogSize")
 			writeFail


### PR DESCRIPTION
2. do not write nullptr for REG_SZ, instead give it an empty null-terminated string
3. change test to use scilexer.dll instead of nppshell_06.dll which is sometimes stuck in use by explorer.exe and can't be rewritten.


Jyothi noticed that the notepadplus.msix after installed, attempting to launch by right clicking a text file and selecting "Edit in Notepad++" gives an unexpected dialog. This is due to the registry devirtualization writing an nullptr as part of a REG_SZ type. Instead, we should write a null-terminated string.

Also, after launching Notepad++ this way, our automated test for this package fails in re-install because nppshell_06.dll is held in use by explorer.exe. So, we choose a separate versioned DLL (scilexer) instead. 