### PR TITLE
Add ability to unpack packages and apply ACLs to the resulting package folders to MSIXCoreInstaller.exe 

### DIFF
--- a/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.cpp
@@ -209,8 +209,8 @@ HRESULT CommandLineInterface::Init()
             auto suboptions = option->second.Suboptions;
             while (index < m_argc)
             {
-                std::wstring optionString = utf8_to_utf16(m_argv[index]);
-                auto suboption = suboptions.find(optionString);
+                std::wstring suboptionString = utf8_to_utf16(m_argv[index]);
+                auto suboption = suboptions.find(suboptionString);
                 if (suboption == suboptions.end())
                 {
                     TraceLoggingWrite(g_MsixUITraceLoggingProvider,
@@ -226,9 +226,9 @@ HRESULT CommandLineInterface::Init()
                     {
                         return E_INVALIDARG;
                     }
-                    parameter = m_argv[index];
+                    suboptionParameter = m_argv[index];
                 }
-                RETURN_IF_FAILED(option->second.DefaultCallback(this, parameter));
+                RETURN_IF_FAILED(suboption->second.Callback(this, suboptionParameter));
 
                 ++index;
             }

--- a/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.hpp
@@ -81,8 +81,10 @@ public:
     void DisplayHelp();
     HRESULT Init();
     bool IsQuietMode() { return m_quietMode; }
+    bool IsApplyACLs() { return m_applyACLs; }
     std::wstring GetPackageFilePathToInstall() { return m_packageFilePath; }
     std::wstring GetPackageFullName() { return m_packageFullName; }
+    std::wstring GetUnpackDestination() { return m_unpackDestination; }
     OperationType GetOperationType() { return m_operationType; }
 private:
     int m_argc = 0;

--- a/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.hpp
+++ b/preview/MsixCore/MsixCoreInstaller/CommandLineInterface.hpp
@@ -16,6 +16,25 @@ enum OperationType
 };
 
 class CommandLineInterface;
+
+struct CaseInsensitiveLess
+{
+    struct CaseInsensitiveCompare
+    {
+        bool operator() (const wchar_t& c1, const wchar_t& c2) const
+        {
+            return tolower(c1) < tolower(c2);
+        }
+    };
+    bool operator() (const std::wstring & s1, const std::wstring & s2) const
+    {
+        return std::lexicographical_compare(
+            s1.begin(), s1.end(),   // source range
+            s2.begin(), s2.end(),   // dest range
+            CaseInsensitiveCompare());  // comparison
+    }
+};
+
 /// Describes an option to a command that the user may specify used for the command line tool
 struct Option
 {
@@ -35,7 +54,7 @@ struct Options
     using CallbackFunction = std::function<HRESULT(CommandLineInterface* commandLineInterface, const std::string& value)>;
 
     Options(bool takesParam, const UINT help, CallbackFunction defaultCallback) : Help(help), DefaultCallback(defaultCallback), TakesParameter(takesParam), HasSuboptions(false) {}
-    Options(bool takesParam, const UINT help, CallbackFunction defaultCallback, std::map<std::wstring, Option> suboptions) : Help(help), DefaultCallback(defaultCallback), TakesParameter(takesParam), Suboptions(suboptions)
+    Options(bool takesParam, const UINT help, CallbackFunction defaultCallback, std::map<std::wstring, Option, CaseInsensitiveLess> suboptions) : Help(help), DefaultCallback(defaultCallback), TakesParameter(takesParam), Suboptions(suboptions)
     {
         HasSuboptions = !Suboptions.empty();
     }
@@ -45,25 +64,7 @@ struct Options
     std::wstring Name;
     UINT Help;
     CallbackFunction DefaultCallback;
-    std::map<std::wstring, Option> Suboptions;
-};
-
-struct CaseInsensitiveLess
-{
-    struct CaseInsensitiveCompare
-    {
-        bool operator() (const wchar_t& c1, const wchar_t& c2) const
-        {
-            return tolower(c1) < tolower(c2);
-        }
-    };
-    bool operator() (const std::wstring & s1, const std::wstring & s2) const
-    {
-        return std::lexicographical_compare(
-            s1.begin(), s1.end(),   // source range
-            s2.begin(), s2.end(),   // dest range
-            CaseInsensitiveCompare());  // comparison
-    }
+    std::map<std::wstring, Option, CaseInsensitiveLess> Suboptions;
 };
 
 /// Parses the command line specified and creates a request.

--- a/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
+++ b/preview/MsixCore/MsixCoreInstaller/MsixCoreInstaller.cpp
@@ -137,6 +137,156 @@ int main(int argc, char * argv[])
             std::cout << numPackages << " Package(s) found" << std::endl;
             return S_OK;
         }
