### PR TITLE
Minor pack improvements

### DIFF
--- a/src/inc/AppxBlockMapWriter.hpp
+++ b/src/inc/AppxBlockMapWriter.hpp
@@ -19,7 +19,7 @@ namespace MSIX {
         BlockMapWriter();
 
         void AddFile(const std::string& name, std::uint64_t uncompressedSize, std::uint32_t lfh);
-        void AddBlock(const std::vector<std::uint8_t>& hash, ULONG size, bool isCompressed);
+        void AddBlock(const std::vector<std::uint8_t>& block, ULONG size, bool isCompressed);
         void CloseFile();
         void Close();
         ComPtr<IStream> GetStream() { return m_xmlWriter.GetStream(); }

--- a/src/inc/AppxPackaging.hpp
+++ b/src/inc/AppxPackaging.hpp
@@ -1569,6 +1569,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackBundleFromStream(
 
 // TODO: expand flags flags as needed.
 MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
+    MSIX_PACKUNPACK_OPTION packUnpackOptions,
     MSIX_VALIDATION_OPTION validationOption,
     char* directoryPath,
     char* outputPackage

--- a/src/inc/MsixErrors.hpp
+++ b/src/inc/MsixErrors.hpp
@@ -67,6 +67,7 @@ namespace MSIX {
 
         // Blockmap semantic errors
         BlockMapSemanticError       = ERROR_FACILITY + 0x0051,
+        BlockMapInvalidData         = ERROR_FACILITY + 0x0052,
 
         // AppxManifest semantic errors
         AppxManifestSemanticError   = ERROR_FACILITY + 0x0061,

--- a/src/makemsix/main.cpp
+++ b/src/makemsix/main.cpp
@@ -40,7 +40,7 @@ struct State
 
     bool CreatePackageSubfolder()
     {
-        unpackOptions = static_cast<MSIX_PACKUNPACK_OPTION>(unpackOptions | MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_CREATEPACKAGESUBFOLDER);
+        packUnpackOptions = static_cast<MSIX_PACKUNPACK_OPTION>(packUnpackOptions | MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_CREATEPACKAGESUBFOLDER);
         return true;
     }
 
@@ -101,7 +101,7 @@ struct State
     std::string directoryName;
     UserSpecified specified                  = UserSpecified::Nothing;
     MSIX_VALIDATION_OPTION validationOptions = MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_FULL;
-    MSIX_PACKUNPACK_OPTION unpackOptions     = MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_NONE;
+    MSIX_PACKUNPACK_OPTION packUnpackOptions     = MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_NONE;
     MSIX_APPLICABILITY_OPTIONS applicability = MSIX_APPLICABILITY_OPTIONS::MSIX_APPLICABILITY_OPTION_FULL;
 };
 
@@ -273,19 +273,19 @@ int ParseAndRun(std::vector<Command>& commands, int argc, char* argv[])
     case UserSpecified::Nothing:
         return Help(argv[0], commands, state);
     case UserSpecified::Unpack:
-        return UnpackPackage(state.unpackOptions, state.validationOptions,
+        return UnpackPackage(state.packUnpackOptions, state.validationOptions,
             const_cast<char*>(state.packageName.c_str()),
             const_cast<char*>(state.directoryName.c_str())
         );
     case UserSpecified::Unbundle:
-        return UnpackBundle(state.unpackOptions, state.validationOptions,
+        return UnpackBundle(state.packUnpackOptions, state.validationOptions,
             state.applicability,
             const_cast<char*>(state.packageName.c_str()),
             const_cast<char*>(state.directoryName.c_str())
         );
     #ifdef MSIX_PACK
     case UserSpecified::Pack:
-        return PackPackage(state.validationOptions, 
+        return PackPackage(state.packUnpackOptions, state.validationOptions, 
             const_cast<char*>(state.directoryName.c_str()),
             const_cast<char*>(state.packageName.c_str()));
     #endif

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -63,8 +63,11 @@ if(NOT WIN32)
                 "JNI_OnLoad"
             )
         endif()
-        # on Linux and linux-derived platforms, you use a version script to achieve similar ends.
-        set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -fvisibility=hidden")
+        # Hide visibility and discard unused functions
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden -ffunction-sections -fdata-sections")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -ffunction-sections -fdata-sections")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--gc-sections")
+        # On Linux and linux-derived platforms, you use a version script to achieve similar ends.
         # Make it look readable. The last ; is in the symbol.map.cmakein file
         string(REGEX REPLACE ";" ";\n\t" MSIX_EXPORTS "${MSIX_EXPORTS}")
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/symbol.map.cmakein ${CMAKE_CURRENT_BINARY_DIR}/symbol.map CRLF)

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -211,6 +211,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackBundleFromStream(
 #ifdef MSIX_PACK
 
 MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
+    MSIX_PACKUNPACK_OPTION packUnpackOptions,
     MSIX_VALIDATION_OPTION validationOption,
     char* directoryPath,
     char* outputPackage

--- a/src/msix/pack/AppxBlockMapWriter.cpp
+++ b/src/msix/pack/AppxBlockMapWriter.cpp
@@ -57,9 +57,9 @@ namespace MSIX {
     {
         // hash block
         std::vector<std::uint8_t> hash;
-        ThrowErrorIfNot(MSIX::Error::SignatureInvalid, 
+        ThrowErrorIfNot(MSIX::Error::BlockMapInvalidData,
             MSIX::SHA256::ComputeHash(const_cast<std::uint8_t*>(block.data()), static_cast<uint32_t>(block.size()), hash), 
-            "Invalid signature");
+            "Failed computing hash");
 
         m_xmlWriter.StartElement(blockElement);
         m_xmlWriter.AddAttribute(hashAttribute, Base64::ComputeBase64(hash));

--- a/src/msix/pack/AppxBlockMapWriter.cpp
+++ b/src/msix/pack/AppxBlockMapWriter.cpp
@@ -53,8 +53,14 @@ namespace MSIX {
     }
 
     // <Block Size="2948" Hash="ORIk+3QF9mSpuOq51oT3Xqn0Gy0vcGbnBRn5lBg5irM="/>
-    void BlockMapWriter::AddBlock(const std::vector<std::uint8_t>& hash, ULONG size, bool isCompressed)
+    void BlockMapWriter::AddBlock(const std::vector<std::uint8_t>& block, ULONG size, bool isCompressed)
     {
+        // hash block
+        std::vector<std::uint8_t> hash;
+        ThrowErrorIfNot(MSIX::Error::SignatureInvalid, 
+            MSIX::SHA256::ComputeHash(const_cast<std::uint8_t*>(block.data()), static_cast<uint32_t>(block.size()), hash), 
+            "Invalid signature");
+
         m_xmlWriter.StartElement(blockElement);
         m_xmlWriter.AddAttribute(hashAttribute, Base64::ComputeBase64(hash));
         // We only add the size attribute for compressed files, we cannot just check for the 

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -8,7 +8,6 @@
 #include "MsixErrors.hpp"
 #include "Exceptions.hpp"
 #include "ContentType.hpp"
-#include "Crypto.hpp"
 #include "ZipFileStream.hpp"
 #include "Encoding.hpp"
 #include "ZipObjectWriter.hpp"
@@ -216,16 +215,10 @@ namespace MSIX {
             ULONG bytesWritten = 0;
             ThrowHrIfFailed(zipFileStream->Write(block.data(), static_cast<ULONG>(block.size()), &bytesWritten));
 
-            // hash block
-            std::vector<std::uint8_t> hash;
-            ThrowErrorIfNot(MSIX::Error::SignatureInvalid, 
-                MSIX::SHA256::ComputeHash(block.data(), static_cast<uint32_t>(block.size()), hash), 
-                "Invalid signature");
-
             // Add block to blockmap
             if (addToBlockMap)
             {
-                m_blockMapWriter.AddBlock(hash, bytesWritten, toCompress);
+                m_blockMapWriter.AddBlock(block, bytesWritten, toCompress);
             }
 
         }


### PR DESCRIPTION
- Add MSIX_PACKUNPACK_OPTION flat to PackPackage entrypoint. This allows us to follow the same patter as UnpackPackage and be open future changes are not validation switches instead of creating a new entrypoint. For example, we might allow naming the package after the package id from the manifest. 
- Move SHA256 hashing inside the BlockMapWriter. I realized that there was need to the AppxPackageWriter to the hashing, just pass the block to the block map writer and encapsulate the SHA256 hashing and the base64 encoding.
- Add compiler and linker flags to hide visibility and discard unused functions for Android. This result in a 10KB drop in the binary size.