### PR TITLE
General improvements to pack

### DIFF
--- a/makewin.cmd
+++ b/makewin.cmd
@@ -43,6 +43,12 @@ if /I "%~2" == "--debug" (
 if /I "%~2" == "-d" (
     set build="Debug"
 )
+if /I "%~2" == "--symbols" (
+    set build="RelWithDebInfo"
+)
+if /I "%~2" == "-sym" (
+    set build="RelWithDebInfo"
+)
 if /I "%~2" == "--parser-xerces" (
     set parser="-DXML_PARSER=xerces"
 )

--- a/src/inc/BlockMapStream.hpp
+++ b/src/inc/BlockMapStream.hpp
@@ -61,7 +61,7 @@ namespace MSIX {
             std::uint64_t sizeRemaining = m_streamSize;
             for (auto block = blocks.begin(); ((sizeRemaining != 0) && (block != blocks.end())); block++)
             {
-                auto rangeStream = ComPtr<IStream>::Make<RangeStream>(offset, std::min(sizeRemaining, BLOCKMAP_BLOCK_SIZE), stream);                
+                auto rangeStream = ComPtr<IStream>::Make<RangeStream>(offset, std::min(sizeRemaining, BLOCKMAP_BLOCK_SIZE), stream.Get());                
                 auto hashStream = ComPtr<IStream>::Make<HashStream>(rangeStream, block->hash);
                 std::uint64_t blockSize = std::min(sizeRemaining, BLOCKMAP_BLOCK_SIZE);
 

--- a/src/inc/DeflateStream.hpp
+++ b/src/inc/DeflateStream.hpp
@@ -22,6 +22,11 @@ namespace MSIX {
         HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept override;
         HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override;
         HRESULT STDMETHODCALLTYPE Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept override;
+
+        // IStreamInternal
+        std::uint64_t GetSize() override { return m_stream.As<IStreamInternal>()->GetSize(); }
+        bool IsCompressed() override { return m_stream.As<IStreamInternal>()->IsCompressed(); }
+        std::string GetName() override { return m_stream.As<IStreamInternal>()->GetName(); }
     
     protected:
         std::vector<std::uint8_t> Deflate(int disposition);

--- a/src/inc/Exceptions.hpp
+++ b/src/inc/Exceptions.hpp
@@ -76,7 +76,15 @@ namespace MSIX {
     #endif
     RaiseException(const int line, const char* const file, const char* details, C c)
     {
-        assert(false);
+#ifdef WIN32
+#ifndef NDEBUG
+        if (IsDebuggerPresent())
+#endif
+#endif
+        {
+            assert(false);
+        }
+
         std::ostringstream builder;
         if (details) { builder << details << "\n"; }
         builder << "Call failed in " << file << " on line " << line;

--- a/src/inc/RangeStream.hpp
+++ b/src/inc/RangeStream.hpp
@@ -81,7 +81,7 @@ namespace MSIX {
             ULONG amountToRead = std::min(countBytes, static_cast<ULONG>(m_size - m_relativePosition));
             ULONG amountRead = 0;
             ThrowHrIfFailed(m_stream->Read(buffer, amountToRead, &amountRead));
-            ThrowErrorIf(Error::FileRead, (amountToRead != amountRead), "Did not read as much as requesteed.");
+            ThrowErrorIf(Error::FileRead, (amountToRead != amountRead), "Did not read as much as requested.");
             m_relativePosition += amountRead;
             if (bytesRead) { *bytesRead = amountRead; }
             ThrowErrorIf(Error::FileSeekOutOfRange, (m_relativePosition > m_size), "seek pointer out of bounds.");
@@ -96,7 +96,7 @@ namespace MSIX {
             ThrowHrIfFailed(m_stream->Seek(offset, StreamBase::START, nullptr));
             ULONG amountWritten = 0;
             ThrowHrIfFailed(m_stream->Write(buffer, countBytes, &amountWritten));
-            ThrowErrorIf(Error::FileWrite, (countBytes != amountWritten), "Did not write as much as requesteed.");
+            ThrowErrorIf(Error::FileWrite, (countBytes != amountWritten), "Did not write as much as requested.");
             m_relativePosition += amountWritten;
             m_size = std::max(m_size, m_relativePosition);
             if (bytesWritten) { *bytesWritten = amountWritten; }

--- a/src/inc/VectorStream.hpp
+++ b/src/inc/VectorStream.hpp
@@ -60,6 +60,11 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         } CATCH_RETURN();
 
+        std::uint64_t GetSize() override
+        {
+            return static_cast<std::uint64_t>(m_data->size());
+        }
+
     protected:
         ULONG m_offset = 0;
         std::vector<std::uint8_t>* m_data;

--- a/src/inc/ZipFileStream.hpp
+++ b/src/inc/ZipFileStream.hpp
@@ -24,16 +24,17 @@ namespace MSIX {
             bool isCompressed,
             std::uint64_t offset,
             std::uint64_t size,
-            const ComPtr<IStream>& stream // this is the actual zip file stream
-        ) : m_isCompressed(isCompressed), RangeStream(offset, size, stream), m_name(name)
+            IStream* stream // this is the actual zip file stream
+        ) : m_isCompressed(isCompressed), RangeStream(offset, size, stream), m_name(std::move(name))
         {
         }
 
         // Represents an stream to be added to the zip file (pack)
         ZipFileStream(
-            const std::string& name,
-            bool isCompressed
-        ) : m_isCompressed(isCompressed), m_name(name), RangeStream(isCompressed)
+            std::string name,
+            bool isCompressed,
+            IStream* stream
+        ) : m_isCompressed(isCompressed), m_name(std::move(name)), RangeStream(stream)
         {
             THROW_IF_PACK_NOT_ENABLED
         }

--- a/src/inc/ZipObject.hpp
+++ b/src/inc/ZipObject.hpp
@@ -124,6 +124,12 @@ namespace MSIX {
             return (Field<2>() || Field<3>() || Field<4>() || Field<5>());
         }
 
+        std::vector<std::uint8_t> GetBytes()
+        {
+            SetSize(static_cast<uint16_t>(Size() - NonOptionalSize));
+            return StructuredObject::GetBytes();
+        }
+
     protected:
         constexpr static size_t NonOptionalSize = 4;
 

--- a/src/inc/ZipObject.hpp
+++ b/src/inc/ZipObject.hpp
@@ -16,6 +16,12 @@
 
 namespace MSIX {
 
+    enum class ZipVersions : std::uint16_t
+    {
+        Zip32DefaultVersion = 20,
+        Zip64FormatExtension = 45,
+    };
+
     enum class GeneralPurposeBitFlags : std::uint16_t
     {
         UNSUPPORTED_0 = 0x0001,         // Bit 0: If set, indicates that the file is encrypted.
@@ -23,7 +29,7 @@ namespace MSIX {
         Deflate_MaxCompress = 0x0002,   // Maximum compression (-exx/-ex), otherwise, normal compression (-en)
         Deflate_FastCompress = 0x0004,  // Fast (-ef), if Max+Fast then SuperFast (-es) compression
 
-        GeneralPurposeBit = 0x0008,     // the field's crc-32 compressed and uncompressed sizes = 0 in the local header
+        DataDescriptor = 0x0008,        // the field's crc-32 compressed and uncompressed sizes = 0 in the local header
                                         // the correct values are put in the data descriptor immediately following the
                                         // compressed data.
         EnhancedDeflate = 0x0010,
@@ -52,6 +58,11 @@ namespace MSIX {
         return static_cast<GeneralPurposeBitFlags>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b));
     }
 
+    constexpr GeneralPurposeBitFlags operator ~(GeneralPurposeBitFlags a)
+    {
+        return static_cast<GeneralPurposeBitFlags>(~static_cast<uint16_t>(a));
+    }
+
     enum class CompressionType : std::uint16_t
     {
         Store = 0,
@@ -69,37 +80,55 @@ namespace MSIX {
         EndOfCentralDirectory   = 0x06054b50,
     };
 
+    constexpr uint64_t MaxSizeToNotUseDataDescriptor = static_cast<uint64_t>(std::numeric_limits<std::uint32_t>::max() - 1);
+
+    template <typename T>
+    inline bool IsValueInExtendedInfo(T value) noexcept
+    {
+        return (value == std::numeric_limits<T>::max());
+    }
+
+    template <typename T>
+    inline bool IsValueInExtendedInfo(const Meta::FieldBase<T>& field) noexcept
+    {
+        return IsValueInExtendedInfo(field.get());
+    }
 
     class Zip64ExtendedInformation final : public Meta::StructuredObject<
-        Meta::Field2Bytes,  // 0 - tag for the "extra" block type               2 bytes(0x0001)
-        Meta::Field2Bytes,  // 1 - size of this "extra" block                   2 bytes
-        Meta::Field8Bytes,  // 2 - Original uncompressed file size              8 bytes
-                            // No point in validating these as it is actually
-                            // possible to have a 0-byte file... Who knew.
-        Meta::Field8Bytes,  // 3 - Compressed file size                         8 bytes
-                            // No point in validating these as it is actually
-                            // possible to have a 0-byte file... Who knew.
-        Meta::Field8Bytes   // 4 - Offset of local header record                8 bytes
-        //Meta::Field4Bytes // 5 - number of the disk on which the file starts  4 bytes -- ITS A FAAKEE!
+        Meta::Field2Bytes,          // 0 - tag for the "extra" block type               2 bytes(0x0001)
+        Meta::Field2Bytes,          // 1 - size of this "extra" block                   2 bytes
+        Meta::OptionalField8Bytes,  // 2 - Original uncompressed file size              8 bytes
+        Meta::OptionalField8Bytes,  // 3 - Compressed file size                         8 bytes
+        Meta::OptionalField8Bytes,  // 4 - Offset of local header record                8 bytes
+        Meta::OptionalField4Bytes   // 5 - number of the disk on which the file starts  4 bytes
     >
     {
     public:
         Zip64ExtendedInformation();
 
-        void SetData(std::uint64_t uncompressedSize, std::uint64_t compressedSize, std::uint64_t relativeOffset);
+        // The incoming values are those from the central directory record. Their value there determines
+        // whether we attempt to read them here.
+        void Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start, uint32_t uncompressedSize, uint32_t compressedSize, uint32_t offset, uint16_t disk);
 
-        void Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start);
+        std::uint64_t GetUncompressedSize() const               { return Field<2>(); }
+        std::uint64_t GetCompressedSize() const                 { return Field<3>(); }
+        std::uint64_t GetRelativeOffsetOfLocalHeader() const    { return Field<4>(); }
+        std::uint32_t GetDiskStartNumber() const                { return Field<5>(); }
 
-        std::uint64_t GetUncompressedSize()            noexcept { return Field<2>().value; }
-        std::uint64_t GetCompressedSize()              noexcept { return Field<3>().value; }
-        std::uint64_t GetRelativeOffsetOfLocalHeader() noexcept { return Field<4>().value; }
+        void SetUncompressedSize(std::uint64_t value) noexcept { Field<2>() = value; }
+        void SetCompressedSize(std::uint64_t value)   noexcept { Field<3>() = value; }
+        void SetRelativeOffsetOfLocalHeader(std::uint64_t value)        noexcept { Field<4>() = value; }
+
+        bool HasAnySet() const
+        {
+            return (Field<2>() || Field<3>() || Field<4>() || Field<5>());
+        }
 
     protected:
-        void SetSignature(std::uint16_t value)        noexcept { Field<0>().value = value; }
-        void SetSize(std::uint16_t value)             noexcept { Field<1>().value = value; }
-        void SetUncompressedSize(std::uint64_t value) noexcept { Field<2>().value = value; }
-        void SetCompressedSize(std::uint64_t value)   noexcept { Field<3>().value = value; }
-        void SetRelativeOffsetOfLocalHeader(std::uint64_t value)        noexcept { Field<4>().value = value; }
+        constexpr static size_t NonOptionalSize = 4;
+
+        void SetSignature(std::uint16_t value)        noexcept { Field<0>() = value; }
+        void SetSize(std::uint16_t value)             noexcept { Field<1>() = value; }
     };
 
     class CentralDirectoryFileHeader final : public Meta::StructuredObject<
@@ -128,81 +157,125 @@ namespace MSIX {
     public:
         CentralDirectoryFileHeader();
 
-        void SetData(std::string& name, std::uint32_t crc, std::uint64_t compressedSize,
-            std::uint64_t uncompressedSize, std::uint64_t relativeOffset,  std::uint16_t compressionMethod);
+        void SetData(const std::string& name, std::uint32_t crc, std::uint64_t compressedSize,
+            std::uint64_t uncompressedSize, std::uint64_t relativeOffset,  std::uint16_t compressionMethod, bool forceDataDescriptor);
 
         void Read(const ComPtr<IStream>& stream, bool isZip64);
 
-        bool IsGeneralPurposeBitSet() noexcept
+        GeneralPurposeBitFlags GetGeneralPurposeBitFlags() const noexcept { return static_cast<GeneralPurposeBitFlags>(Field<3>().get()); }
+
+        bool IsGeneralPurposeBitSet() const noexcept
         {
-            return ((static_cast<GeneralPurposeBitFlags>(Field<3>().value) & GeneralPurposeBitFlags::GeneralPurposeBit) == GeneralPurposeBitFlags::GeneralPurposeBit);
+            return ((GetGeneralPurposeBitFlags() & GeneralPurposeBitFlags::DataDescriptor) == GeneralPurposeBitFlags::DataDescriptor);
         }
 
-        CompressionType GetCompressionMethod() noexcept { return static_cast<CompressionType>(Field<4>().value); }
+        CompressionType GetCompressionMethod() const noexcept { return static_cast<CompressionType>(Field<4>().get()); }
 
-        std::uint64_t GetCompressedSize() noexcept
+        std::uint64_t GetCompressedSize() const noexcept
         {
-            if (m_isZip64)
+            if (IsValueInExtendedInfo(Field<8>()))
             {
                 return m_extendedInfo.GetCompressedSize();
             }
-            return static_cast<std::uint64_t>(Field<8>().value);
+            return static_cast<std::uint64_t>(Field<8>().get());
         }
 
-        std::uint64_t GetUncompressedSize() noexcept
+        std::uint64_t GetUncompressedSize() const noexcept
         {
-            if (m_isZip64)
+            if (IsValueInExtendedInfo(Field<9>()))
             {
                 return m_extendedInfo.GetUncompressedSize();
             }
-            return static_cast<std::uint64_t>(Field<9>().value);
+            return static_cast<std::uint64_t>(Field<9>().get());
         }
 
-        std::uint64_t GetRelativeOffsetOfLocalHeader() noexcept
+        std::uint64_t GetRelativeOffsetOfLocalHeader() const noexcept
         {
-            if (m_isZip64)
+            if (IsValueInExtendedInfo(Field<16>()))
             {
                 return m_extendedInfo.GetRelativeOffsetOfLocalHeader();
 
             }
-            return static_cast<std::uint64_t>(Field<16>().value);
+            return static_cast<std::uint64_t>(Field<16>().get());
         }
 
-        std::string GetFileName()
+        std::string GetFileName() const
         {
-            auto data = Field<17>().value;
+            auto data = Field<17>().get();
             return std::string(data.begin(), data.end());
         }
 
     protected:
-        void SetSignature(std::uint32_t value)                   noexcept { Field<0>().value = value; }
-        void SetVersionMadeBy(std::uint16_t value)               noexcept { Field<1>().value = value; }
-        void SetVersionNeededToExtract(std::uint16_t value)      noexcept { Field<2>().value = value; }
-        void SetGeneralPurposeBitFlags(std::uint16_t value)      noexcept { Field<3>().value = value; }
-        void SetCompressionMethod(std::uint16_t value)           noexcept { Field<4>().value = value; }
-        void SetLastModFileTime(std::uint16_t value)             noexcept { Field<5>().value = value; }
-        void SetLastModFileDate(std::uint16_t value)             noexcept { Field<6>().value = value; }
-        void SetCrc(std::uint32_t value)                         noexcept { Field<7>().value = value; }
-        void SetCompressedSize(std::uint32_t value)              noexcept { Field<8>().value = value; }
-        void SetUncompressedSize(std::uint32_t value)            noexcept { Field<9>().value = value; }
-        void SetFileNameLength(std::uint16_t value)              noexcept { Field<10>().value = value; }
-        void SetExtraFieldLength(std::uint16_t value)            noexcept { Field<11>().value = value; }
-        void SetFileCommentLength(std::uint16_t value)           noexcept { Field<12>().value = value; }
-        void SetDiskNumberStart(std::uint16_t value)             noexcept { Field<13>().value = value; }
-        void SetInternalFileAttributes(std::uint16_t value)      noexcept { Field<14>().value = value; }
-        void SetExternalFileAttributes(std::uint16_t value)      noexcept { Field<15>().value = value; }
-        void SetRelativeOffsetOfLocalHeader(std::uint32_t value) noexcept { Field<16>().value = value; }
-        void SetFileName(std::string& name)
+        void SetSignature(std::uint32_t value)                   noexcept { Field<0>() = value; }
+        void SetVersionMadeBy(std::uint16_t value)               noexcept { Field<1>() = value; }
+        void SetVersionNeededToExtract(std::uint16_t value)      noexcept { Field<2>() = value; }
+        void SetGeneralPurposeBitFlags(std::uint16_t value)      noexcept { Field<3>() = value; }
+        void SetCompressionMethod(std::uint16_t value)           noexcept { Field<4>() = value; }
+        void SetLastModFileTime(std::uint16_t value)             noexcept { Field<5>() = value; }
+        void SetLastModFileDate(std::uint16_t value)             noexcept { Field<6>() = value; }
+        void SetCrc(std::uint32_t value)                         noexcept { Field<7>() = value; }
+        void SetFileNameLength(std::uint16_t value)              noexcept { Field<10>() = value; }
+        void SetExtraFieldLength(std::uint16_t value)            noexcept { Field<11>() = value; }
+        void SetFileCommentLength(std::uint16_t value)           noexcept { Field<12>() = value; }
+        void SetDiskNumberStart(std::uint16_t value)             noexcept { Field<13>() = value; }
+        void SetInternalFileAttributes(std::uint16_t value)      noexcept { Field<14>() = value; }
+        void SetExternalFileAttributes(std::uint16_t value)      noexcept { Field<15>() = value; }
+
+        // Values that might appear in the extended info (minus disk, which we will never set there)
+        void SetCompressedSize(std::uint64_t value) noexcept
+        {
+            if (value > MaxSizeToNotUseDataDescriptor)
+            {
+                m_extendedInfo.SetCompressedSize(value);
+                Field<8>() = std::numeric_limits<uint32_t>::max();
+            }
+            else
+            {
+                Field<8>() = static_cast<uint32_t>(value);
+            }
+        }
+
+        void SetUncompressedSize(std::uint64_t value)noexcept
+        {
+            if (value > MaxSizeToNotUseDataDescriptor)
+            {
+                m_extendedInfo.SetUncompressedSize(value);
+                Field<9>() = std::numeric_limits<uint32_t>::max();
+            }
+            else
+            {
+                Field<9>() = static_cast<uint32_t>(value);
+            }
+        }
+
+        void SetRelativeOffsetOfLocalHeader(std::uint64_t value) noexcept
+        {
+            if (value > MaxSizeToNotUseDataDescriptor)
+            {
+                m_extendedInfo.SetRelativeOffsetOfLocalHeader(value);
+                Field<16>() = std::numeric_limits<uint32_t>::max();
+            }
+            else
+            {
+                Field<16>() = static_cast<uint32_t>(value);
+            }
+        }
+
+        void SetFileName(const std::string& name)
         {
             SetFileNameLength(static_cast<std::uint16_t>(name.size()));
-            Field<17>().value.resize(name.size(), 0);
-            std::copy(name.begin(), name.end(), Field<17>().value.begin());
+            Field<17>().get().resize(name.size(), 0);
+            std::copy(name.begin(), name.end(), Field<17>().get().begin());
         }
-        void SetExtraField(std::uint64_t compressedSize, std::uint64_t uncompressedSize, std::uint64_t relativeOffset)
+
+        void UpdateExtraField()
         {
-            m_extendedInfo.SetData(compressedSize, uncompressedSize, relativeOffset);
-            SetExtraFieldLength(static_cast<std::uint16_t>(m_extendedInfo.Size()));
-            Field<18>().value = m_extendedInfo.GetBytes();
+            if (m_extendedInfo.HasAnySet())
+            {
+                SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
+                SetExtraFieldLength(static_cast<std::uint16_t>(m_extendedInfo.Size()));
+                Field<18>().get() = m_extendedInfo.GetBytes();
+            }
         }
 
         Zip64ExtendedInformation m_extendedInfo;
@@ -228,40 +301,42 @@ namespace MSIX {
     public:
         LocalFileHeader();
 
-        void SetData(std::string& name, bool isCompressed);
+        void SetData(const std::string& name, bool isCompressed);
+        void SetData(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize);
 
         void Read(const ComPtr<IStream>& stream, CentralDirectoryFileHeader& directoryEntry);
 
-        std::uint16_t GetCompressionMethod() noexcept { return Field<3>().value; }
-        std::uint16_t GetFileNameLength()    noexcept { return Field<9>().value;  }
-        std::string GetFileName()
+        GeneralPurposeBitFlags GetGeneralPurposeBitFlags() const noexcept { return static_cast<GeneralPurposeBitFlags>(Field<2>().get()); }
+        std::uint16_t GetCompressionMethod() const noexcept { return Field<3>(); }
+        std::uint16_t GetFileNameLength() const noexcept    { return Field<9>();  }
+        std::string GetFileName() const
         {
-            auto data = Field<11>().value;
+            auto data = Field<11>().get();
             return std::string(data.begin(), data.end());
         }
 
     protected:
-        bool IsGeneralPurposeBitSet() noexcept
+        bool IsGeneralPurposeBitSet() const noexcept
         {
-            return ((static_cast<GeneralPurposeBitFlags>(Field<2>().value) & GeneralPurposeBitFlags::GeneralPurposeBit) == GeneralPurposeBitFlags::GeneralPurposeBit);
+            return ((GetGeneralPurposeBitFlags() & GeneralPurposeBitFlags::DataDescriptor) == GeneralPurposeBitFlags::DataDescriptor);
         }
 
-        void SetSignature(std::uint32_t value)              noexcept { Field<0>().value = value; }
-        void SetVersionNeededToExtract(std::uint16_t value) noexcept { Field<1>().value = value; }
-        void SetGeneralPurposeBitFlags(std::uint16_t value) noexcept { Field<2>().value = value; }
-        void SetCompressionMethod(std::uint16_t value)      noexcept { Field<3>().value = value; }
-        void SetLastModFileTime(std::uint16_t value)        noexcept { Field<4>().value = value; }
-        void SetLastModFileDate(std::uint16_t value)        noexcept { Field<5>().value = value; }
-        void SetCrc(std::uint32_t value)                    noexcept { Field<6>().value = value; }
-        void SetCompressedSize(std::uint32_t value)         noexcept { Field<7>().value = value; }
-        void SetUncompressedSize(std::uint32_t value)       noexcept { Field<8>().value = value; }
-        void SetFileNameLength(std::uint16_t value)         noexcept { Field<9>().value = value; }
-        void SetExtraFieldLength(std::uint16_t value)       noexcept { Field<10>().value = value; }
-        void SetFileName(std::string& name)
+        void SetSignature(std::uint32_t value)              noexcept { Field<0>() = value; }
+        void SetVersionNeededToExtract(std::uint16_t value) noexcept { Field<1>() = value; }
+        void SetGeneralPurposeBitFlags(std::uint16_t value) noexcept { Field<2>() = value; }
+        void SetCompressionMethod(std::uint16_t value)      noexcept { Field<3>() = value; }
+        void SetLastModFileTime(std::uint16_t value)        noexcept { Field<4>() = value; }
+        void SetLastModFileDate(std::uint16_t value)        noexcept { Field<5>() = value; }
+        void SetCrc(std::uint32_t value)                    noexcept { Field<6>() = value; }
+        void SetCompressedSize(std::uint32_t value)         noexcept { Field<7>() = value; }
+        void SetUncompressedSize(std::uint32_t value)       noexcept { Field<8>() = value; }
+        void SetFileNameLength(std::uint16_t value)         noexcept { Field<9>() = value; }
+        void SetExtraFieldLength(std::uint16_t value)       noexcept { Field<10>() = value; }
+        void SetFileName(const std::string& name)
         {
             SetFileNameLength(static_cast<std::uint16_t>(name.size()));
-            Field<11>().value.resize(name.size(), 0);
-            std::copy(name.begin(), name.end(), Field<11>().value.begin());
+            Field<11>().get().resize(name.size(), 0);
+            std::copy(name.begin(), name.end(), Field<11>().get().begin());
         }
     };
 
@@ -287,23 +362,23 @@ namespace MSIX {
 
         void Read(const ComPtr<IStream>& stream);
 
-        std::uint64_t GetTotalNumberOfEntries() noexcept { return Field<6>().value; }
-        std::uint64_t GetOffsetStartOfCD()      noexcept { return Field<9>().value; }
+        std::uint64_t GetTotalNumberOfEntries() const noexcept  { return Field<6>(); }
+        std::uint64_t GetOffsetStartOfCD() const noexcept       { return Field<9>(); }
 
     protected:
-        void SetSignature(std::uint32_t value)                    noexcept { Field<0>().value = value; }
-        void SetSizeOfZip64CDRecord(std::uint64_t value)          noexcept { Field<1>().value = value; }
-        void SetVersionMadeBy(std::uint16_t value)                noexcept { Field<2>().value = value; }
-        void SetVersionNeededToExtract(std::uint16_t value)       noexcept { Field<3>().value = value; }
-        void SetNumberOfThisDisk(std::uint32_t value)             noexcept { Field<4>().value = value; }
-        void SetNumberOfTheDiskWithStartOfCD(std::uint32_t value) noexcept { Field<5>().value = value; }
+        void SetSignature(std::uint32_t value)                    noexcept { Field<0>() = value; }
+        void SetSizeOfZip64CDRecord(std::uint64_t value)          noexcept { Field<1>() = value; }
+        void SetVersionMadeBy(std::uint16_t value)                noexcept { Field<2>() = value; }
+        void SetVersionNeededToExtract(std::uint16_t value)       noexcept { Field<3>() = value; }
+        void SetNumberOfThisDisk(std::uint32_t value)             noexcept { Field<4>() = value; }
+        void SetNumberOfTheDiskWithStartOfCD(std::uint32_t value) noexcept { Field<5>() = value; }
         void SetTotalNumberOfEntriesDisk(std::uint64_t value) noexcept
         {
-            Field<6>().value = value;
-            Field<7>().value = value;
+            Field<6>() = value;
+            Field<7>() = value;
         }
-        void SetSizeOfCD(std::uint64_t value)         noexcept { Field<8>().value = value; }
-        void SetOffsetfStartOfCD(std::uint64_t value) noexcept { Field<9>().value = value; }
+        void SetSizeOfCD(std::uint64_t value)         noexcept { Field<8>() = value; }
+        void SetOffsetfStartOfCD(std::uint64_t value) noexcept { Field<9>() = value; }
     };
 
     class Zip64EndOfCentralDirectoryLocator final : public Meta::StructuredObject<
@@ -322,13 +397,13 @@ namespace MSIX {
 
         void Read(const ComPtr<IStream>& stream);
 
-        std::uint64_t GetRelativeOffset()           noexcept { return Field<2>().value; }
+        std::uint64_t GetRelativeOffset() const noexcept { return Field<2>(); }
 
     protected:
-        void SetSignature(std::uint32_t value)          noexcept { Field<0>().value = value; }
-        void SetNumberOfDisk(std::uint32_t value)       noexcept { Field<1>().value = value; }
-        void SetRelativeOffset(std::uint64_t value)     noexcept { Field<2>().value = value; }
-        void SetTotalNumberOfDisks(std::uint32_t value) noexcept { Field<3>().value = value; }
+        void SetSignature(std::uint32_t value)          noexcept { Field<0>() = value; }
+        void SetNumberOfDisk(std::uint32_t value)       noexcept { Field<1>() = value; }
+        void SetRelativeOffset(std::uint64_t value)     noexcept { Field<2>() = value; }
+        void SetTotalNumberOfDisks(std::uint32_t value) noexcept { Field<3>() = value; }
     };
 
     class EndCentralDirectoryRecord final : public Meta::StructuredObject<
@@ -352,24 +427,22 @@ namespace MSIX {
 
         void Read(const ComPtr<IStream>& stream);
 
-        bool GetArchiveHasZip64Locator() noexcept { return m_archiveHasZip64Locator; }
-        bool GetIsZip64()                noexcept { return m_isZip64; }
+        bool GetIsZip64() const noexcept { return m_isZip64; }
 
-        std::uint64_t GetNumberOfCentralDirectoryEntries() noexcept { return static_cast<std::uint64_t>(Field<3>().value); }
-        std::uint64_t GetStartOfCentralDirectory()         noexcept { return static_cast<std::uint64_t>(Field<6>().value); }
+        std::uint64_t GetNumberOfCentralDirectoryEntries() noexcept { return static_cast<std::uint64_t>(Field<3>().get()); }
+        std::uint64_t GetStartOfCentralDirectory()         noexcept { return static_cast<std::uint64_t>(Field<6>().get()); }
 
     protected:
-        void SetSignature(std::uint32_t value)                      noexcept { Field<0>().value = value; }
-        void SetNumberOfDisk(std::uint16_t value)                   noexcept { Field<1>().value = value; }
-        void SetDiskStart(std::uint16_t value)                      noexcept { Field<2>().value = value; }
-        void SetTotalNumberOfEntries(std::uint16_t value)           noexcept { Field<3>().value = value; }
-        void SetTotalEntriesInCentralDirectory(std::uint16_t value) noexcept { Field<4>().value = value; }
-        void SetSizeOfCentralDirectory(std::uint32_t value)         noexcept { Field<5>().value = value; }
-        void SetOffsetOfCentralDirectory(std::uint32_t value)       noexcept { Field<6>().value = value; }
-        void SetCommentLength(std::uint16_t value)                  noexcept { Field<7>().value = value; }
+        void SetSignature(std::uint32_t value)                      noexcept { Field<0>() = value; }
+        void SetNumberOfDisk(std::uint16_t value)                   noexcept { Field<1>() = value; }
+        void SetDiskStart(std::uint16_t value)                      noexcept { Field<2>() = value; }
+        void SetTotalNumberOfEntries(std::uint16_t value)           noexcept { Field<3>() = value; }
+        void SetTotalEntriesInCentralDirectory(std::uint16_t value) noexcept { Field<4>() = value; }
+        void SetSizeOfCentralDirectory(std::uint32_t value)         noexcept { Field<5>() = value; }
+        void SetOffsetOfCentralDirectory(std::uint32_t value)       noexcept { Field<6>() = value; }
+        void SetCommentLength(std::uint16_t value)                  noexcept { Field<7>() = value; }
 
         bool m_isZip64 = true;
-        bool m_archiveHasZip64Locator = true;
     };
 
     class ZipObject

--- a/src/inc/ZipObjectWriter.hpp
+++ b/src/inc/ZipObjectWriter.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <utility>
 
 // {350dd671-0c40-4cd7-9a5b-27456d604bd0}
 #ifndef WIN32
@@ -24,12 +25,11 @@ class IZipWriter : public IUnknown
 {
 public:
     // Writes the lfh header to the stream and return the size of the header
-    virtual std::uint32_t PrepareToAddFile(std::string& name, bool isCompressed) = 0;
+    virtual std::pair<std::uint32_t, MSIX::ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) = 0;
 
-    // Writes the stream provided to the zip file, writes data descriptor and adds an entry
+    // Ends the file, rewrites the LFH or writes data descriptor and adds an entry
     // to the central directories map
-    virtual void AddFile(MSIX::ComPtr<IStream>& fileStream, std::uint32_t crc,
-            std::uint64_t compressedSize, std::uint64_t uncompressedSize) = 0;
+    virtual void EndFile(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize, bool forceDataDescriptor) = 0;
 
     // Ends zip file by writing the central directory records, zip64 locator,
     // zip64 end of central directory and the end of central directories.
@@ -52,9 +52,8 @@ namespace MSIX {
         std::string GetFileName() override { NOTIMPLEMENTED };
 
         // IZipWriter
-        std::uint32_t PrepareToAddFile(std::string& name, bool isCompressed) override;
-        void AddFile(MSIX::ComPtr<IStream>& fileStream, std::uint32_t crc,
-            std::uint64_t compressedSize, std::uint64_t uncompressedSize) override;
+        std::pair<std::uint32_t, ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) override;
+        void EndFile(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize, bool forceDataDescriptor) override;
         void Close() override;
 
     protected:

--- a/src/msix/common/ZipObject.cpp
+++ b/src/msix/common/ZipObject.cpp
@@ -93,8 +93,7 @@ constexpr static const GeneralPurposeBitFlags UnsupportedFlagsMask =
 Zip64ExtendedInformation::Zip64ExtendedInformation()
 {
     SetSignature(static_cast<std::uint16_t>(HeaderIDs::Zip64ExtendedInfo));
-    // Should be 0x18, but do it this way if we end up field 5
-    SetSize(static_cast<std::uint16_t>(Size() - Field<0>().Size() - Field<1>().Size()));
+    SetSize(NonOptionalSize);
 }
 
 void Zip64ExtendedInformation::Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start, uint32_t uncompressedSize, uint32_t compressedSize, uint32_t offset, uint16_t disk)

--- a/src/msix/common/ZipObject.cpp
+++ b/src/msix/common/ZipObject.cpp
@@ -37,11 +37,6 @@ namespace MSIX {
 [Zip64EndOfCentralDirectoryLocator]
 [EndCentralDirectoryRecord]
 */
-enum class ZipVersions : std::uint16_t
-{
-    Zip32DefaultVersion = 20,
-    Zip64FormatExtension = 45,
-};
 
 // from AppNote.txt, section 4.5.2:
 enum class HeaderIDs : std::uint16_t
@@ -102,27 +97,35 @@ Zip64ExtendedInformation::Zip64ExtendedInformation()
     SetSize(static_cast<std::uint16_t>(Size() - Field<0>().Size() - Field<1>().Size()));
 }
 
-void Zip64ExtendedInformation::SetData(std::uint64_t uncompressedSize, std::uint64_t compressedSize, std::uint64_t relativeOffset)
+void Zip64ExtendedInformation::Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start, uint32_t uncompressedSize, uint32_t compressedSize, uint32_t offset, uint16_t disk)
 {
-    THROW_IF_PACK_NOT_ENABLED
-    SetUncompressedSize(uncompressedSize);
-    SetCompressedSize(compressedSize);
-    SetRelativeOffsetOfLocalHeader(relativeOffset);
-}
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(HeaderIDs::Zip64ExtendedInfo));
 
-void Zip64ExtendedInformation::Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start)
-{
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<0>().value, static_cast<std::uint32_t>(HeaderIDs::Zip64ExtendedInfo));
+    StreamBase::Read(stream, &Field<1>());
+    // The incoming stream will be just the extended info, and our size should match it minus the fixed bytes
+    Meta::ExactValueValidation<std::uint32_t>(Field<1>(), static_cast<uint32_t>(stream.As<IStreamInternal>()->GetSize() - NonOptionalSize));
 
-    StreamBase::Read(stream, &Field<1>().value);
-    Meta::OnlyEitherValueValidation<std::uint32_t>(Field<1>().value, 24, 28);
-        
-    StreamBase::Read(stream, &Field<2>().value);
-    StreamBase::Read(stream, &Field<3>().value);
+    if (IsValueInExtendedInfo(uncompressedSize))
+    {
+        StreamBase::Read(stream, &Field<2>());
+    }
 
-    StreamBase::Read(stream, &Field<4>().value);
-    ThrowErrorIfNot(Error::ZipBadExtendedData, Field<4>().value < start.QuadPart, "invalid relative header offset");
+    if (IsValueInExtendedInfo(compressedSize))
+    {
+        StreamBase::Read(stream, &Field<3>());
+    }
+
+    if (IsValueInExtendedInfo(offset))
+    {
+        StreamBase::Read(stream, &Field<4>());
+        ThrowErrorIfNot(Error::ZipBadExtendedData, Field<4>().get() < start.QuadPart, "invalid relative header offset");
+    }
+
+    if (IsValueInExtendedInfo(disk))
+    {
+        StreamBase::Read(stream, &Field<5>());
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -132,104 +135,112 @@ CentralDirectoryFileHeader::CentralDirectoryFileHeader()
 {
     SetSignature(static_cast<std::uint32_t>(Signatures::CentralFileHeader));
     SetVersionMadeBy(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
-    SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension)); // we always do zip64
-    SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GeneralPurposeBitFlags::GeneralPurposeBit));
+    SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip32DefaultVersion));
+    SetGeneralPurposeBitFlags(0);
     SetLastModFileDate(static_cast<std::uint16_t>(MagicNumbers::FileDate)); // TODO: figure out how to convert to msdos time
     SetLastModFileTime(static_cast<std::uint16_t>(MagicNumbers::FileTime));
