### PR TITLE
Make MSIX_PACK as non default option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ option(USE_VALIDATION_PARSER "Turn on to validates using the resouce schemas. De
 option(USE_SHARED_ZLIB "Choose the type of dependency for zlib, Use the -DUSE_SHARED_ZLIB=on to have a shared dependency. Default is 'off' (static)" OFF)
 option(USE_STATIC_MSVC "Windows only. Pass /MT as a compiler flag to use the staic version of the run-time library. Default is 'off' (dynamic)" OFF)
 option(SKIP_BUNDLES "Removes bundle functionality from the MSIX SDK. Default is 'off'" OFF)
-option(MSIX_PACK "Include packaging features for the MSIX SDK. Not supported for mobile. Default is 'on'" ON)
+option(MSIX_PACK "Include packaging features for the MSIX SDK. Not supported for mobile. Default is 'off'" OFF)
 
 set(CMAKE_BUILD_TYPE Debug CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.  Use the -DCMAKE_BUILD_TYPE=[option] to specify.")
 set(XML_PARSER "" CACHE STRING "Choose the type of parser, options are: [xerces, msxml6, javaxml].  Use the -DXML_PARSER=[option] to specify.")

--- a/makelinux.sh
+++ b/makelinux.sh
@@ -3,7 +3,7 @@
 build=MinSizeRel
 bundle=off
 validationParser=off
-pack=on
+pack=off
 
 usage()
 {
@@ -11,7 +11,7 @@ usage()
     echo $'\t' "-b build_type           Default MinSizeRel"
     echo $'\t' "-sb                     Skip bundle support."
     echo $'\t' "--validation-parser|-vp Enable XML schema validation."
-    echo $'\t' "--no-pack               Don't include packaging features."
+    echo $'\t' "--pack                  Include packaging features."
 }
 
 printsetup()
@@ -36,7 +36,7 @@ while [ "$1" != "" ]; do
                 ;;
         -vp )   validationParser=on
                 ;;
-        --no-pack ) pack=off
+        --pack ) pack=on
                     ;;
         * )     usage
                 exit 1

--- a/makemac.sh
+++ b/makemac.sh
@@ -6,18 +6,18 @@ bundle=off
 xmlparser=applexml
 addressSanitizer=off
 validationParser=off
-pack=on
+pack=off
 
 usage()
 {
     echo "usage: makemac [options]"
     echo $'\t' "-b build_type           Default MinSizeRel"
-    echo $'\t' "-xzlib                  Use MSIX SDK Zlib instead of inbox libCompression api. Default on MacOS is libCompression. Required for pack support."
+    echo $'\t' "-xzlib                  Use MSIX SDK Zlib instead of inbox libCompression api. Default on MacOS is libCompression."
     echo $'\t' "-sb                     Skip bundle support."
     echo $'\t' "-parser-xerces          Use xerces xml parser instead of default apple xml parser."
     echo $'\t' "-asan                   Turn on address sanitizer for memory corruption detection."
     echo $'\t' "--validation-parser|-vp Enable XML schema validation."
-    echo $'\t' "--no-pack               Don't include packaging features."
+    echo $'\t' "--pack                  Include packaging features. Must be used with -xzlib"
 }
 
 printsetup()
@@ -49,7 +49,7 @@ while [ "$1" != "" ]; do
                 ;;
         -vp )   validationParser=on
                 ;;
-        --no-pack ) pack=off
+        --pack ) pack=on
                 ;;
         -h )    usage
                 exit

--- a/makewin.cmd
+++ b/makewin.cmd
@@ -34,7 +34,7 @@ set parser="-DXML_PARSER=msxml6"
 set crypto="-DCRYPTO_LIB=crypt32"
 set msvc="-DUSE_STATIC_MSVC=off"
 set bundle="-DSKIP_BUNDLES=off"
