### PR TITLE
Fix AV for unbundle using pfn option

### DIFF
--- a/src/inc/DirectoryObject.hpp
+++ b/src/inc/DirectoryObject.hpp
@@ -26,7 +26,7 @@ namespace MSIX {
         std::vector<std::string> GetFileNames(FileNameOptions options) override;
         ComPtr<IStream> GetFile(const std::string& fileName) override;
         ComPtr<IStream> OpenFile(const std::string& fileName, MSIX::FileStream::Mode mode) override;
-        std::string GetFileName() override { NOTIMPLEMENTED; }
+        std::string GetFileName() override { return m_root; }
 
     protected:
         std::string m_root;


### PR DESCRIPTION
makemsix.exe unbundle -d <output> -p <bundle> -pfn AVs because we try to access the appx manifest from the AppxPackageObject instead of the appx bundle manifest. 

The expected behavior is using the pfn option in a bundle should be:
```
<output directory>\
    <bundle package family name>\
        AppxBlockMap.xml
        AppxMetadata\AppxBundleManifest.xml
        <package family name 1>\
        <package family name n>\
```