-    SetCompressedSize(std::numeric_limits<std::uint32_t>::max()); // always use zip64
-    SetUncompressedSize(std::numeric_limits<std::uint32_t>::max()); // always use zip64
+    SetCompressedSize(0);
+    SetUncompressedSize(0);
     SetExtraFieldLength(0);
     SetFileCommentLength(0);
     SetDiskNumberStart(0);
     SetInternalFileAttributes(0);
     SetExternalFileAttributes(0);
-    SetRelativeOffsetOfLocalHeader(std::numeric_limits<std::uint32_t>::max()); // always use zip64
+    SetRelativeOffsetOfLocalHeader(0);
 }
 
-void CentralDirectoryFileHeader::SetData(std::string& name, std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize,
-    std::uint64_t relativeOffset,  std::uint16_t compressionMethod)
+void CentralDirectoryFileHeader::SetData(const std::string& name, std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize,
+    std::uint64_t relativeOffset,  std::uint16_t compressionMethod, bool forceDataDescriptor)
 {
     THROW_IF_PACK_NOT_ENABLED
     SetCompressionMethod(compressionMethod);
     SetCrc(crc);
     SetFileName(name);
-    SetExtraField(uncompressedSize, compressedSize, relativeOffset);
+
+    // Set these values that may end up in the extra field info; then make sure to update it
+    SetCompressedSize(compressedSize);
+    SetUncompressedSize(uncompressedSize);
+    SetRelativeOffsetOfLocalHeader(relativeOffset);
+    UpdateExtraField();
+
+    if (forceDataDescriptor ||
+        compressedSize > MaxSizeToNotUseDataDescriptor ||
+        uncompressedSize > MaxSizeToNotUseDataDescriptor)
+    {
+        SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GeneralPurposeBitFlags::DataDescriptor));
+        SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
+    }
 }
 
 void CentralDirectoryFileHeader::Read(const ComPtr<IStream>& stream, bool isZip64)
 {
     m_isZip64 = isZip64;
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<0>().value, static_cast<std::uint32_t>(Signatures::CentralFileHeader));
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(Signatures::CentralFileHeader));
 
