### PR TITLE
Hide percentage windows after install is complete

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/InstallUI.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/InstallUI.cpp
@@ -129,6 +129,8 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             UpdateWindow(hWnd);
             ShowWindow(g_progressHWnd, SW_HIDE); //hide progress bar
             ShowWindow(g_checkboxHWnd, SW_HIDE); //hide launch check box
+            ShowWindow(g_percentageTextHWnd, SW_HIDE);
+            ShowWindow(g_staticPercentText, SW_HIDE);
             ShowWindow(g_LaunchbuttonHWnd, SW_SHOW);
         }
     }


### PR DESCRIPTION
The text 'Installing app package 100%' would still be displayed on the UI after app installation is complete. This should be hidden after app installation is complete.