-set pack="-DMSIX_PACK=on"
+set pack="-DMSIX_PACK=off"
 
 :parseArgs
 if /I "%~2" == "--debug" (
@@ -82,8 +82,8 @@ if /I "%~2" == "--skip-bundles" (
 if /I "%~2" == "-sb" (
     set bundle="-DSKIP_BUNDLES=on"
 )
-if /I "%~2" == "--no-pack" (
-    set pack="-DMSIX_PACK=off"
+if /I "%~2" == "--pack" (
+    set pack="-DMSIX_PACK=on"
 )
 shift /2
 if not "%~2"=="" goto parseArgs
@@ -107,13 +107,14 @@ echo Helper to build the MSIX SDK for Windows. Assumes the user has a version of
 echo:
 echo Options
 echo    --debug, -d              = Build chk binary.
-echo    --parser-xerces, -px     = use Xerces-C parser. Default MSXML6.
-echo    --validation-parser, -vp = enable XML schema validation.
-echo    --shared-zlib, -sz       = don't statically link zlib.
-echo    --crypto-openssl, -co    = use OpenSSL crypto [currently for testing]. Default Crypt32.
-echo    -mt                      = use compiler flag /MT to use static version of the run-time library.
-echo    --skip-bundles, -sb      = turn off bundle support.
-echo    --no-pack                = Don't include packaging features.
-echo    --help, -h, /?           = print this usage information and exit.
+echo    --symbols, -sym          = Produce symbols for release binaries.
+echo    --parser-xerces, -px     = Use Xerces-C parser. Default MSXML6.
+echo    --validation-parser, -vp = Enable XML schema validation.
+echo    --shared-zlib, -sz       = Don't statically link zlib.
+echo    --crypto-openssl, -co    = Use OpenSSL crypto [currently for testing]. Default Crypt32.
+echo    -mt                      = Use compiler flag /MT to use static version of the run-time library.
+echo    --skip-bundles, -sb      = Turn off bundle support.
+echo    --pack                   = Include packaging features.
+echo    --help, -h, /?           = Print this usage information and exit.
 :Exit
 EXIT /B 0

--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -34,24 +34,24 @@ jobs:
   strategy:
     # TODO: add builds using xerces if needed.
     matrix:
-      debug:
+      debug_nopack:
         _arguments: -b Debug
         _artifact: LINUXchk
-      release:
+      release_nopack:
         _arguments: -b MinSizeRel
         _artifact: LINUX
       release_nobundle:
-        _arguments: -b MinSizeRel -sb --no-pack
+        _arguments: -b MinSizeRel -sb
         _artifact: LINUX-nobundle
       release_validation_parser:
-        _arguments: -b MinSizeRel -vp
+        _arguments: -b MinSizeRel -vp --pack
         _artifact: LINUX-ValidationParser
-      release_nopack:
-        _arguments: -b MinSizeRel --no-pack
-        _artifact: LINUX-nopack
-      debug_nopack:
-        _arguments: -b Debug --no-pack
-        _artifact: LINUXchk-nopack
+      release_pack:
+        _arguments: -b MinSizeRel --pack
+        _artifact: LINUX-pack
+      debug_pack:
+        _arguments: -b Debug --pack
+        _artifact: LINUXchk-pack
 
   steps:
   - task: Bash@3

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -34,21 +34,21 @@ jobs:
   strategy:
     # TODO: add builds using xerces if needed.
     matrix:
-      debug:
-        _arguments: -b Debug -xzlib
+      debug_nopack:
+        _arguments: -b Debug
         _artifact: MACOSchk
-      release:
-        _arguments: -b MinSizeRel -xzlib
+      release_nopack:
+        _arguments: -b MinSizeRel
         _artifact: MACOS
       release_nobundle:
-        _arguments: -b MinSizeRel -sb --no-pack
+        _arguments: -b MinSizeRel -sb
         _artifact: MACOS-nobundle
-      relaese_nopack:
-        _arguments: -b MinSizeRel --no-pack
-        _artifact: MACOSchk-nopack
-      debug_nopack:
-        _arguments: -b Debug --no-pack
-        _artifact: MACOSchk-nopack
+      relaese_pack:
+        _arguments: -b MinSizeRel --pack -xzlib
+        _artifact: MACOSchk-pack
+      debug_pack:
+        _arguments: -b Debug --pack -xzlib
+        _artifact: MACOSchk-pack
   steps:
   - task: Bash@3
     displayName: Build

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -34,29 +34,29 @@ jobs:
   strategy:
     # TODO: add debug for validation parser and xerces if needed.
     matrix:
-      debug_32:
+      debug_32_nopack:
         _arguments: x86 -d
         _artifact: WIN32chk
-      debug_64:
+      debug_64_nopack:
         _arguments: x64 -d
         _artifact: WIN32-x64chk
-      release_32:
+      release_32_nopack:
         _arguments: x86
         _artifact: WIN32
-      release_64:
+      release_64_nopack:
         _arguments: x64
         _artifact: WIN32-x64
       release_32_validation_parser:
-        _arguments: x86 --validation-parser
+        _arguments: x86 --validation-parser --pack
         _artifact: WIN32ValidationParser
       release_64_validation_parser:
-        _arguments: x64 --validation-parser
+        _arguments: x64 --validation-parser --pack
         _artifact: WIN32-x64ValidationParser
       release_32_xerces:
-        _arguments: x86 --parser-xerces
+        _arguments: x86 --parser-xerces --pack
         _artifact: WIN32Xerces
       release_64_xerces:
-        _arguments: x64 --parser-xerces
+        _arguments: x64 --parser-xerces --pack
         _artifact: WIN32-x64Xerces
       release_32_nobundle:
         _arguments: x86 -sb --no-pack
@@ -64,18 +64,18 @@ jobs:
       release_64_nobundle:
         _arguments: x64 -sb --no-pack
         _artifact: WIN32-x64-nobundle
-      release_32_nopack:
-        _arguments: x86 --no-pack
-        _artifact: WIN32-nopack
-      release_64_nopack:
-        _arguments: x64 --no-pack
-        _artifact: WIN32-nopack
-      debug_32_nopack:
-        _arguments: x86 -d --no-pack
-        _artifact: WIN32chk-nopack
-      debug_64_nopack:
-        _arguments: x86 -d --no-pack
-        _artifact: WIN32chk-nopack
+      release_32_pack:
+        _arguments: x86 --pack
+        _artifact: WIN32-pack
+      release_64_pack:
+        _arguments: x64 --pack
+        _artifact: WIN32-pack
+      debug_32_pack:
+        _arguments: x86 -d --pack
+        _artifact: WIN32chk-pack
+      debug_64_pack:
+        _arguments: x86 -d --pack
+        _artifact: WIN32chk-pack
 
   steps:
   - task: BatchScript@1


### PR DESCRIPTION
Turn off pack support as the default option for the MSIX SDK.

To enable packing, pass the --pack flag to makewin.cmd, makemas.sh or makelinux.sh or MSIX_PACK=on as a CMake parameter.