### PR TITLE
Validate output pack package using the Windows AppxPackaging APIs

### DIFF
--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -51,7 +51,7 @@ if(MSIX_PACK)
         )
     else()
         list(APPEND MsixTestFiles
-            PAL/Pack/nonWindows/PackValidation.cpp
+            PAL/Pack/NonWindows/PackValidation.cpp
         )
     endif()
 endif()

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -45,6 +45,15 @@ if(MSIX_PACK)
         api_packagewriter.cpp
         testData/PackTestData.cpp
         )
+    if (WIN32)
+        list(APPEND MsixTestFiles
+            PAL/Pack/Windows/PackValidation.cpp
+        )
+    else()
+        list(APPEND MsixTestFiles
+            PAL/Pack/nonWindows/PackValidation.cpp
+        )
+    endif()
 endif()
 
 if (WIN32)

--- a/src/test/msixtest/PAL/Pack/NonWindows/PackValidation.cpp
+++ b/src/test/msixtest/PAL/Pack/NonWindows/PackValidation.cpp
@@ -1,0 +1,33 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#include "catch.hpp"
+#include "msixtest_int.hpp"
+#include "PackTestData.hpp"
+#include "FileHelpers.hpp"
+
+namespace MsixTest {
+    namespace Pack
+    {
+        // For non-windows, just use the MSIX SDK to validate the package.
+        void ValidatePackageStream(const std::string& packageName)
+        {
+            // verify output package exists
+            auto outputStream = MsixTest::StreamFile(packageName, true, true);
+
+            // Verify new package can be unpacked
+            auto outputDir = MsixTest::TestPath::GetInstance()->GetPath(MsixTest::TestPath::Directory::Output);
+            REQUIRE_SUCCEEDED(UnpackPackageFromStream(MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_NONE,
+                                                    MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_SKIPSIGNATURE,
+                                                    outputStream.Get(),
+                                                    const_cast<char*>(outputDir.c_str())));
+
+            auto files = MsixTest::Pack::GetExpectedFiles();
+            CHECK(MsixTest::Directory::CompareDirectory(outputDir, files));
+
+            // Clean directory
+            CHECK(MsixTest::Directory::CleanDirectory(outputDir));
+        }
+    } 
+}

--- a/src/test/msixtest/PAL/Pack/Windows/PackValidation.cpp
+++ b/src/test/msixtest/PAL/Pack/Windows/PackValidation.cpp
@@ -1,0 +1,50 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#include "catch.hpp"
+#include "msixtest_int.hpp"
+#include "PackTestData.hpp"
+#include "FileHelpers.hpp"
+
+#include "Windows.h"
+#include <iostream>
+namespace MsixTest {
+    namespace Pack
+    {
+        // For windows, just use the MSIX SDK and Windows AppxPackaging APIs to validate the package.
+        void ValidatePackageStream(const std::string& packageName)
+        {
+            // verify output package exists
+            auto packageStream = MsixTest::StreamFile(packageName, true, true);
+
+            // Verify new package can be unpacked via MSIX SDK
+            auto outputDir = MsixTest::TestPath::GetInstance()->GetPath(MsixTest::TestPath::Directory::Output);
+            REQUIRE_SUCCEEDED(UnpackPackageFromStream(MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_NONE,
+                                                      MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_SKIPSIGNATURE,
+                                                      packageStream.Get(),
+                                                      const_cast<char*>(outputDir.c_str())));
+
+            auto files = MsixTest::Pack::GetExpectedFiles();
+            CHECK(MsixTest::Directory::CompareDirectory(outputDir, files));
+
+            // Clean directory
+            CHECK(MsixTest::Directory::CleanDirectory(outputDir));
+
+            // Verify new package can be unpacked via Windows AppxPackaging Apis
+            LARGE_INTEGER start = { 0 };
+            REQUIRE_SUCCEEDED(packageStream->Seek(start, STREAM_SEEK_SET, nullptr));
+
+            REQUIRE_SUCCEEDED(CoInitializeEx(NULL, COINIT_MULTITHREADED));
+            {
+                MsixTest::ComPtr<IAppxFactory> appxFactory;
+                REQUIRE_SUCCEEDED(CoCreateInstance(__uuidof(AppxFactory), nullptr,
+                    CLSCTX_INPROC_SERVER, __uuidof(IAppxFactory), reinterpret_cast<LPVOID*>(&appxFactory)));
+            
+                MsixTest::ComPtr<IAppxPackageReader> packageReader;
+                REQUIRE_SUCCEEDED(appxFactory->CreatePackageReader(packageStream.Get(), &packageReader));
+            }
+            CoUninitialize();
+        }
+    } 
+}

--- a/src/test/msixtest/inc/PackValidation.hpp
+++ b/src/test/msixtest/inc/PackValidation.hpp
@@ -1,0 +1,13 @@
+//
+//  Copyright (C) 2019 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#pragma once
+#include "AppxPackaging.hpp"
+
+namespace MsixTest {
+    namespace Pack
+    {
+        void ValidatePackageStream(const std::string& packageName);
+    } 
+}

--- a/src/test/msixtest/inc/msixtest_int.hpp
+++ b/src/test/msixtest/inc/msixtest_int.hpp
@@ -184,6 +184,7 @@ namespace MsixTest {
         void Initialize(std::string fileName, bool toRead, bool toDelete = false);
         void Initialize(std::wstring fileName, bool toRead, bool toDelete = false);
 
+        inline IStream* operator->() const { return m_stream.Get(); }
         inline IStream* Get() const { return m_stream.Get(); }
         IStream* Detach()
         {

--- a/src/test/msixtest/pack.cpp
+++ b/src/test/msixtest/pack.cpp
@@ -8,6 +8,7 @@
 #include "macros.hpp"
 #include "FileHelpers.hpp"
 #include "PackTestData.hpp"
+#include "PackValidation.hpp"
 
 #include <iostream>
 
@@ -40,21 +41,8 @@ TEST_CASE("Pack_Good", "[pack]")
 
     RunPackTest(expected, directory);
 
-    // verify output package exists
-    auto outputStream = MsixTest::StreamFile(outputPackage, true, true);
-
-    // Verify new package can be unpacked
-    auto outputDir = MsixTest::TestPath::GetInstance()->GetPath(MsixTest::TestPath::Directory::Output);
-    REQUIRE_SUCCEEDED(UnpackPackageFromStream(MSIX_PACKUNPACK_OPTION::MSIX_PACKUNPACK_OPTION_NONE,
-                                              MSIX_VALIDATION_OPTION::MSIX_VALIDATION_OPTION_SKIPSIGNATURE,
-                                              outputStream.Get(),
-                                              const_cast<char*>(outputDir.c_str())));
-
-    auto files = MsixTest::Pack::GetExpectedFiles();
-    CHECK(MsixTest::Directory::CompareDirectory(outputDir, files));
-
-    // Clean directory
-    CHECK(MsixTest::Directory::CleanDirectory(outputDir));
+    // Verify output package
+    MsixTest::Pack::ValidatePackageStream(outputPackage);
 }
 
 // Fail if there's no AppxManifest.xml


### PR DESCRIPTION
Adds verification of output package via the Windows AppxPackaging APIs in Pack_Good.

CoCreates Windows implementation of AppxFactory and validates the stream by creating the windows implementation of package reader via CreatePackageReader.