-    StreamBase::Read(stream, &Field<1>().value);
-    StreamBase::Read(stream, &Field<2>().value);
+    StreamBase::Read(stream, &Field<1>());
+    StreamBase::Read(stream, &Field<2>());
 
-    StreamBase::Read(stream, &Field<3>().value);
+    StreamBase::Read(stream, &Field<3>());
     ThrowErrorIfNot(Error::ZipCentralDirectoryHeader,
-        0 == (Field<3>().value & static_cast<std::uint16_t>(UnsupportedFlagsMask)),
+        0 == (Field<3>().get() & static_cast<std::uint16_t>(UnsupportedFlagsMask)),
         "unsupported flag(s) specified");
 
-    StreamBase::Read(stream, &Field<4>().value);
-    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<4>().value,  static_cast<std::uint16_t>(CompressionType::Deflate),
+    StreamBase::Read(stream, &Field<4>());
+    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<4>(),  static_cast<std::uint16_t>(CompressionType::Deflate),
         static_cast<std::uint16_t>(CompressionType::Store));
 
-    StreamBase::Read(stream, &Field<5>().value);
-    StreamBase::Read(stream, &Field<6>().value);
-    StreamBase::Read(stream, &Field<7>().value);
-    StreamBase::Read(stream, &Field<8>().value);
-    StreamBase::Read(stream, &Field<9>().value);
+    StreamBase::Read(stream, &Field<5>());
+    StreamBase::Read(stream, &Field<6>());
+    StreamBase::Read(stream, &Field<7>());
+    StreamBase::Read(stream, &Field<8>());
+    StreamBase::Read(stream, &Field<9>());
 
