### PR TITLE
[MsixCore] Debug/x64 must use /MTd instead /MDd

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.vcxproj
+++ b/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.vcxproj
@@ -114,7 +114,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>..\MsixCoreInstallerLib\inc;..\..\..\.vs\src\msix;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/preview/MsixCore/MsixCoreInstallerLib/MsixCoreInstallerLib.vcxproj
+++ b/preview/MsixCore/MsixCoreInstallerLib/MsixCoreInstallerLib.vcxproj
@@ -92,7 +92,7 @@
       <PreprocessorDefinitions>MsixCoreInstallerLib_EXPORTS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;..\MsixCoreInstaller;inc;..\..\..\.vs\src\msix;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -112,7 +112,7 @@
       <PreprocessorDefinitions>MsixCoreInstallerLib_EXPORTS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>.;..\MsixCoreInstaller;inc;..\..\..\.vs\src\msix;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Fix some issues with runtime library:
- At the moment, Debug/x64 uses /MDd (Runtime library = Multi-threaded DLL debug) instead of /MTd (Multi-threaded debug) similarly to all other compilation modes.
- MsixInstallerLib used the non-debug version of the runtime library with Debug/x86.