### PR TITLE
DeflateStream

### DIFF
--- a/src/inc/DeflateStream.hpp
+++ b/src/inc/DeflateStream.hpp
@@ -26,6 +26,14 @@ namespace MSIX {
     protected:
         std::vector<std::uint8_t> Deflate(int disposition);
 
+        typedef enum
+        {
+            Open,
+            Closed,
+        }
+        State;
+
+        State m_state = State::Open;
         z_stream m_zstrm;
         ComPtr<IStream> m_stream;
     };

--- a/src/inc/DeflateStream.hpp
+++ b/src/inc/DeflateStream.hpp
@@ -1,0 +1,32 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#pragma once
+
+#include "ComHelper.hpp"
+#include "StreamBase.hpp"
+
+#include <vector>
+#include <zlib.h>
+
+namespace MSIX {
+
+    class DeflateStream final : public StreamBase
+    {
+    public:
+        DeflateStream(const ComPtr<IStream>& stream);
+        ~DeflateStream();
+
+        // IStream
+        HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept override;
+        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override;
+        HRESULT STDMETHODCALLTYPE Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept override;
+    
+    protected:
+        std::vector<std::uint8_t> Deflate(int disposition);
+
+        z_stream m_zstrm;
+        ComPtr<IStream> m_stream;
+    };
+}