-    StreamBase::Read(stream, &Field<10>().value);
-    ThrowErrorIfNot(Error::ZipCentralDirectoryHeader, (Field<10>().value != 0), "unsupported file name size");
-    if (Field<10>().value !=0) {Field<17>().value.resize(Field<10>().value, 0); }
+    StreamBase::Read(stream, &Field<10>());
+    ThrowErrorIfNot(Error::ZipCentralDirectoryHeader, (Field<10>().get() != 0), "unsupported file name size");
+    if (Field<10>().get() != 0) {Field<17>().get().resize(Field<10>().get(), 0); }
 
-    StreamBase::Read(stream, &Field<11>().value);
-    if (Field<11>().value != 0) { Field<18>().value.resize(Field<11>().value, 0); }
+    StreamBase::Read(stream, &Field<11>());
+    if (Field<11>().get() != 0) { Field<18>().get().resize(Field<11>().get(), 0); }
 
-    StreamBase::Read(stream, &Field<12>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<12>().value, 0);
+    StreamBase::Read(stream, &Field<12>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<12>(), 0);
 
-    StreamBase::Read(stream, &Field<13>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<13>().value, 0);
+    StreamBase::Read(stream, &Field<13>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<13>(), 0);
 
-    StreamBase::Read(stream, &Field<14>().value);
+    StreamBase::Read(stream, &Field<14>());
 