+        case OperationType::Unpack:
+        {
+            auto packageFilePath = cli.GetPackageFilePathToInstall();
+            auto unpackDestination = cli.GetUnpackDestination();
+            auto unpackDestinationUTF8 = utf16_to_utf8(unpackDestination);
+            std::vector<char> destination(unpackDestinationUTF8.c_str(), unpackDestinationUTF8.c_str() + unpackDestinationUTF8.size() + 1);
+            std::vector<std::wstring> packageFolders;
+
+            MSIX_PACKUNPACK_OPTION unpackOption = MSIX_PACKUNPACK_OPTION_UNPACKWITHFLATSTRUCTURE;
+            MSIX_VALIDATION_OPTION validationOption = MSIX_VALIDATION_OPTION_FULL;
+
+            if (IsPackageFile(packageFilePath))
+            {
+                ComPtr<IAppxFactory> factory;
+                RETURN_IF_FAILED(CoCreateAppxFactoryWithHeap(MyAllocate, MyFree, validationOption, &factory));
+
+                ComPtr<IStream> stream;
+                RETURN_IF_FAILED(CreateStreamOnFileUTF16(packageFilePath.c_str(), true, &stream));
+
+                ComPtr<IAppxPackageReader> reader;
+                RETURN_IF_FAILED(factory->CreatePackageReader(stream.Get(), &reader));
+
+                RETURN_IF_FAILED(UnpackPackageFromPackageReader(
+                    unpackOption,
+                    reader.Get(),
+                    &destination[0]));
+
+                if (cli.IsApplyACLs())
+                {
+                    PWSTR packageFullName = nullptr;
+                    //std::wstring packageFullName;
+
+                    ComPtr<IAppxManifestReader> manifestReader;
+                    RETURN_IF_FAILED(reader->GetManifest(&manifestReader));
+
+                    ComPtr<IAppxManifestPackageId> packageId;
+                    RETURN_IF_FAILED(manifestReader->GetPackageId(&packageId));
+
+                    RETURN_IF_FAILED(packageId->GetPackageFullName(&packageFullName));
+
+                    std::wstring packageFolderName = unpackDestination + L"\\" + packageFullName;
+                    packageFolders.push_back(packageFolderName);
+                }
+
+            }
+            else if (IsBundleFile(packageFilePath))
+            {
+                MSIX_APPLICABILITY_OPTIONS applicabilityOption = static_cast<MSIX_APPLICABILITY_OPTIONS>(MSIX_APPLICABILITY_NONE);
+
+                ComPtr<IAppxBundleFactory> factory;
+                RETURN_IF_FAILED(CoCreateAppxBundleFactoryWithHeap(MyAllocate, MyFree, validationOption, applicabilityOption, &factory));
+
+                ComPtr<IStream> stream;
+                RETURN_IF_FAILED(CreateStreamOnFileUTF16(packageFilePath.c_str(), true, &stream));
+
+                ComPtr<IAppxBundleReader> reader;
+                RETURN_IF_FAILED(factory->CreateBundleReader(stream.Get(), &reader));
+
+                RETURN_IF_FAILED(UnpackBundleFromBundleReader(
+                    unpackOption,
+                    reader.Get(),
+                    &destination[0]));
+
+                if (cli.IsApplyACLs())
+                {
+                    ComPtr<IAppxBundleManifestReader> bundleManifestReader;
+                    RETURN_IF_FAILED(reader->GetManifest(&bundleManifestReader));
+
+                    // Determine the name of the folder created for the unpacked bundle, and add this name to our list of package folders
+                    PWSTR bundleFullName = nullptr;
+                    ComPtr<IAppxManifestPackageId> bundleId;
+                    RETURN_IF_FAILED(bundleManifestReader->GetPackageId(&bundleId));
+                    RETURN_IF_FAILED(bundleId->GetPackageFullName(&bundleFullName));
+
+                    std::wstring bundleFolderName = unpackDestination + L"\\" + bundleFullName;
+                    packageFolders.push_back(bundleFolderName);
+
+                    // Now we must determine the names of the folders created for each package in the bundle
+                    // To do so, we can use the bundle reader's GetPayloadPackages API, which will tell us the names of all the package FILES 
+                    // that were unpacked. While we could then create a stream for each of these files to determine their package full names, this could
+                    // be potentially costly. Instead, we will use the bundle manifest reader's GetPackageInfoItems API, which will give us easy access
+                    // to <package file name, package full name> pairs for ALL packages in the bundle (not necessarily the ones that were unpacked). Once
+                    // we have built up a map of these file name -> full name pairs, we can quickly determine the package full name for each file name
+                    // returned by GetPayloadPackages. Append the package full name to the destination to get the folder name for the unpacked package, then
+                    // add this folder name to our list of package folder names.
+                    std::map <std::wstring, std::wstring>  packagesMap;
+
+                    ComPtr<IAppxBundleManifestPackageInfoEnumerator> packages;
+                    ComPtr<IAppxBundleManifestPackageInfo> currentPackage;
+                    RETURN_IF_FAILED(bundleManifestReader->GetPackageInfoItems(&packages));
+                    BOOL hasCurrent = FALSE;
+                    // Populate the packagesMap with package file name, package full name pairs
+                    for (packages->GetHasCurrent(&hasCurrent); hasCurrent; packages->MoveNext(&hasCurrent))
+                    {
+                        RETURN_IF_FAILED(packages->GetCurrent(&currentPackage));
+                        ComPtr<IAppxManifestPackageId> manifestPackageID;
+                        RETURN_IF_FAILED(currentPackage->GetPackageId(&manifestPackageID));
+
+                        PWSTR packageFullName = nullptr;
+                        RETURN_IF_FAILED(manifestPackageID->GetPackageFullName(&packageFullName));
+
+                        PWSTR packageFileName = nullptr;
+                        RETURN_IF_FAILED(currentPackage->GetFileName(&packageFileName));
+
+                        std::wstring stdPackageFileName = packageFileName;
+                        std::wstring stdPackageFullName = packageFullName;
+
+                        packagesMap[stdPackageFileName] = stdPackageFullName;
+                    }
+
+                    // Use GetPayloadPackages to enumerate over the package files that actually got unpacked
+                    // after applicability logic was applied. 
+                    hasCurrent = false;
+                    ComPtr<IAppxFilesEnumerator> packageFilesEnumerator;
+                    RETURN_IF_FAILED(reader->GetPayloadPackages(&packageFilesEnumerator));
+                    RETURN_IF_FAILED(packageFilesEnumerator->GetHasCurrent(&hasCurrent));
+                    while (hasCurrent)
+                    {
+                        ComPtr<IAppxFile> file;
+                        RETURN_IF_FAILED(packageFilesEnumerator->GetCurrent(&file));
+
+                        PWSTR packageFileName = nullptr;
+                        RETURN_IF_FAILED(file->GetName(&packageFileName));
+
+                        std::wstring stdPackageFileName = packageFileName;
+
+                        auto packageFullName = packagesMap[packageFileName];
+
+                        std::wstring packageFolderName = unpackDestination + L"\\" + packageFullName;
+
+                        packageFolders.push_back(packageFolderName);
+
+                        RETURN_IF_FAILED(packageFilesEnumerator->MoveNext(&hasCurrent));
+                    }
+                }
+
+            }
+            else
+            {
+                return E_INVALIDARG;
+            }
+
+            // Update this to pass folder names to API that apply ACLs to those folders
+            for (auto folder : packageFolders)
+            {
+                std::wcout << folder << std::endl;
+            }
+
+        }
+
         default:
             return E_NOT_SET;
         }

