### PR TITLE
setvalue takes size in bytes, not wchars

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/RegistryKey.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/RegistryKey.cpp
@@ -107,7 +107,7 @@ HRESULT RegistryKey::SetStringValue(PCWSTR name, const std::wstring& value)
     if (value.empty())
     {
         // Documentation for RegSetValueEx indicates that REG_SZ type the string must be null-terminated-- we can't just write nullptr here.
-        return SetValue(name, L"", 1, REG_SZ);
+        return SetValue(name, L"", sizeof(WCHAR), REG_SZ);
     }
     return SetValue(name, value.c_str(), static_cast<DWORD>(value.size() * sizeof(WCHAR)), REG_SZ);
 }


### PR DESCRIPTION
Follow-up fix to pass in the correct size to RegSetValueEx in BYTES instead of WCHARs.