-    StreamBase::Read(stream, &Field<15>().value);
-    StreamBase::Read(stream, &Field<16>().value);
+    StreamBase::Read(stream, &Field<15>());
+    StreamBase::Read(stream, &Field<16>());
     ULARGE_INTEGER pos = {0};
     ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::CURRENT, &pos));
-    if (m_isZip64)
+    if (!m_isZip64 || !IsValueInExtendedInfo(Field<16>()))
     {
-        ThrowErrorIf(Error::ZipCentralDirectoryHeader, (Field<16>().value != 0xFFFFFFFF), "invalid zip64 local header offset");
-    }
-    else
-    {
-        ThrowErrorIf(Error::ZipCentralDirectoryHeader, (Field<16>().value >= pos.QuadPart), "invalid relative header offset");
+        ThrowErrorIf(Error::ZipCentralDirectoryHeader, (Field<16>().get() >= pos.QuadPart), "invalid relative header offset");
     }
 
     if (Field<17>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<17>().value.data()), static_cast<ULONG>(Field<17>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<17>().get().data()), static_cast<ULONG>(Field<17>().Size()), nullptr));
     }
 
     if (Field<18>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<18>().value.data()), static_cast<ULONG>(Field<18>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<18>().get().data()), static_cast<ULONG>(Field<18>().Size()), nullptr));
     }
     // Only process for Zip64ExtendedInformation
