### PR TITLE
Validate multiple target device families in app manifest

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
@@ -78,8 +78,18 @@ HRESULT ValidateTargetDeviceFamily::ParseAndValidateTargetDeviceFamilyFromPackag
         {
             TraceLoggingWrite(g_MsixTraceLoggingProvider,
                 "Target device family name and manifest min version are compatible with OS",
-                TraceLoggingLevel(WINEVENT_LEVEL_INFO));
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                TraceLoggingValue(m_targetDeviceFamilyName.c_str(), "TargetDeviceFamilyName"),
+                TraceLoggingValue(manifestMinVersion.c_str(), "ManifestMinVersion"));
             return S_OK;
+        }
+        else
+        {
+            TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                "Target device family name and manifest min version are not compatible with OS",
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO),
+                TraceLoggingValue(m_targetDeviceFamilyName.c_str(), "TargetDeviceFamilyName"),
+                TraceLoggingValue(manifestMinVersion.c_str(), "ManifestMinVersion"));
         }
 
         RETURN_IF_FAILED(dependencyEnum->MoveNext(&hc));

--- a/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
@@ -80,7 +80,7 @@ HRESULT ValidateTargetDeviceFamily::ParseAndValidateTargetDeviceFamilyFromPackag
                 "Target device family name and manifest min version are compatible with OS",
                 TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                 TraceLoggingValue(m_targetDeviceFamilyName.c_str(), "TargetDeviceFamilyName"),
-                TraceLoggingValue(manifestMinVersion.c_str(), "ManifestMinVersion"));
+                TraceLoggingValue(minVersion.Get(), "ManifestMinVersion"));
             return S_OK;
         }
         else
@@ -89,7 +89,7 @@ HRESULT ValidateTargetDeviceFamily::ParseAndValidateTargetDeviceFamilyFromPackag
                 "Target device family name and manifest min version are not compatible with OS",
                 TraceLoggingLevel(WINEVENT_LEVEL_INFO),
                 TraceLoggingValue(m_targetDeviceFamilyName.c_str(), "TargetDeviceFamilyName"),
-                TraceLoggingValue(manifestMinVersion.c_str(), "ManifestMinVersion"));
+                TraceLoggingValue(minVersion.Get(), "ManifestMinVersion"));
         }
 
         RETURN_IF_FAILED(dependencyEnum->MoveNext(&hc));

