### PR TITLE
[MsixCore] Support installation of packages via IStream

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/ErrorHandler.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/ErrorHandler.cpp
@@ -21,7 +21,7 @@ HRESULT ErrorHandler::ExecuteForAddRequest()
 HRESULT ErrorHandler::RemovePackage(std::wstring packageFullName)
 {
     AutoPtr<MsixRequest> removePackageRequest;
-    RETURN_IF_FAILED(MsixRequest::Make(OperationType::Remove, std::wstring(), packageFullName,
+    RETURN_IF_FAILED(MsixRequest::Make(OperationType::Remove, nullptr, packageFullName,
         MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_FULL, &removePackageRequest));
 
     const HRESULT hrCancelRequest = removePackageRequest->ProcessRequest();

--- a/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
@@ -82,7 +82,7 @@ std::map<PCWSTR, HandlerInfo> RemoveHandlers =
     {Extractor::HandlerName,                    {Extractor::CreateHandler,                    nullptr}},
 };
 
-HRESULT MsixRequest::Make(OperationType operationType, const std::wstring & packageFilePath, std::wstring packageFullName, MSIX_VALIDATION_OPTION validationOption, MsixRequest ** outInstance)
+HRESULT MsixRequest::Make(OperationType operationType, IStream * packageStream, std::wstring packageFullName, MSIX_VALIDATION_OPTION validationOption, MsixRequest ** outInstance)
 {
     AutoPtr<MsixRequest> instance(new MsixRequest());
     if (instance == nullptr)
@@ -90,7 +90,7 @@ HRESULT MsixRequest::Make(OperationType operationType, const std::wstring & pack
         return E_OUTOFMEMORY;
     }
     instance->m_operationType = operationType;
-    instance->m_packageFilePath = packageFilePath;
+    instance->m_packageStream = packageStream;
     instance->m_packageFullName = packageFullName;
     instance->m_validationOptions = validationOption;
     RETURN_IF_FAILED(FilePathMappings::GetInstance().GetInitializationResult());

--- a/preview/MsixCore/MsixCoreInstaller/MsixRequest.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixRequest.hpp
@@ -16,7 +16,7 @@ class MsixRequest
 {
 private:
     /// Should always be available via constructor
-    std::wstring m_packageFilePath;
+    ComPtr<IStream> m_packageStream;
     std::wstring m_packageFullName;
     MSIX_VALIDATION_OPTION m_validationOptions = MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_FULL;
     OperationType m_operationType = Add;
@@ -30,7 +30,7 @@ private:
 protected:
     MsixRequest() {}
 public:
-    static HRESULT Make(OperationType operationType, const std::wstring & packageFilePath, std::wstring packageFullName, MSIX_VALIDATION_OPTION validationOption, MsixRequest** outInstance);
+    static HRESULT Make(OperationType operationType, IStream * packageStream, std::wstring packageFullName, MSIX_VALIDATION_OPTION validationOption, MsixRequest** outInstance);
 
     /// The main function processes the request based on whichever operation type was requested and then
     /// going through the sequence of individual handlers.
@@ -48,7 +48,7 @@ public:
     }
 
     inline MSIX_VALIDATION_OPTION GetValidationOptions() { return m_validationOptions; }
-    inline PCWSTR GetPackageFilePath() { return m_packageFilePath.c_str(); }
+    inline IStream * GetPackageStream() { return m_packageStream.Get(); }
     inline PCWSTR GetPackageFullName() { return m_packageFullName.c_str(); }
 
     /// Retrieves the msixResponse object

--- a/preview/MsixCore/MsixCoreInstaller/PopulatePackageInfo.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/PopulatePackageInfo.hpp
@@ -25,7 +25,7 @@ public:
     ~PopulatePackageInfo() {}
 
     static HRESULT GetPackageInfoFromManifest(const std::wstring & directoryPath, MSIX_VALIDATION_OPTION validationOption, std::shared_ptr<InstalledPackage> * packageInfo);
-    static HRESULT GetPackageInfoFromPackage(const std::wstring & packageFilePath, MSIX_VALIDATION_OPTION validationOption, std::shared_ptr<Package> * packageInfo);
+    static HRESULT GetPackageInfoFromPackage(IStream * packageStream, MSIX_VALIDATION_OPTION validationOption, std::shared_ptr<Package> * packageInfo);
 private:
     MsixRequest* m_msixRequest = nullptr;
 

--- a/preview/MsixCore/MsixCoreInstaller/ProcessPotentialUpdate.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/ProcessPotentialUpdate.cpp
@@ -36,7 +36,7 @@ HRESULT ProcessPotentialUpdate::RemovePackage(std::wstring packageFullName)
         TraceLoggingValue(packageFullName.c_str(), "PackageToBeRemoved"));
 
     AutoPtr<MsixRequest> localRequest;
-    RETURN_IF_FAILED(MsixRequest::Make(OperationType::Remove, std::wstring(), packageFullName, MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_FULL, &localRequest));
+    RETURN_IF_FAILED(MsixRequest::Make(OperationType::Remove, nullptr, packageFullName, MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_FULL, &localRequest));
 
     const HRESULT hrProcessRequest = localRequest->ProcessRequest();
     if (FAILED(hrProcessRequest))

--- a/preview/MsixCore/MsixCoreInstallerLib/PackageManager.hpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/PackageManager.hpp
@@ -10,7 +10,9 @@ namespace MsixCoreLib {
     public:
         PackageManager();
         std::shared_ptr<IMsixResponse> AddPackageAsync(const std::wstring & packageFilePath, DeploymentOptions options, std::function<void(const IMsixResponse&)> callback = nullptr) override;
+        std::shared_ptr<IMsixResponse> AddPackageAsync(IStream * packageStream, DeploymentOptions options, std::function<void(const IMsixResponse&)> callback = nullptr) override;
         HRESULT AddPackage(const std::wstring & packageFilePath, DeploymentOptions options) override;
+        HRESULT AddPackage(IStream * packageStream, DeploymentOptions options) override;
         std::shared_ptr<IMsixResponse> RemovePackageAsync(const std::wstring & packageFullName, std::function<void(const IMsixResponse&)> callback = nullptr) override;
         HRESULT RemovePackage(const std::wstring & packageFullName) override;
         std::shared_ptr<IInstalledPackage> FindPackage(const std::wstring & packageFullName) override;

--- a/preview/MsixCore/MsixCoreInstallerLib/inc/IPackageManager.hpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/inc/IPackageManager.hpp
@@ -6,13 +6,14 @@
 #include "IPackage.hpp"
 #include "DeploymentOptions.hpp"
 
-
 namespace MsixCoreLib {
     class IPackageManager
     {
     public:
         virtual std::shared_ptr<IMsixResponse> AddPackageAsync(const std::wstring & packageFilePath, DeploymentOptions options, std::function<void(const IMsixResponse&)> callback = nullptr) = 0;
+        virtual std::shared_ptr<IMsixResponse> AddPackageAsync(IStream * packageStream, DeploymentOptions options, std::function<void(const IMsixResponse&)> callback = nullptr) = 0;
         virtual HRESULT AddPackage(const std::wstring & packageFilePath, DeploymentOptions options) = 0;
+        virtual HRESULT AddPackage(IStream * packageStream, DeploymentOptions options) = 0;
         virtual std::shared_ptr<IMsixResponse> RemovePackageAsync(const std::wstring & packageFullName, std::function<void(const IMsixResponse&)> callback = nullptr) = 0;
         virtual HRESULT RemovePackage(const std::wstring & packageFullName) = 0;
         virtual std::shared_ptr<IInstalledPackage> FindPackage(const std::wstring & packageFamilyName) = 0;


### PR DESCRIPTION
Fix #121

> In addition to the 2 existing functions AddPackage(wstring filepath...) and AddPackageAsync(wstring filepath....) using a file path to represent a msix package file, MsixCore should also support the installation of Msix packages not stored as files but as streams.

### Changes

Modify `AddPackage` and `AddPackageAsync` to replace the file path by a `IStream`:

```cpp
  HRESULT AddPackage(IStream * packageStream, DeploymentOptions options);`
```

```cpp
  std::shared_ptr<IMsixResponse> AddPackageAsync(IStream * packageStream, DeploymentOptions options, std::function<void(const IMsixResponse&)> callback = nullptr);`
```

And add 2 methods with the same prototype than the 2 original methods to still support installation of packages based on a file path.

MsixRequest was also modified to use a `IStream` instead of a file path as a reference of the Msix package we want to install.