-    if (Field<18>().Size() > 2 && Field<18>().value[0] == 0x01 && Field<18>().value[1] == 0x00)
+    if (Field<18>().Size() > 2 && Field<18>().get()[0] == 0x01 && Field<18>().get()[1] == 0x00)
     {
         LARGE_INTEGER zero = {0};
         ThrowHrIfFailed(stream->Seek(zero, StreamBase::Reference::CURRENT, &pos));
-        auto vectorStream = ComPtr<IStream>::Make<VectorStream>(&Field<18>().value);
-        ThrowErrorIfNot(Error::ZipCentralDirectoryHeader, (Field<18>().Size() >= m_extendedInfo.Size()), "Unexpected extended info size");
-        m_extendedInfo.Read(vectorStream.Get(), pos);
+        auto vectorStream = ComPtr<IStream>::Make<VectorStream>(&Field<18>());
+        m_extendedInfo.Read(vectorStream.Get(), pos, Field<9>(), Field<8>(), Field<16>(), Field<13>());
     }
 
     if (Field<19>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<19>().value.data()), static_cast<ULONG>(Field<19>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<19>().get().data()), static_cast<ULONG>(Field<19>().Size()), nullptr));
     }
 }
 
@@ -239,8 +250,8 @@ void CentralDirectoryFileHeader::Read(const ComPtr<IStream>& stream, bool isZip6
 LocalFileHeader::LocalFileHeader()
 {
     SetSignature(static_cast<std::uint32_t>(Signatures::LocalFileHeader));
-    SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension)); // always zip64
-    SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GeneralPurposeBitFlags::GeneralPurposeBit));
+    SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension)); // deafult to zip64
+    SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GeneralPurposeBitFlags::DataDescriptor));
     SetLastModFileTime(static_cast<std::uint16_t>(MagicNumbers::FileTime)); // TODO: figure out how to convert to msdos time
     SetLastModFileDate(static_cast<std::uint16_t>(MagicNumbers::FileDate));
     SetCrc(0);
@@ -249,7 +260,7 @@ LocalFileHeader::LocalFileHeader()
     SetExtraFieldLength(0);
 }
 
-void LocalFileHeader::SetData(std::string& name, bool isCompressed)
+void LocalFileHeader::SetData(const std::string& name, bool isCompressed)
 {
     THROW_IF_PACK_NOT_ENABLED
     auto compressMethod = (isCompressed) ? CompressionType::Deflate : CompressionType::Store; 
@@ -257,49 +268,59 @@ void LocalFileHeader::SetData(std::string& name, bool isCompressed)
     SetFileName(name);
 }
 
+void LocalFileHeader::SetData(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize)
+{
+    THROW_IF_PACK_NOT_ENABLED
+    SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip32DefaultVersion));
+    SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GetGeneralPurposeBitFlags() & ~GeneralPurposeBitFlags::DataDescriptor));
+    SetCrc(crc);
+    SetCompressedSize(static_cast<uint32_t>(compressedSize));
+    SetUncompressedSize(static_cast<uint32_t>(uncompressedSize));
+}
+
 void LocalFileHeader::Read(const ComPtr<IStream> &stream, CentralDirectoryFileHeader& directoryEntry)
 {
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>( Field<0>().value, static_cast<std::uint32_t>(Signatures::LocalFileHeader));
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(Signatures::LocalFileHeader));
 
-    StreamBase::Read(stream, &Field<1>().value);
-    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<1>().value, static_cast<std::uint16_t>(ZipVersions::Zip32DefaultVersion),
+    StreamBase::Read(stream, &Field<1>());
+    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<1>(), static_cast<std::uint16_t>(ZipVersions::Zip32DefaultVersion),
                                               static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
 
-    StreamBase::Read(stream, &Field<2>().value);
-    ThrowErrorIfNot(Error::ZipLocalFileHeader, ((Field<2>().value & static_cast<std::uint16_t>(UnsupportedFlagsMask)) == 0), "unsupported flag(s) specified");
+    StreamBase::Read(stream, &Field<2>());
+    ThrowErrorIfNot(Error::ZipLocalFileHeader, ((Field<2>().get() & static_cast<std::uint16_t>(UnsupportedFlagsMask)) == 0), "unsupported flag(s) specified");
     ThrowErrorIfNot(Error::ZipLocalFileHeader, (IsGeneralPurposeBitSet() == directoryEntry.IsGeneralPurposeBitSet()), "inconsistent general purpose bits specified");
 
-    StreamBase::Read(stream, &Field<3>().value);
-    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<3>().value, static_cast<std::uint16_t>(CompressionType::Deflate),
+    StreamBase::Read(stream, &Field<3>());
+    Meta::OnlyEitherValueValidation<std::uint16_t>(Field<3>(), static_cast<std::uint16_t>(CompressionType::Deflate),
                                               static_cast<std::uint16_t>(CompressionType::Store));
 
-    StreamBase::Read(stream, &Field<4>().value);
-    StreamBase::Read(stream, &Field<5>().value);
-    StreamBase::Read(stream, &Field<6>().value);
-    ThrowErrorIfNot(Error::ZipLocalFileHeader, (!IsGeneralPurposeBitSet() || (Field<6>().value == 0)), "Invalid Zip CRC");
+    StreamBase::Read(stream, &Field<4>());
+    StreamBase::Read(stream, &Field<5>());
+    StreamBase::Read(stream, &Field<6>());
+    ThrowErrorIfNot(Error::ZipLocalFileHeader, (!IsGeneralPurposeBitSet() || (Field<6>().get() == 0)), "Invalid Zip CRC");
 