--- a/preview/MsixCore/MsixCoreInstallerLib/GeneralUtil.cpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/GeneralUtil.cpp
@@ -135,4 +135,24 @@ namespace MsixCoreLib
 
         return VerifyVersionInfo(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask);
     }
+
+    bool EndsWith(std::wstring const &fullString, std::wstring const &ending) {
+        if (fullString.length() >= ending.length()) {
+            return (0 == fullString.compare(fullString.length() - ending.length(), ending.length(), ending));
+        }
+        else {
+            return false;
+        }
+    }
+
+    bool IsPackageFile(std::wstring const& packageFilePath)
+    {
+        return EndsWith(packageFilePath, L".appx") || EndsWith(packageFilePath, L".msix");
+    }
+
+    bool IsBundleFile(std::wstring const& bundleFilePath)
+    {
+        return EndsWith(bundleFilePath, L".appxbundle") || EndsWith(bundleFilePath, L".msixbundle");
+    }
+
 }

--- a/preview/MsixCore/MsixCoreInstallerLib/GeneralUtil.hpp
+++ b/preview/MsixCore/MsixCoreInstallerLib/GeneralUtil.hpp
@@ -63,6 +63,12 @@ namespace MsixCoreLib
     /// https://docs.microsoft.com/en-us/windows/desktop/SysInfo/targeting-your-application-at-windows-8-1
     BOOL IsWindows10RS3OrLater();
 
+    bool EndsWith(std::wstring const &fullString, std::wstring const &ending);
+
+    bool IsPackageFile(std::wstring const& packageFilePath);
+
+    bool IsBundleFile(std::wstring const& bundleFilePath);
+
     //
     // Stripped down ComPtr class provided for those platforms that do not already have a ComPtr class.
     //


### PR DESCRIPTION
PR currently adds logic to unpack a package and builds up a list of the names of all the package folders created.

Also fixes some bugs in parsing suboptions.

TODO: 
- Apply ACLs to the created package folders 