### PR TITLE
Converting FTA DEH to per user

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/FileTypeAssociation.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/FileTypeAssociation.cpp
@@ -163,8 +163,11 @@ HRESULT FileTypeAssociation::ProcessFtaForAdd(Fta& fta)
             return HRESULT_FROM_WIN32(ERROR_INSTALL_USEREXIT);
         }
 
+        //bool registryHasExtension = false;
+        //RETURN_IF_FAILED(m_registryDevirtualizer->HasFTA(*extensionName, registryHasExtension));
+
         bool registryHasExtension = false;
-        RETURN_IF_FAILED(m_registryDevirtualizer->HasFTA(*extensionName, registryHasExtension));
+        RETURN_IF_FAILED(m_registryDevirtualizer->HasRegistryKey(HKEY_CURRENT_USER, classesKeyPath.c_str(), *extensionName, registryHasExtension));
 
         if (registryHasExtension)
         {
@@ -305,7 +308,8 @@ HRESULT FileTypeAssociation::CreateHandler(MsixRequest * msixRequest, IPackageHa
         return E_OUTOFMEMORY;
     }
 
-    RETURN_IF_FAILED(localInstance->m_classesKey.Open(HKEY_CLASSES_ROOT, nullptr, KEY_READ | KEY_WRITE | WRITE_DAC));
+    //RETURN_IF_FAILED(localInstance->m_classesKey.Open(HKEY_CLASSES_ROOT, nullptr, KEY_READ | KEY_WRITE | WRITE_DAC));
+    RETURN_IF_FAILED(localInstance->m_classesKey.Open(HKEY_CURRENT_USER, classesKeyPath.c_str(), KEY_READ | KEY_WRITE | WRITE_DAC));
 
     std::wstring registryFilePath = msixRequest->GetPackageDirectoryPath() + registryDatFile;
     RETURN_IF_FAILED(RegistryDevirtualizer::Create(registryFilePath, msixRequest, &localInstance->m_registryDevirtualizer));

--- a/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixRequest.cpp
@@ -33,6 +33,7 @@
 #include "ErrorHandler.hpp"
 #include "ValidateTargetDeviceFamily.hpp"
 #include "PrepareDevirtualizedRegistry.hpp"
+#include "WriteDevirtualizedRegistry.hpp"
 
 #include "Constants.hpp"
 
@@ -78,7 +79,8 @@ std::map<PCWSTR, AddHandlerInfo> AddHandlers =
     {ComInterface::HandlerName,                 {ComInterface::CreateHandler,                 ComServer::HandlerName,                    ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {ComServer::HandlerName,                    {ComServer::CreateHandler,                    StartupTask::HandlerName,                  ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {StartupTask::HandlerName,                  {StartupTask::CreateHandler,                  FileTypeAssociation::HandlerName,          ExecuteErrorHandler, ErrorHandler::HandlerName}},
-    {FileTypeAssociation::HandlerName,          {FileTypeAssociation::CreateHandler,          InstallComplete::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {FileTypeAssociation::HandlerName,          {FileTypeAssociation::CreateHandler,          WriteDevirtualizedRegistry::HandlerName,   ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {WriteDevirtualizedRegistry::HandlerName,   {WriteDevirtualizedRegistry::CreateHandler,   InstallComplete::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {InstallComplete::HandlerName,              {InstallComplete::CreateHandler,              nullptr,                                   ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {ErrorHandler::HandlerName,                 {ErrorHandler::CreateHandler,                 nullptr,                                   ReturnError,         nullptr}},
 };

--- a/preview/MsixCore/MsixCoreInstaller/PrepareDevirtualizedRegistry.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/PrepareDevirtualizedRegistry.cpp
@@ -27,7 +27,8 @@ HRESULT PrepareDevirtualizedRegistry::ExtractRegistry(bool remove)
 
     AutoPtr<RegistryDevirtualizer> registryDevirtualizer;
     RETURN_IF_FAILED(RegistryDevirtualizer::Create(registryFilePath, m_msixRequest, &registryDevirtualizer));
-    RETURN_IF_FAILED(registryDevirtualizer->Run(remove));
+    //TODO: This should run only for remove, not add(move to remove method)
+    //RETURN_IF_FAILED(registryDevirtualizer->Run(remove));
     return S_OK;
 }
 

--- a/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.cpp
@@ -509,6 +509,7 @@ HRESULT RegistryDevirtualizer::CreateTempKeyName(std::wstring &tempName)
 
 RegistryDevirtualizer::~RegistryDevirtualizer()
 {
+    //TODO:: move to WriteDevirtualizedRegistry destructor
     /*if (m_hiveFileNameExists)
     {
         m_rootKey.Close();

--- a/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/RegistryDevirtualizer.hpp
@@ -20,6 +20,16 @@ public:
     /// @param remove - if true, remove all the keys and values; if false, add all the keys and values
     HRESULT Run(_In_ bool remove);
 
+    /// Deletes the registry key from the mounted Registry.dat if present since per user values take precedence
+    ///
+    /// @param registryKey - the registry key to be deleted from the mounted Registry.dat
+    HRESULT DeleteKeyIfPresent(_In_ RegistryKey * registryKey);
+
+    /// Determines whether the mounted Registry.dat contains the registry key. Does not perform any modifications to the system.
+    /// 
+    /// @param registryKey - the registry key to look for in the mounted Registry.dat
+    HRESULT HasRegistryKey(_In_ HKEY registryKey, _In_ std::wstring subkeyPath, _In_ std::wstring extensionName,  _Out_ bool& hasRegistryKey);
+
     /// Determines whether Registry.dat contains a FTA (file type association). Does not perform any modifications to the system.
     /// 
     /// @param ftaName - the name of the FTA extension (i.e. .mp4)

--- a/preview/MsixCore/MsixCoreInstaller/WriteDevirtualizedRegistry.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/WriteDevirtualizedRegistry.cpp
@@ -1,0 +1,42 @@
+#include <windows.h>
+
+#include <shlobj_core.h>
+#include <CommCtrl.h>
+
+#include "WriteDevirtualizedRegistry.hpp"
+#include "GeneralUtil.hpp"
+#include <TraceLoggingProvider.h>
+#include "MsixTraceLoggingProvider.hpp"
+#include "Constants.hpp"
+#include "RegistryDevirtualizer.hpp"
+
+using namespace MsixCoreLib;
+
+const PCWSTR WriteDevirtualizedRegistry::HandlerName = L"WriteDevirtualizedRegistry";
+
+HRESULT WriteDevirtualizedRegistry::ExecuteForAddRequest()
+{
+    //copy rest of the keys here
+    AutoPtr<RegistryDevirtualizer> registryDevirtualizer;
+    RETURN_IF_FAILED(registryDevirtualizer->Run(false));
+    return S_OK;
+}
+
+HRESULT WriteDevirtualizedRegistry::CreateHandler(MsixRequest * msixRequest, IPackageHandler ** instance)
+{
+    std::unique_ptr<WriteDevirtualizedRegistry > localInstance(new WriteDevirtualizedRegistry(msixRequest));
+    if (localInstance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+    *instance = localInstance.release();
+
+    return S_OK;
+}
+
+//TODO: Unload mounted hive here
+/*WriteDevirtualizedRegistry::~WriteDevirtualizedRegistry()
+{
+    // unload loaded hive here
+
+}*/

--- a/preview/MsixCore/MsixCoreInstaller/WriteDevirtualizedRegistry.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/WriteDevirtualizedRegistry.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "GeneralUtil.hpp"
+#include "IPackageHandler.hpp"
+#include "MsixRequest.hpp"
+
+namespace MsixCoreLib
+{
+    class WriteDevirtualizedRegistry : IPackageHandler
+    {
+    public:
+        HRESULT ExecuteForAddRequest();
+
+        static const PCWSTR HandlerName;
+        static HRESULT CreateHandler(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
+        //~WriteDevirtualizedRegistry() {}
+    private:
+        MsixRequest * m_msixRequest = nullptr;
+
+        WriteDevirtualizedRegistry() {}
+        WriteDevirtualizedRegistry(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}
+    };
+}

--- a/preview/MsixCore/MsixCoreInstallerLib/MsixCoreInstallerLib.vcxproj
+++ b/preview/MsixCore/MsixCoreInstallerLib/MsixCoreInstallerLib.vcxproj
@@ -203,6 +203,7 @@
     <ClInclude Include="..\MsixCoreInstaller\RegistryKey.hpp" />
     <ClInclude Include="..\MsixCoreInstaller\StartMenuLink.hpp" />
     <ClInclude Include="..\MsixCoreInstaller\PrepareDevirtualizedRegistry.hpp" />
+    <ClInclude Include="..\MsixCoreInstaller\WriteDevirtualizedRegistry.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\MsixCoreInstaller\ComInterface.cpp" />
@@ -229,6 +230,7 @@
     <ClCompile Include="..\MsixCoreInstaller\StartMenuLink.cpp" />
     <ClCompile Include="MsixCoreInstallerActions.cpp" />
     <ClCompile Include="..\MsixCoreInstaller\PrepareDevirtualizedRegistry.cpp" />
+    <ClCompile Include="..\MsixCoreInstaller\WriteDevirtualizedRegistry.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Creating PR to get feedback on approach adopted for 'Invert preference when registry.dat contains same keys as DEH-written keys to use DEH-written keys instead' task.
-Created WriteDevirtualizedRegistry handler which copies rest of the keys to the real registry, runs destructor which unmounts the mounted hive at the end after all DEH's have run.
-Modified File Type association DEH which calls HasRegistryKey() in RegistryDevirtualizer.cpp which maps real key to virtual key and check if key exists.