-    StreamBase::Read(stream, &Field<7>().value);
-    ThrowErrorIfNot(Error::ZipLocalFileHeader, (!IsGeneralPurposeBitSet() || (Field<7>().value == 0)), "Invalid Zip compressed size");
+    StreamBase::Read(stream, &Field<7>());
+    ThrowErrorIfNot(Error::ZipLocalFileHeader, (!IsGeneralPurposeBitSet() || (Field<7>().get() == 0)), "Invalid Zip compressed size");
 
-    StreamBase::Read(stream, &Field<8>().value);
+    StreamBase::Read(stream, &Field<8>());
 
-    StreamBase::Read(stream, &Field<9>().value);
-    ThrowErrorIfNot(Error::ZipLocalFileHeader, (Field<9>().value != 0), "unsupported file name size");
-    Field<11>().value.resize(GetFileNameLength(), 0);
+    StreamBase::Read(stream, &Field<9>());
+    ThrowErrorIfNot(Error::ZipLocalFileHeader, (Field<9>().get() != 0), "unsupported file name size");
+    Field<11>().get().resize(GetFileNameLength(), 0);
 
-    StreamBase::Read(stream, &Field<10>().value);
+    StreamBase::Read(stream, &Field<10>());
     // Even if we don't validate them, we need to read the extra field
-    if (Field<10>().value != 0) {Field<12>().value.resize(Field<10>().value, 0); }
+    if (Field<10>().get() != 0) {Field<12>().get().resize(Field<10>().get(), 0); }
 
     if (Field<11>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<11>().value.data()), static_cast<ULONG>(Field<11>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<11>().get().data()), static_cast<ULONG>(Field<11>().Size()), nullptr));
     }
 
     if (Field<12>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<12>().value.data()), static_cast<ULONG>(Field<12>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<12>().get().data()), static_cast<ULONG>(Field<12>().Size()), nullptr));
     }
 }
 
@@ -326,46 +347,46 @@ void Zip64EndOfCentralDirectoryRecord::SetData(std::uint64_t numCentralDirs, std
 
 void Zip64EndOfCentralDirectoryRecord::Read(const ComPtr<IStream>& stream)
 {
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<0>().value, static_cast<std::uint32_t>(Signatures::Zip64EndOfCD));
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(Signatures::Zip64EndOfCD));
 
-    StreamBase::Read(stream, &Field<1>().value);
+    StreamBase::Read(stream, &Field<1>());
     //4.3.14.1 The value stored into the "size of zip64 end of central
     //    directory record" should be the size of the remaining
     //    record and should not include the leading 12 bytes.
-    ThrowErrorIfNot(Error::Zip64EOCDRecord, (Field<1>().value == (this->Size() - 12)), "invalid size of zip64 EOCD");
+    ThrowErrorIfNot(Error::Zip64EOCDRecord, (Field<1>().get() == (this->Size() - 12)), "invalid size of zip64 EOCD");
 
-    StreamBase::Read(stream, &Field<2>().value);
-    Meta::ExactValueValidation<std::uint16_t>(Field<2>().value, static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
+    StreamBase::Read(stream, &Field<2>());
+    Meta::ExactValueValidation<std::uint16_t>(Field<2>(), static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
 
-    StreamBase::Read(stream, &Field<3>().value);
-    Meta::ExactValueValidation<std::uint16_t>(Field<3>().value, static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
+    StreamBase::Read(stream, &Field<3>());
+    Meta::ExactValueValidation<std::uint16_t>(Field<3>(), static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
 
-    StreamBase::Read(stream, &Field<4>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<4>().value, 0);
+    StreamBase::Read(stream, &Field<4>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<4>(), 0);
 
-    StreamBase::Read(stream, &Field<5>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<5>().value, 0);
+    StreamBase::Read(stream, &Field<5>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<5>(), 0);
 
-    StreamBase::Read(stream, &Field<6>().value);
-    Meta::NotValueValidation<std::uint64_t>(Field<6>().value, 0);
+    StreamBase::Read(stream, &Field<6>());
+    Meta::NotValueValidation<std::uint64_t>(Field<6>(), 0);
 
-    StreamBase::Read(stream, &Field<7>().value);
-    Meta::NotValueValidation<std::uint64_t>(Field<7>().value, 0);
-    ThrowErrorIfNot(Error::Zip64EOCDRecord, (Field<7>().value == GetTotalNumberOfEntries()), "invalid total number of entries");
+    StreamBase::Read(stream, &Field<7>());
+    Meta::NotValueValidation<std::uint64_t>(Field<7>(), 0);
+    ThrowErrorIfNot(Error::Zip64EOCDRecord, (Field<7>().get() == GetTotalNumberOfEntries()), "invalid total number of entries");
 
     ULARGE_INTEGER pos = {0};
     ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::CURRENT, &pos));
-    StreamBase::Read(stream, &Field<8>().value);
-    ThrowErrorIfNot(Error::Zip64EOCDRecord, ((Field<8>().value != 0) && (Field<8>().value < pos.QuadPart)), "invalid size of central directory");
+    StreamBase::Read(stream, &Field<8>());
+    ThrowErrorIfNot(Error::Zip64EOCDRecord, ((Field<8>().get() != 0) && (Field<8>().get() < pos.QuadPart)), "invalid size of central directory");
 
     ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::CURRENT, &pos));
-    StreamBase::Read(stream, &Field<9>().value);
-    ThrowErrorIfNot(Error::Zip64EOCDRecord, ((Field<9>().value != 0) && (Field<9>().value < pos.QuadPart)), "invalid size of central directory");
+    StreamBase::Read(stream, &Field<9>());
+    ThrowErrorIfNot(Error::Zip64EOCDRecord, ((Field<9>().get() != 0) && (Field<9>().get() < pos.QuadPart)), "invalid size of central directory");
 
     if (Field<10>().Size())
     {
-        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<10>().value.data()), static_cast<ULONG>(Field<10>().Size()), nullptr));
+        ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<10>().get().data()), static_cast<ULONG>(Field<10>().Size()), nullptr));
     }
 }
 
@@ -386,19 +407,19 @@ void Zip64EndOfCentralDirectoryLocator::SetData(std::uint64_t zip64EndCdrOffset)
 
 void Zip64EndOfCentralDirectoryLocator::Read(const ComPtr<IStream>& stream)
 {
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<0>().value, static_cast<std::uint32_t>(Signatures::Zip64EndOfCDLocator));
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(Signatures::Zip64EndOfCDLocator));
 
-    StreamBase::Read(stream, &Field<1>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<1>().value, 0);
+    StreamBase::Read(stream, &Field<1>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<1>(), 0);
 
     ULARGE_INTEGER pos = {0};
-    StreamBase::Read(stream, &Field<2>().value);
+    StreamBase::Read(stream, &Field<2>());
     ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::CURRENT, &pos));
-    ThrowErrorIfNot(Error::Zip64EOCDLocator, ((Field<2>().value != 0) && (Field<2>().value < pos.QuadPart)), "Invalid relative offset");
+    ThrowErrorIfNot(Error::Zip64EOCDLocator, ((Field<2>().get() != 0) && (Field<2>().get() < pos.QuadPart)), "Invalid relative offset");
 