--- a/src/inc/MsixErrors.hpp
+++ b/src/inc/MsixErrors.hpp
@@ -74,6 +74,10 @@ namespace MSIX {
         // Bundle errors
         PackageIsBundle             = ERROR_FACILITY + 0x0071,
 
+        // Deflate errors
+        DeflateInitialize           = ERROR_FACILITY + 0x0081,
+        DeflateWrite                = ERROR_FACILITY + 0x0082,
+
         // XML parsing errors
         XmlWarning                  = XML_FACILITY + 0x0001,
         XmlError                    = XML_FACILITY + 0x0002,

--- a/src/inc/MsixErrors.hpp
+++ b/src/inc/MsixErrors.hpp
@@ -77,6 +77,7 @@ namespace MSIX {
         // Deflate errors
         DeflateInitialize           = ERROR_FACILITY + 0x0081,
         DeflateWrite                = ERROR_FACILITY + 0x0082,
+        DeflateRead                 = ERROR_FACILITY + 0x0083,
 
         // XML parsing errors
         XmlWarning                  = XML_FACILITY + 0x0001,

--- a/src/inc/ZipFileStream.hpp
+++ b/src/inc/ZipFileStream.hpp
@@ -8,6 +8,7 @@
 #include "StreamBase.hpp"
 #include "RangeStream.hpp"
 #include "AppxFactory.hpp"
+#include "MsixFeatureSelector.hpp"
 
 #include <string>
 
@@ -17,17 +18,26 @@ namespace MSIX {
     class ZipFileStream final : public RangeStream
     {
     public:
-        // TODO: define what streams to pass in on the .ctor
+        // Represents an stream taken from the zip file (unpack)
         ZipFileStream(
             std::string name,
             std::string contentType,
-            IMsixFactory* factory,
             bool isCompressed,
             std::uint64_t offset,
             std::uint64_t size,
-            const ComPtr<IStream>& stream
-        ) : m_isCompressed(isCompressed), RangeStream(offset, size, stream), m_name(name), m_contentType(contentType), m_factory(factory), m_compressedSize(size)
+            const ComPtr<IStream>& stream // this is the actual zip file stream
+        ) : m_isCompressed(isCompressed), RangeStream(offset, size, stream), m_name(name), m_contentType(contentType), m_compressedSize(size)
         {
+        }
+
+        // Represents an stream to be added to the zip file (pack)
+        ZipFileStream(
+            const std::string& name,
+            const std::string& contentType,
+            bool isCompressed
+        ) : m_isCompressed(isCompressed), m_name(name), m_contentType(contentType), RangeStream(isCompressed)
+        {
+            THROW_IF_PACK_NOT_ENABLED
         }
 
         // IStreamInternal
@@ -36,7 +46,6 @@ namespace MSIX {
         std::string GetName() override { return m_name; }
 
     protected:
-        IMsixFactory*   m_factory;
         std::string     m_name;
         std::string     m_contentType;
         bool            m_isCompressed = false;

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -113,6 +113,7 @@ if(MSIX_PACK)
         pack/AppxBlockMapWriter.cpp
         pack/ContentTypeWriter.cpp
         pack/ContentType.cpp
+        pack/DeflateStream.cpp
     )
 endif()
 

--- a/src/msix/pack/DeflateStream.cpp
+++ b/src/msix/pack/DeflateStream.cpp
@@ -28,6 +28,7 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE DeflateStream::Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept try
     {
         // just forward to the VectorStream
+        ThrowErrorIf(Error::FileWrite, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
         ThrowHrIfFailed(m_stream->Seek(move, origin, newPosition));
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -35,6 +36,7 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE DeflateStream::Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept try
     {
         // just forward to the VectorStream
+        ThrowErrorIf(Error::FileWrite, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
         ThrowHrIfFailed(m_stream->Read(buffer, countBytes, bytesRead));
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -42,9 +44,15 @@ namespace MSIX {
     // Caller should NOT assume that bytesWritten returned is going to be equal to countBytes
     HRESULT STDMETHODCALLTYPE DeflateStream::Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept try
     {
+        ThrowErrorIf(Error::FileWrite, m_state == State::Closed, "DeflateStream is already closed");
         // Important! If this stream is asked to write with 0 bytes, then it means that we are done.
-        // We need to terminate the stream anc call deflate with Z_FINISH.
-        int disposition = (countBytes > 0) ? Z_FULL_FLUSH : Z_FINISH;
+        // We need to terminate the stream and call deflate with Z_FINISH.
+        int disposition = Z_FULL_FLUSH;
+        if (countBytes == 0)
+        {
+            disposition = Z_FINISH;
+            m_state = State::Closed;
+        }
         m_zstrm.next_in = reinterpret_cast<Bytef *>(const_cast<void*>(buffer));
         m_zstrm.avail_in = static_cast<std::uint32_t>(countBytes);
         auto toWrite = Deflate(disposition);

--- a/src/msix/pack/DeflateStream.cpp
+++ b/src/msix/pack/DeflateStream.cpp
@@ -28,7 +28,7 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE DeflateStream::Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept try
     {
         // just forward to the VectorStream
-        ThrowErrorIf(Error::FileWrite, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
+        ThrowErrorIf(Error::DeflateRead, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
         ThrowHrIfFailed(m_stream->Seek(move, origin, newPosition));
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -36,7 +36,7 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE DeflateStream::Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept try
     {
         // just forward to the VectorStream
-        ThrowErrorIf(Error::FileWrite, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
+        ThrowErrorIf(Error::DeflateRead, m_state != State::Closed, "DeflateStream needs to be closed before being consume");
         ThrowHrIfFailed(m_stream->Read(buffer, countBytes, bytesRead));
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -44,7 +44,7 @@ namespace MSIX {
     // Caller should NOT assume that bytesWritten returned is going to be equal to countBytes
     HRESULT STDMETHODCALLTYPE DeflateStream::Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept try
     {
-        ThrowErrorIf(Error::FileWrite, m_state == State::Closed, "DeflateStream is already closed");
+        ThrowErrorIf(Error::DeflateWrite, m_state == State::Closed, "DeflateStream is already closed");
         // Important! If this stream is asked to write with 0 bytes, then it means that we are done.
         // We need to terminate the stream and call deflate with Z_FINISH.
         int disposition = Z_FULL_FLUSH;

--- a/src/msix/pack/DeflateStream.cpp
+++ b/src/msix/pack/DeflateStream.cpp
@@ -1,0 +1,75 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+
+#include "DeflateStream.hpp"
+#include "Exceptions.hpp"
+
+#include <vector>
+
+namespace MSIX {
+
+    DeflateStream::DeflateStream(const ComPtr<IStream>& stream) : m_stream(stream)
+    {
+        m_zstrm.zalloc = Z_NULL;
+        m_zstrm.zfree = Z_NULL;
+        m_zstrm.opaque = Z_NULL;
+        auto result = deflateInit2(&m_zstrm, Z_BEST_COMPRESSION, Z_DEFLATED, -MAX_WBITS, MAX_MEM_LEVEL, Z_DEFAULT_STRATEGY);
+        ThrowErrorIf(Error::DeflateInitialize, result != Z_OK, "Error calling deflateinit2");
+    }
+
+    DeflateStream::~DeflateStream()
+    {
+        deflateEnd(&m_zstrm);
+    }
+
+    // IStream
+    HRESULT STDMETHODCALLTYPE DeflateStream::Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept try
+    {
+        // just forward to the VectorStream
+        ThrowHrIfFailed(m_stream->Seek(move, origin, newPosition));
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    HRESULT STDMETHODCALLTYPE DeflateStream::Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept try
+    {
+        // just forward to the VectorStream
+        ThrowHrIfFailed(m_stream->Read(buffer, countBytes, bytesRead));
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    // Caller should NOT assume that bytesWritten returned is going to be equal to countBytes
+    HRESULT STDMETHODCALLTYPE DeflateStream::Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept try
+    {
+        // Important! If this stream is asked to write with 0 bytes, then it means that we are done.
+        // We need to terminate the stream anc call deflate with Z_FINISH.
+        int disposition = (countBytes > 0) ? Z_FULL_FLUSH : Z_FINISH;
+        m_zstrm.next_in = reinterpret_cast<Bytef *>(const_cast<void*>(buffer));
+        m_zstrm.avail_in = static_cast<std::uint32_t>(countBytes);
+        auto toWrite = Deflate(disposition);
+        ThrowHrIfFailed(m_stream->Write(toWrite.data(), static_cast<ULONG>(toWrite.size()), bytesWritten));
+        return static_cast<HRESULT>(Error::OK);
+    } CATCH_RETURN();
+
+    std::vector<std::uint8_t> DeflateStream::Deflate(int disposition)
+    {
+        std::vector<std::uint8_t> compressedBuffer;
+        std::vector<std::uint8_t> deflateBuffer(1024);
+        do
+        {
+            m_zstrm.next_out = deflateBuffer.data();
+            m_zstrm.avail_out = static_cast<std::uint32_t>(deflateBuffer.size());
+            auto result = deflate(&m_zstrm, disposition);
+            if (disposition == Z_FINISH && result == Z_STREAM_END)
+            {
+                result = Z_OK;
+            }
+            ThrowErrorIf(Error::DeflateWrite, result != Z_OK, "Error deflating stream");
+            auto have = deflateBuffer.size() - m_zstrm.avail_out;
+            compressedBuffer.insert(compressedBuffer.end(), deflateBuffer.data(), deflateBuffer.data() + have);
+       } while (m_zstrm.avail_out == 0);
+       return compressedBuffer;
+    }
+
+}

--- a/src/msix/unpack/ZipObject.cpp
+++ b/src/msix/unpack/ZipObject.cpp
@@ -850,7 +850,6 @@ ZipObject::ZipObject(IMsixFactory* appxFactory, const ComPtr<IStream>& stream) :
         auto fileStream = ComPtr<IStream>::Make<ZipFileStream>(
             centralFileHeader.second->GetFileName(),
             "TODO: Implement", // TODO: put value from content type 
-            m_factory,
             localFileHeader->GetCompressionType() == CompressionType::Deflate,
             centralFileHeader.second->GetRelativeOffsetOfLocalHeader() + localFileHeader->Size(),
             localFileHeader->GetCompressedSize(),


### PR DESCRIPTION
Implement DeflateStream

Uses previous implementations of ZipFileStream and RangeStream.

For pack, RangeStream will create a VectorStream. If the file needs to be compressed, it will create then  DeflateStream passing that VectorStream.

DeflateStream will deflate the buffer until IStream::Write is called with 0 bytes. This is because we need to terminate the stream using Z_FINISH. 
