### PR TITLE
Pass to win10 installer on 1709 or greater

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
@@ -59,8 +59,25 @@ int main(int argc, char * argv[])
             }
             else
             {
-                auto ui = new UI(packageManager, cli.GetPackageFilePathToInstall(), UIType::InstallUIAdd);
-                ui->ShowUI();
+                if (IsWindows10RS3OrLater())
+                {
+                    const int bufSize = 1024;
+                    wchar_t path[bufSize];
+                    if (!GetFullPathNameW(cli.GetPackageFilePathToInstall().c_str(), bufSize, path, nullptr))
+                    {
+                        return HRESULT_FROM_WIN32(GetLastError());
+                    }
+
+                    std::wstring protocol = std::wstring(L"ms-appinstaller:?source=");
+                    protocol.append(path);
+
+                    ShellExecuteW(nullptr, L"Open", protocol.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+                }
+                else
+                {
+                    auto ui = new UI(packageManager, cli.GetPackageFilePathToInstall(), UIType::InstallUIAdd);
+                    ui->ShowUI();
+                }
             }
             break;
         }


### PR DESCRIPTION
- Updated code to redirect to native app installer in case of windows 1709 and above.