-    StreamBase::Read(stream, &Field<3>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<3>().value, 1);
+    StreamBase::Read(stream, &Field<3>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<3>(), 1);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -408,8 +429,8 @@ EndCentralDirectoryRecord::EndCentralDirectoryRecord()
 {
     SetSignature(static_cast<std::uint32_t>(Signatures::EndOfCentralDirectory));
     // Always use zip64
-    SetNumberOfDisk(std::numeric_limits<std::uint16_t>::max());
-    SetDiskStart(std::numeric_limits<std::uint16_t>::max());
+    SetNumberOfDisk(0);
+    SetDiskStart(0);
     SetTotalNumberOfEntries(std::numeric_limits<std::uint16_t>::max());
     SetTotalEntriesInCentralDirectory(std::numeric_limits<std::uint16_t>::max());
     SetSizeOfCentralDirectory(std::numeric_limits<std::uint32_t>::max());
@@ -419,42 +440,45 @@ EndCentralDirectoryRecord::EndCentralDirectoryRecord()
 
 void EndCentralDirectoryRecord::Read(const ComPtr<IStream>& stream)
 {
-    StreamBase::Read(stream, &Field<0>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<0>().value, static_cast<std::uint32_t>(Signatures::EndOfCentralDirectory));
+    StreamBase::Read(stream, &Field<0>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<0>(), static_cast<std::uint32_t>(Signatures::EndOfCentralDirectory));
 
-    StreamBase::Read(stream, &Field<1>().value);
-    Meta::OnlyEitherValueValidation<std::uint32_t>(Field<1>().value, 0, 0xFFFF);
+    StreamBase::Read(stream, &Field<1>());
+    Meta::OnlyEitherValueValidation<std::uint32_t>(Field<1>(), 0, 0xFFFF);
 
-    StreamBase::Read(stream, &Field<2>().value);
-    Meta::OnlyEitherValueValidation<std::uint32_t>(Field<2>().value, 0, 0xFFFF);
-    ThrowErrorIf(Error::ZipEOCDRecord, (Field<1>().value != Field<2>().value), "field missmatch");
-    m_isZip64 = (0xFFFF == Field<2>().value);
+    StreamBase::Read(stream, &Field<2>());
+    Meta::OnlyEitherValueValidation<std::uint32_t>(Field<2>(), 0, 0xFFFF);
+    ThrowErrorIf(Error::ZipEOCDRecord, (Field<1>().get() != Field<2>().get()), "field missmatch");
 
-    StreamBase::Read(stream, &Field<3>().value);
-    if (Field<3>().value != 0 && Field<3>().value != 0xFFFF)
-    {   m_archiveHasZip64Locator = false;
-    }
+    StreamBase::Read(stream, &Field<3>());
+    StreamBase::Read(stream, &Field<4>());
+    ThrowErrorIf(Error::ZipEOCDRecord, (Field<3>().get() != Field<4>().get()), "field missmatch");
 
-    StreamBase::Read(stream, &Field<4>().value);
-    ThrowErrorIf(Error::ZipEOCDRecord, (Field<3>().value != Field<4>().value), "field missmatch");
+    StreamBase::Read(stream, &Field<5>());
+    StreamBase::Read(stream, &Field<6>());
 
-    StreamBase::Read(stream, &Field<5>().value);
-    StreamBase::Read(stream, &Field<6>().value);
+    m_isZip64 = (
+        IsValueInExtendedInfo(Field<1>()) ||
+        IsValueInExtendedInfo(Field<2>()) ||
+        IsValueInExtendedInfo(Field<3>()) ||
+        IsValueInExtendedInfo(Field<4>()) ||
+        IsValueInExtendedInfo(Field<5>()) ||
+        IsValueInExtendedInfo(Field<6>()));
 
-    if(m_archiveHasZip64Locator)
+    if (m_isZip64)
     {
-        ThrowErrorIf(Error::ZipEOCDRecord, ((Field<5>().value != 0) && (Field<5>().value != 0xFFFFFFFF)),
+        ThrowErrorIf(Error::ZipEOCDRecord, ((Field<5>().get() != 0) && (Field<5>().get() != 0xFFFFFFFF)),
             "unsupported size of central directory");
-        ThrowErrorIf(Error::ZipEOCDRecord, ((Field<6>().value != 0) && (Field<6>().value != 0xFFFFFFFF)),
+        ThrowErrorIf(Error::ZipEOCDRecord, ((Field<6>().get() != 0) && (Field<6>().get() != 0xFFFFFFFF)),
             "unsupported offset of start of central directory");
     }
 
-    StreamBase::Read(stream, &Field<7>().value);
-    Meta::ExactValueValidation<std::uint32_t>(Field<7>().value, 0);
+    StreamBase::Read(stream, &Field<7>());
+    Meta::ExactValueValidation<std::uint32_t>(Field<7>(), 0);
 
     if (Field<8>().Size())
     {
-       ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<8>().value.data()), static_cast<ULONG>(Field<8>().Size()), nullptr));
+       ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(Field<8>().get().data()), static_cast<ULONG>(Field<8>().Size()), nullptr));
     }
 }
 

--- a/src/msix/unpack/ZipObjectReader.cpp
+++ b/src/msix/unpack/ZipObjectReader.cpp
@@ -22,7 +22,7 @@ namespace MSIX {
         // find where the zip central directory exists.
         std::uint64_t offsetStartOfCD = 0;
         std::uint64_t totalNumberOfEntries = 0;
-        if (!m_endCentralDirectoryRecord.GetArchiveHasZip64Locator())
+        if (!m_endCentralDirectoryRecord.GetIsZip64())
         {
             offsetStartOfCD = m_endCentralDirectoryRecord.GetStartOfCentralDirectory();
             totalNumberOfEntries = m_endCentralDirectoryRecord.GetNumberOfCentralDirectoryEntries();
@@ -52,7 +52,7 @@ namespace MSIX {
             m_centralDirectories.insert(std::make_pair(centralFileHeader.GetFileName(), std::move(centralFileHeader)));
         }
 
-        if (m_endCentralDirectoryRecord.GetArchiveHasZip64Locator())
+        if (m_endCentralDirectoryRecord.GetIsZip64())
         {   // We should have no data between the end of the last central directory header and the start of the EoCD
             ULARGE_INTEGER uPos = {0};
             ThrowHrIfFailed(m_stream->Seek({0}, StreamBase::Reference::CURRENT, &uPos));
@@ -94,7 +94,7 @@ namespace MSIX {
                 centralFileHeader->second.GetCompressionMethod() == CompressionType::Deflate,
                 centralFileHeader->second.GetRelativeOffsetOfLocalHeader() + lfh.Size(),
                 centralFileHeader->second.GetCompressedSize(),
-                m_stream
+                m_stream.Get()
             );
 
             if (centralFileHeader->second.GetCompressionMethod() == CompressionType::Deflate)

--- a/src/msix/unpack/ZipObjectReader.cpp
+++ b/src/msix/unpack/ZipObjectReader.cpp
@@ -15,7 +15,8 @@ namespace MSIX {
     ZipObjectReader::ZipObjectReader(const ComPtr<IStream>& stream) : ZipObject(stream)
     {
         LARGE_INTEGER pos = {0};
-        pos.QuadPart = -1 * m_endCentralDirectoryRecord.Size();
+        pos.QuadPart = m_endCentralDirectoryRecord.Size();
+        pos.QuadPart *= -1;
         ThrowHrIfFailed(m_stream->Seek(pos, StreamBase::Reference::END, nullptr));
         m_endCentralDirectoryRecord.Read(m_stream.Get());
 
@@ -29,7 +30,8 @@ namespace MSIX {
         }
         else
         {   // Make sure that we have a zip64 end of central directory locator
-            pos.QuadPart = -1*(m_endCentralDirectoryRecord.Size() + m_zip64Locator.Size());
+            pos.QuadPart = m_endCentralDirectoryRecord.Size() + m_zip64Locator.Size();
+            pos.QuadPart *= -1;
             ThrowHrIfFailed(m_stream->Seek(pos, StreamBase::Reference::END, nullptr));
             m_zip64Locator.Read(m_stream.Get());
 


### PR DESCRIPTION
This change generally improves packing, as well as making a slightly more sweeping change to the zip serialization code.  Changes include:

- In debug builds on Windows, don't assert unless the debugger is attached
- Usage changes to FieldBase, and addition of OptionalFieldBase
  - Additionally, writing the bytes out no longer requires allocation of hundreds of tiny vectors
- Changing stream usage for writing to be more consistent with usage for reading
  - This means instead of ZipFileStream -> RangeStream -> DeflateStream -> VectorStream on RangeStream's vector, we have DeflateStream -> ZipFileStream -> RangeStream -> output stream
  - This also means that we avoid holding entire zip'd streams in memory, instead writing directly to output as we go
- Changed Zip64ExtendedInformation to support the fact that the 4 fields are optional
  - This includes making the entire structure optional, in the event that no field is necessary
- IZipWriter interface changes to reflect the write through nature of the above stream restructuring
- Detection of Zip64 format now based on any of the EoCD fields being -1, rather than just one of them
- Data descriptors for LFH are also now optional, but to match Windows behavior are always generated when not signing