### PR TITLE
Check if registry file exists before copying file over

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/PrepareDevirtualizedRegistry.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/PrepareDevirtualizedRegistry.cpp
@@ -25,9 +25,13 @@ HRESULT PrepareDevirtualizedRegistry::ExtractRegistry()
 {
     std::wstring registryFilePath = m_msixRequest->GetPackageDirectoryPath() + registryDatFile;
     std::wstring registryFileCopyPath = m_msixRequest->GetPackageDirectoryPath() + registryDatFileCopy;
-    if (!CopyFile(registryFilePath.c_str(), registryFileCopyPath.c_str(), false))
+
+    if (std::experimental::filesystem::exists(registryFilePath))
     {
-        return HRESULT_FROM_WIN32(GetLastError());
+        if (!CopyFile(registryFilePath.c_str(), registryFileCopyPath.c_str(), false))
+        {
+            return HRESULT_FROM_WIN32(GetLastError());
+        }
     }
 
     std::shared_ptr<RegistryDevirtualizer> registryDevirtualizer;


### PR DESCRIPTION
Addressing bug in code due to which certain packages were not being installed. 
**Issue:** In cases where the registry file does not exist in case of certain packages, CopyFile was returning an error and the installer crashes. 
**Solution:** Handled this by checking if registry file exists before copying it over and passing it further down.