### PR TITLE
Error handling changes

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/IPackageHandler.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/IPackageHandler.hpp
@@ -9,7 +9,7 @@ namespace MsixCoreLib
     {
     public:
 
-        virtual HRESULT ExecuteForAddRequest(HRESULT & hrExecute) = 0;
+        virtual HRESULT ExecuteForAddRequest() = 0;
 
         virtual HRESULT ExecuteForRemoveRequest() { return S_OK; }
 

--- a/preview/MsixCore/MsixCoreInstaller/IPackageHandler.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/IPackageHandler.hpp
@@ -4,22 +4,20 @@
 
 namespace MsixCoreLib
 {
-/// Interface for a logical chunk of work done on an Msix request
-class IPackageHandler
-{
-public:
+    /// Interface for a logical chunk of work done on an Msix request
+    class IPackageHandler
+    {
+    public:
 
-    virtual HRESULT ExecuteForAddRequest() = 0;
+        virtual HRESULT ExecuteForAddRequest(HRESULT & hrExecute) = 0;
 
-    virtual HRESULT ExecuteForRemoveRequest() { return S_OK; }
-    virtual bool IsMandatoryForRemoveRequest() { return false; }
-    virtual bool IsMandatoryForAddRequest() { return true; }
+        virtual HRESULT ExecuteForRemoveRequest() { return S_OK; }
 
-    virtual ~IPackageHandler() {};
-};
+        virtual ~IPackageHandler() {};
+    };
 
-/// Function responsible for creating an instance of an IPackageHandler object 	/// Function responsible for creating an instance of an IPackageHandler object 
-/// @param msixRequest - the msix request object to act upon	/// @return S_OK    of the package.
-/// @return S_OK if CreateHandler is to not fail the deployment of the package.
-typedef HRESULT(*CreateHandler)(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
+    /// Function responsible for creating an instance of an IPackageHandler object
+    /// @param msixRequest - the msix request object to act upon
+    /// @return S_OK if CreateHandler is to not fail the deployment of the package.
+    typedef HRESULT(*CreateHandler)(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
 }

--- a/preview/MsixCore/MsixCoreInstaller/InstallUI.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/InstallUI.cpp
@@ -310,6 +310,11 @@ HRESULT UI::ShowUI()
 
 void UI::PreprocessRequest()
 {
+    if (FAILED(m_loadingPackageInfoCode))
+    {
+        return;
+    }
+
     auto existingPackage = m_packageManager->FindPackageByFamilyName(m_packageInfo->GetPackageFamilyName());
     if (existingPackage != nullptr)
     {

--- a/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
@@ -50,10 +50,11 @@ int main(int argc, char * argv[])
 
             if (cli.IsQuietMode())
             {
-                auto res = packageManager->AddPackage(cli.GetPackageFilePathToInstall(), DeploymentOptions::None);
-                if (FAILED(res))
+                HRESULT hrAddPackage = packageManager->AddPackage(cli.GetPackageFilePathToInstall(), DeploymentOptions::None);
+                if (FAILED(hrAddPackage))
                 {
-                    return res;
+                    std::wcout << GetStringResource(IDS_STRING_FAILED_REQUEST) << " " << std::hex << hrAddPackage << std::endl;
+                    return hrAddPackage;
                 }
             }
             else
@@ -70,10 +71,11 @@ int main(int argc, char * argv[])
             RETURN_IF_FAILED(MsixCoreLib_CreatePackageManager(&packageManager));
 
             auto packageFullName = cli.GetPackageFullName();
-            auto res = packageManager->RemovePackage(packageFullName);
-            if (FAILED(res))
+            HRESULT hrRemovePackage = packageManager->RemovePackage(packageFullName);
+            if (FAILED(hrRemovePackage))
             {
-                return res;
+                std::wcout << GetStringResource(IDS_STRING_FAILED_REQUEST) << " " << std::hex << hrRemovePackage << std::endl;
+                return hrRemovePackage;
             }
             break;
         }

--- a/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
@@ -84,14 +84,16 @@ int main(int argc, char * argv[])
             AutoPtr<IPackageManager> packageManager;
             RETURN_IF_FAILED(MsixCoreLib_CreatePackageManager(&packageManager));
 
-            shared_ptr<IInstalledPackage> packageInfo = packageManager->FindPackage(cli.GetPackageFullName());
-            if (packageInfo == NULL)
+            shared_ptr<IInstalledPackage> packageInfo;
+            HRESULT hr = packageManager->FindPackage(cli.GetPackageFullName(), packageInfo);
+            if (packageInfo == NULL || FAILED(hr))
             {
                 std::wcout << std::endl;
-                std::wcout << L"No packages found" << std::endl;
+                std::wcout << L"No packages found " << hr << std::endl;
                 std::wcout << std::endl;
             }
-            else {
+            else
+            {
                 std::wcout << std::endl;
                 std::wcout << L"PackageFullName: " << packageInfo->GetPackageFullName().c_str() << std::endl;
                 std::wcout << L"DisplayName: " << packageInfo->GetDisplayName().c_str() << std::endl;
@@ -106,7 +108,8 @@ int main(int argc, char * argv[])
             AutoPtr<IPackageManager> packageManager;
             RETURN_IF_FAILED(MsixCoreLib_CreatePackageManager(&packageManager));
 
-            auto packages = packageManager->FindPackages();
+            std::unique_ptr<std::vector<std::shared_ptr<IInstalledPackage>>> packages;
+            RETURN_IF_FAILED(packageManager->FindPackages(packages));
 
             unsigned int numPackages = 0;
             for (auto& package : *packages)
@@ -115,7 +118,7 @@ int main(int argc, char * argv[])
                 numPackages++;
             }
 
-            std::cout << numPackages << " Packages found" << std::endl;
+            std::cout << numPackages << " Package(s) found" << std::endl;
             return S_OK;
         }
         default:

--- a/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
@@ -40,43 +40,61 @@
 using namespace std;
 #include <GdiPlus.h>
 using namespace MsixCoreLib;
-struct HandlerInfo
+
+enum ErrorHandling
+{
+    IgnoreError = 0,
+    ExecuteErrorHandler = 1,
+    ExecuteNextHandler = 2, // if returned from function, this explicitly tells us to go to next?
+    ReturnError = 3,        // for fatal errors, do not go to errorHandler, return immediately with error
+    SkipRestOfHandlers = 4, //early return when detect do-nothing?
+};
+
+struct AddHandlerInfo
 {
     CreateHandler create;
     PCWSTR nextHandler;
+    ErrorHandling errorHandling;
     PCWSTR errorHandler;
 };
 
-std::map<PCWSTR, HandlerInfo> AddHandlers =
+struct RemoveHandlerInfo
 {
-    //HandlerName                             Function to create                          NextHandler                              ErrorHandlerInfo
-    {PopulatePackageInfo::HandlerName,        {PopulatePackageInfo::CreateHandler,        ValidateTargetDeviceFamily::HandlerName, nullptr /*nothing to rollback if we can't open the package*/}},
-    {ValidateTargetDeviceFamily::HandlerName, {ValidateTargetDeviceFamily::CreateHandler, ProcessPotentialUpdate::HandlerName,     ErrorHandler::HandlerName}},
-    {ProcessPotentialUpdate::HandlerName,     {ProcessPotentialUpdate::CreateHandler,     Extractor::HandlerName,                  ErrorHandler::HandlerName}},
-    {Extractor::HandlerName,                  {Extractor::CreateHandler,                  StartMenuLink::HandlerName,              ErrorHandler::HandlerName}},
-    {StartMenuLink::HandlerName,              {StartMenuLink::CreateHandler,              AddRemovePrograms::HandlerName,          ErrorHandler::HandlerName}},
-    {AddRemovePrograms::HandlerName,          {AddRemovePrograms::CreateHandler,          Protocol::HandlerName,                   ErrorHandler::HandlerName}},
-    {Protocol::HandlerName,                   {Protocol::CreateHandler,                   ComInterface::HandlerName,               ErrorHandler::HandlerName}},
-    {ComInterface::HandlerName,               {ComInterface::CreateHandler,               ComServer::HandlerName,                  ErrorHandler::HandlerName}},
-    {ComServer::HandlerName,                  {ComServer::CreateHandler,                  StartupTask::HandlerName,                ErrorHandler::HandlerName}},
-    {StartupTask::HandlerName,                {StartupTask::CreateHandler,                FileTypeAssociation::HandlerName,        ErrorHandler::HandlerName}},
-    {FileTypeAssociation::HandlerName,        {FileTypeAssociation::CreateHandler,        InstallComplete::HandlerName,            ErrorHandler::HandlerName}},
-    {InstallComplete::HandlerName,            {InstallComplete::CreateHandler,            nullptr,                                 ErrorHandler::HandlerName}},
-    {ErrorHandler::HandlerName,               {ErrorHandler::CreateHandler,               nullptr,                                 nullptr}},
+    CreateHandler create;
+    PCWSTR nextHandler;
+    ErrorHandling errorHandling;
 };
 
-std::map<PCWSTR, HandlerInfo> RemoveHandlers =
+std::map<PCWSTR, AddHandlerInfo> AddHandlers =
 {
-    //HandlerName                       Function to create                   NextHandler
-    {PopulatePackageInfo::HandlerName,  {PopulatePackageInfo::CreateHandler, StartMenuLink::HandlerName}},
-    {StartMenuLink::HandlerName,        {StartMenuLink::CreateHandler,       AddRemovePrograms::HandlerName}},
-    {AddRemovePrograms::HandlerName,    {AddRemovePrograms::CreateHandler,   Protocol::HandlerName}},
-    {Protocol::HandlerName,             {Protocol::CreateHandler,            ComInterface::HandlerName}},
-    {ComInterface::HandlerName,         {ComInterface::CreateHandler,        ComServer::HandlerName}},
-    {ComServer::HandlerName,            {ComServer::CreateHandler,           StartupTask::HandlerName}},
-    {StartupTask::HandlerName,          {StartupTask::CreateHandler,         FileTypeAssociation::HandlerName}},
-    {FileTypeAssociation::HandlerName,  {FileTypeAssociation::CreateHandler, Extractor::HandlerName}},
-    {Extractor::HandlerName,            {Extractor::CreateHandler,           nullptr}},
+    //HandlerName                             Function to create                          NextHandler (on success)                 ErrorHandling        ErrorHandler (when ExecuteErrorHandler)
+    {PopulatePackageInfo::HandlerName,        {PopulatePackageInfo::CreateHandler,        ValidateTargetDeviceFamily::HandlerName, ReturnError,         nullptr}},
+    {ValidateTargetDeviceFamily::HandlerName, {ValidateTargetDeviceFamily::CreateHandler, ProcessPotentialUpdate::HandlerName,     ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {ProcessPotentialUpdate::HandlerName,     {ProcessPotentialUpdate::CreateHandler,     Extractor::HandlerName,                  ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {Extractor::HandlerName,                  {Extractor::CreateHandler,                  StartMenuLink::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {StartMenuLink::HandlerName,              {StartMenuLink::CreateHandler,              AddRemovePrograms::HandlerName,          ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {AddRemovePrograms::HandlerName,          {AddRemovePrograms::CreateHandler,          Protocol::HandlerName,                   ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {Protocol::HandlerName,                   {Protocol::CreateHandler,                   ComInterface::HandlerName,               ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {ComInterface::HandlerName,               {ComInterface::CreateHandler,               ComServer::HandlerName,                  ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {ComServer::HandlerName,                  {ComServer::CreateHandler,                  StartupTask::HandlerName,                ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {StartupTask::HandlerName,                {StartupTask::CreateHandler,                FileTypeAssociation::HandlerName,        ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {FileTypeAssociation::HandlerName,        {FileTypeAssociation::CreateHandler,        InstallComplete::HandlerName,            ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {InstallComplete::HandlerName,            {InstallComplete::CreateHandler,            nullptr,                                 ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {ErrorHandler::HandlerName,               {ErrorHandler::CreateHandler,               nullptr,                                 IgnoreError,         nullptr}},
+};
+
+std::map<PCWSTR, RemoveHandlerInfo> RemoveHandlers =
+{
+    //HandlerName                       Function to create                   NextHandler                        ErrorHandling
+    {PopulatePackageInfo::HandlerName,  {PopulatePackageInfo::CreateHandler, StartMenuLink::HandlerName,        ReturnError}},
+    {StartMenuLink::HandlerName,        {StartMenuLink::CreateHandler,       AddRemovePrograms::HandlerName,    IgnoreError}},
+    {AddRemovePrograms::HandlerName,    {AddRemovePrograms::CreateHandler,   Protocol::HandlerName,             IgnoreError}},
+    {Protocol::HandlerName,             {Protocol::CreateHandler,            ComInterface::HandlerName,         IgnoreError}},
+    {ComInterface::HandlerName,         {ComInterface::CreateHandler,        ComServer::HandlerName,            IgnoreError}},
+    {ComServer::HandlerName,            {ComServer::CreateHandler,           StartupTask::HandlerName,          IgnoreError}},
+    {StartupTask::HandlerName,          {StartupTask::CreateHandler,         FileTypeAssociation::HandlerName,  IgnoreError}},
+    {FileTypeAssociation::HandlerName,  {FileTypeAssociation::CreateHandler, Extractor::HandlerName,            IgnoreError}},
+    {Extractor::HandlerName,            {Extractor::CreateHandler,           nullptr,                           IgnoreError}},
 };
 
 HRESULT MsixRequest::Make(OperationType operationType, const std::wstring & packageFilePath, std::wstring packageFullName, MSIX_VALIDATION_OPTION validationOption, MsixRequest ** outInstance)
@@ -108,7 +126,11 @@ HRESULT MsixRequest::ProcessRequest()
     {
     case OperationType::Add:
     {
-        RETURN_IF_FAILED(ProcessAddRequest());
+        HRESULT hr = ProcessAddRequest();
+        if (FAILED(hr))
+        {
+            m_msixResponse->SetErrorStatus(hr, L"Failed to process add request");
+        }
         break;
     }
     case OperationType::Remove:
@@ -132,22 +154,14 @@ HRESULT MsixRequest::ProcessAddRequest()
             "Executing handler",
             TraceLoggingValue(currentHandlerName, "HandlerName"));
 
-        HandlerInfo currentHandler = AddHandlers[currentHandlerName];
+        AddHandlerInfo currentHandler = AddHandlers[currentHandlerName];
         AutoPtr<IPackageHandler> handler;
-        auto hrExecute = currentHandler.create(this, &handler);
-        if (FAILED(hrExecute))
-        {
-            if (handler->IsMandatoryForAddRequest())
-            {
-                m_msixResponse->SetErrorStatus(hrExecute, L"Can't create the handler " + std::wstring(currentHandlerName));
-                return hrExecute;
-            }
-        }
+        RETURN_IF_FAILED(currentHandler.create(this, &handler));
 
-        hrExecute = handler->ExecuteForAddRequest();
+        HRESULT hrExecute = S_OK;
+        RETURN_IF_FAILED(handler->ExecuteForAddRequest(hrExecute));
         if (FAILED(hrExecute))
         {
-            m_msixResponse->SetErrorStatus(hrExecute, L"Can't execute the handler " + std::wstring(currentHandlerName));
             currentHandlerName = currentHandler.errorHandler;
         }
         else
@@ -168,7 +182,7 @@ HRESULT MsixRequest::ProcessRemoveRequest()
             "Executing handler",
             TraceLoggingValue(currentHandlerName, "HandlerName"));
 
-        HandlerInfo currentHandler = RemoveHandlers[currentHandlerName];
+        RemoveHandlerInfo currentHandler = RemoveHandlers[currentHandlerName];
         AutoPtr<IPackageHandler> handler;
         HRESULT hrExecute = currentHandler.create(this, &handler);
         if (FAILED(hrExecute))

--- a/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
@@ -67,8 +67,8 @@ std::map<PCWSTR, AddHandlerInfo> AddHandlers =
 {
     //HandlerName                             Function to create                          NextHandler (on success)                 ErrorHandlingMode    ErrorHandler (when ExecuteErrorHandler)
     {PopulatePackageInfo::HandlerName,        {PopulatePackageInfo::CreateHandler,        ValidateTargetDeviceFamily::HandlerName, ReturnError,         nullptr}},
-    {ValidateTargetDeviceFamily::HandlerName, {ValidateTargetDeviceFamily::CreateHandler, ProcessPotentialUpdate::HandlerName,     ExecuteErrorHandler, ErrorHandler::HandlerName}},
-    {ProcessPotentialUpdate::HandlerName,     {ProcessPotentialUpdate::CreateHandler,     Extractor::HandlerName,                  ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {ValidateTargetDeviceFamily::HandlerName, {ValidateTargetDeviceFamily::CreateHandler, ProcessPotentialUpdate::HandlerName,     ReturnError,         nullptr}},
+    {ProcessPotentialUpdate::HandlerName,     {ProcessPotentialUpdate::CreateHandler,     Extractor::HandlerName,                  ReturnError,         nullptr}},
     {Extractor::HandlerName,                  {Extractor::CreateHandler,                  StartMenuLink::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {StartMenuLink::HandlerName,              {StartMenuLink::CreateHandler,              AddRemovePrograms::HandlerName,          ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {AddRemovePrograms::HandlerName,          {AddRemovePrograms::CreateHandler,          Protocol::HandlerName,                   ExecuteErrorHandler, ErrorHandler::HandlerName}},
@@ -157,12 +157,12 @@ HRESULT MsixRequest::ProcessAddRequest()
         }
         if (FAILED(hr) && currentHandler.errorMode != IgnoreAndProcessNextHandler)
         {
-            currentHandlerName = currentHandler.errorHandler;
             if (currentHandler.errorMode == ReturnError)
             {
                 m_msixResponse->SetErrorStatus(hr, L"Failed to process add request");
                 return hr;
             }
+            currentHandlerName = currentHandler.errorHandler;
         }
         else
         {

--- a/preview/MsixCore/MsixCoreInstaller/PopulatePackageInfo.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/PopulatePackageInfo.hpp
@@ -18,8 +18,6 @@ public:
     /// @return E_NOT_SET when the package cannot be found
     HRESULT ExecuteForRemoveRequest();
 
-    bool IsMandatoryForRemoveRequest() { return true; }
-
     static const PCWSTR HandlerName;
     static HRESULT CreateHandler(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
     ~PopulatePackageInfo() {}

--- a/preview/MsixCore/MsixCoreInstallerLib/PackageManager.hpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/PackageManager.hpp
@@ -13,11 +13,11 @@ namespace MsixCoreLib {
         HRESULT AddPackage(const std::wstring & packageFilePath, DeploymentOptions options) override;
         std::shared_ptr<IMsixResponse> RemovePackageAsync(const std::wstring & packageFullName, std::function<void(const IMsixResponse&)> callback = nullptr) override;
         HRESULT RemovePackage(const std::wstring & packageFullName) override;
-        std::shared_ptr<IInstalledPackage> FindPackage(const std::wstring & packageFullName) override;
-        std::shared_ptr<IInstalledPackage> FindPackageByFamilyName(const std::wstring & packageFamilyName) override;
-        std::unique_ptr<std::vector<std::shared_ptr<IInstalledPackage>>> FindPackages() override;
-        std::shared_ptr<IPackage> GetMsixPackageInfo(const std::wstring & msixFullPath) override;
+        HRESULT FindPackage(const std::wstring & packageFullName, std::shared_ptr<IInstalledPackage> & installedPackage) override;
+        HRESULT FindPackageByFamilyName(const std::wstring & packageFamilyName, std::shared_ptr<IInstalledPackage> & installedPackage) override;
+        HRESULT FindPackages(std::unique_ptr<std::vector<std::shared_ptr<IInstalledPackage>>> & installedPackages) override;
+        HRESULT GetMsixPackageInfo(const std::wstring & msixFullPath, std::shared_ptr<IPackage> & package) override;
     private:
-        std::shared_ptr<IInstalledPackage> GetPackageInfo(const std::wstring & msixCoreDirectory, const std::wstring & directoryPath);
+        HRESULT GetPackageInfo(const std::wstring & msixCoreDirectory, const std::wstring & directoryPath, std::shared_ptr<IInstalledPackage> & installedPackage);
     };
 }

--- a/preview/MsixCore/MsixCoreInstallerLib/inc/IPackageManager.hpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/inc/IPackageManager.hpp
@@ -15,9 +15,9 @@ namespace MsixCoreLib {
         virtual HRESULT AddPackage(const std::wstring & packageFilePath, DeploymentOptions options) = 0;
         virtual std::shared_ptr<IMsixResponse> RemovePackageAsync(const std::wstring & packageFullName, std::function<void(const IMsixResponse&)> callback = nullptr) = 0;
         virtual HRESULT RemovePackage(const std::wstring & packageFullName) = 0;
-        virtual std::shared_ptr<IInstalledPackage> FindPackage(const std::wstring & packageFamilyName) = 0;
-        virtual std::shared_ptr<IInstalledPackage> FindPackageByFamilyName(const std::wstring & packageFamilyName) = 0;
-        virtual std::unique_ptr<std::vector<std::shared_ptr<IInstalledPackage>>> FindPackages() = 0;
-        virtual std::shared_ptr<IPackage> GetMsixPackageInfo(const std::wstring & msixFullPath) = 0;
+        virtual HRESULT FindPackage(const std::wstring & packageFullName, std::shared_ptr<IInstalledPackage> &package) = 0;
+        virtual HRESULT FindPackageByFamilyName(const std::wstring & packageFamilyName, std::shared_ptr<IInstalledPackage> & installedPackage) = 0;
+        virtual HRESULT FindPackages(std::unique_ptr<std::vector<std::shared_ptr<IInstalledPackage>>> & installedPackages) = 0;
+        virtual HRESULT GetMsixPackageInfo(const std::wstring & msixFullPath, std::shared_ptr<IPackage> & package) = 0;
     };
 }


### PR DESCRIPTION
Add ErrorHandlingMode enum and column to the HandlerInfo registration tables, and modified ProcessAddRequest/ProcessRemoveRequest to handle the behaviors. replacing the IsMandatory() checks.

Fix crash when package open fails by checking for the error.

Return command line string when failure happens in quiet mode.