--- a/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.cpp
@@ -15,24 +15,11 @@ const PCWSTR ValidateTargetDeviceFamily::HandlerName = L"ValidateTargetDeviceFam
 
 HRESULT ValidateTargetDeviceFamily::ExecuteForAddRequest()
 {
-    RETURN_IF_FAILED(ParseTargetDeviceFamilyFromPackage());
-    if (IsTargetDeviceFamilyNameCompatibleWithOS() && IsManifestVersionCompatibleWithOS())
-    {
-        TraceLoggingWrite(g_MsixTraceLoggingProvider,
-            "Target device family name and manifest min version are compatible with OS",
-            TraceLoggingLevel(WINEVENT_LEVEL_INFO));
-    }
-    else
-    {
-        TraceLoggingWrite(g_MsixTraceLoggingProvider,
-            "Target device family name or manifest min version are not compatible with the OS",
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
-        return HRESULT_FROM_WIN32(ERROR_INSTALL_REJECTED);
-    }
+    RETURN_IF_FAILED(ParseAndValidateTargetDeviceFamilyFromPackage());
     return S_OK;
 }
 
-HRESULT ValidateTargetDeviceFamily::ParseTargetDeviceFamilyFromPackage()
+HRESULT ValidateTargetDeviceFamily::ParseAndValidateTargetDeviceFamilyFromPackage()
 {
     auto packageInfo = m_msixRequest->GetPackageInfo();
 
@@ -58,33 +45,50 @@ HRESULT ValidateTargetDeviceFamily::ParseTargetDeviceFamilyFromPackage()
         return HRESULT_FROM_WIN32(ERROR_INSTALL_REJECTED);
     }
 
-    ComPtr<IMsixElement> dependencyElement;
-    RETURN_IF_FAILED(dependencyEnum->GetCurrent(&dependencyElement));
+    while (hc)
+    {
+        ComPtr<IMsixElement> dependencyElement;
+        RETURN_IF_FAILED(dependencyEnum->GetCurrent(&dependencyElement));
 
-    Text<wchar_t> targetDeviceFamilyName;
-    RETURN_IF_FAILED(dependencyElement->GetAttributeValue(L"Name", &targetDeviceFamilyName));
-    m_targetDeviceFamilyName = targetDeviceFamilyName.Get();
+        Text<wchar_t> targetDeviceFamilyName;
+        RETURN_IF_FAILED(dependencyElement->GetAttributeValue(L"Name", &targetDeviceFamilyName));
+        m_targetDeviceFamilyName = targetDeviceFamilyName.Get();
 
-    Text<wchar_t> minVersion;
-    RETURN_IF_FAILED(dependencyElement->GetAttributeValue(L"MinVersion", &minVersion));
-    std::wstring manifestMinVersion = minVersion.Get();
+        Text<wchar_t> minVersion;
+        RETURN_IF_FAILED(dependencyElement->GetAttributeValue(L"MinVersion", &minVersion));
+        std::wstring manifestMinVersion = minVersion.Get();
 
-    /// Major version
-    size_t start = 0;
-    size_t end = manifestMinVersion.find_first_of(L'.');
-    m_majorVersion = manifestMinVersion.substr(start, end - start);
+        /// Major version
+        size_t start = 0;
+        size_t end = manifestMinVersion.find_first_of(L'.');
+        m_majorVersion = manifestMinVersion.substr(start, end - start);
 
-    /// Minor version
-    manifestMinVersion.replace(start, end - start + 1, L"");
-    end = manifestMinVersion.find_first_of(L'.');
-    m_minorVersion = manifestMinVersion.substr(start, end - start);
+        /// Minor version
+        manifestMinVersion.replace(start, end - start + 1, L"");
+        end = manifestMinVersion.find_first_of(L'.');
+        m_minorVersion = manifestMinVersion.substr(start, end - start);
 
-    /// Build number
-    manifestMinVersion.replace(start, end - start + 1, L"");
-    end = manifestMinVersion.find_first_of(L'.');
-    m_buildNumber = manifestMinVersion.substr(start, end - start);
+        /// Build number
+        manifestMinVersion.replace(start, end - start + 1, L"");
+        end = manifestMinVersion.find_first_of(L'.');
+        m_buildNumber = manifestMinVersion.substr(start, end - start);
 
-    return S_OK;
+        /// Return if any one of the target device families are compatible with OS
+        if (IsTargetDeviceFamilyNameCompatibleWithOS() && IsManifestVersionCompatibleWithOS())
+        {
+            TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                "Target device family name and manifest min version are compatible with OS",
+                TraceLoggingLevel(WINEVENT_LEVEL_INFO));
+            return S_OK;
+        }
+
+        RETURN_IF_FAILED(dependencyEnum->MoveNext(&hc));
+    }
+
+    TraceLoggingWrite(g_MsixTraceLoggingProvider,
+        "Target device family name or manifest min version are not compatible with the OS",
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR));
+    return HRESULT_FROM_WIN32(ERROR_INSTALL_REJECTED);
 }
 
 bool ValidateTargetDeviceFamily::IsTargetDeviceFamilyNameCompatibleWithOS()

--- a/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/ValidateTargetDeviceFamily.hpp
@@ -32,7 +32,7 @@ namespace MsixCoreLib
         ValidateTargetDeviceFamily(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}
 
         /// This function parses the target device family fields from the app manifest
-        HRESULT ParseTargetDeviceFamilyFromPackage();
+        HRESULT ParseAndValidateTargetDeviceFamilyFromPackage();
 
         /// This function returns true if the target device family name is compatible with the operating system
         /// Desktop OS is compatible with MsixCore.Desktop and MsixCore.Server, Server OS is compatible with MsixCore.Server


### PR DESCRIPTION
There could be multiple target device families listed in an app manifest. Currently, the code does not check for compatibility of multiple TDF's. ValidateTargetDeviceFamily.cpp should return S_OK if any one of them is compatible with the OS.
If none of them are compatible, ERROR_INSTALL_REJECTED is returned.