### PR TITLE
Fix not getting elements that belongs to different namespaces

### DIFF
--- a/src/inc/AppxManifestObject.hpp
+++ b/src/inc/AppxManifestObject.hpp
@@ -255,6 +255,8 @@ namespace MSIX {
         HRESULT STDMETHODCALLTYPE GetDocumentElement(IMsixElement** documentElement) noexcept override;
 
     protected:
+        std::vector<std::string> GetCapabilities(APPX_CAPABILITY_CLASS_TYPE capabilityClass);
+
         ComPtr<IMsixFactory> m_factory;
         ComPtr<IStream> m_stream;
         ComPtr<IAppxManifestPackageId> m_packageId;

--- a/src/inc/AppxPackaging.hpp
+++ b/src/inc/AppxPackaging.hpp
@@ -1219,6 +1219,7 @@ interface IAppxManifestPackageDependencyUtf8;
 interface IAppxManifestPackageIdUtf8;
 interface IAppxManifestPropertiesUtf8;
 interface IAppxManifestQualifiedResourceUtf8;
+interface IAppxManifestCapabilitiesEnumeratorUtf8;
 interface IAppxManifestResourcesEnumeratorUtf8;
 interface IAppxManifestTargetDeviceFamilyUtf8;
 interface IAppxPackageReaderUtf8;
@@ -1403,6 +1404,19 @@ interface IAppxPackageWriter3Utf8;
             /* [retval][string][out] */  LPSTR *language) noexcept = 0;
     };
 #endif 	/* __IAppxManifestQualifiedResourceUtf8_INTERFACE_DEFINED__ */
+
+#ifndef __IAppxManifestCapabilitiesEnumeratorUtf8_INTERFACE_DEFINED__
+#define __IAppxManifestCapabilitiesEnumeratorUtf8_INTERFACE_DEFINED__
+
+    // {cc422f8e-a4d9-4f2e-bb49-ac3a5ce2a2f0}
+    MSIX_INTERFACE(IAppxManifestCapabilitiesEnumeratorUtf8,0xcc422f8e,0xa4d9,0x4f2e,0xbb,0x49,0xac,0x3a,0x5c,0xe2,0xa2,0xf0);
+    interface IAppxManifestCapabilitiesEnumeratorUtf8 : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetCurrent(
+            /* [retval][string][out] */ LPSTR *resource) noexcept = 0;
+    };
+#endif 	/* __IAppxManifestCapabilitiesEnumeratorUtf8_INTERFACE_DEFINED__ */
 
 #ifndef __IAppxManifestResourcesEnumeratorUtf8_INTERFACE_DEFINED__
 #define __IAppxManifestResourcesEnumeratorUtf8_INTERFACE_DEFINED__

--- a/src/inc/IXml.hpp
+++ b/src/inc/IXml.hpp
@@ -52,6 +52,7 @@ enum class XmlQueryName : std::uint8_t
     Package_Properties_Framework,
     Package_Properties_ResourcePackage,
     Package_Properties_SupportedUsers,
+    Package_Capabilities_CustomCapability,
 };
 
 // defines attribute names for use in IXmlElement:: [GetAttributeValue|GetBase64DecodedAttributeValue]
@@ -92,6 +93,7 @@ public:
     virtual std::string               GetAttributeValue(XmlAttributeName attribute) = 0;
     virtual std::vector<std::uint8_t> GetBase64DecodedAttributeValue(XmlAttributeName attribute) = 0;
     virtual std::string               GetText() = 0;
+    virtual std::string               GetPrefix() = 0;
 };
 MSIX_INTERFACE(IXmlElement, 0xac94449e,0x442d,0x4bed,0x8f,0xca,0x83,0x77,0x0c,0x0f,0x7e,0xe9);
 

--- a/src/msix/PAL/XML/AOSP/XmlObject.cpp
+++ b/src/msix/PAL/XML/AOSP/XmlObject.cpp
@@ -43,6 +43,9 @@ public:
         getTextContentFunc = m_env->GetMethodID(
                 xmlElementClass.get(), "GetTextContent",
                 "()Ljava/lang/String;");
+        getPrefixFunc = m_env->GetMethodID(
+                xmlElementClass.get(), "GetPrefix",
+                "()Ljava/lang/String;");
         getElementsByTagNameFunc = m_env->GetMethodID(
                 xmlElementClass.get(), "GetElementsByTagName",
                 "(Ljava/lang/String;)[Lcom/microsoft/msix/XmlElement;");
@@ -68,6 +71,16 @@ public:
     {
         std::unique_ptr<_jstring, JObjectDeleter> jvalue(reinterpret_cast<jstring>(m_env->CallObjectMethod(m_javaXmlElementObject.get(), getTextContentFunc)));
         return GetStringFromJString(jvalue.get());
+    }
+
+    std::string GetPrefix() override
+    {
+        std::unique_ptr<_jstring, JObjectDeleter> jvalue(reinterpret_cast<jstring>(m_env->CallObjectMethod(m_javaXmlElementObject.get(), getPrefixFunc)));
+        if (jvalue.get() != nullptr)
+        {
+            return GetStringFromJString(jvalue.get());
+        }
+        return {};
     }
 
     // IJavaXmlElement
@@ -130,6 +143,7 @@ private:
     std::unique_ptr<_jobject, JObjectDeleter> m_javaXmlElementObject;
     jmethodID getAttributeValueFunc = nullptr;
     jmethodID getTextContentFunc = nullptr;
+    jmethodID getPrefixFunc = nullptr;
     jmethodID getElementsByTagNameFunc = nullptr;
     jmethodID getElementsFunc = nullptr;
     JNIEnv* m_env = nullptr;

--- a/src/msix/PAL/XML/AOSP/XmlObject.cpp
+++ b/src/msix/PAL/XML/AOSP/XmlObject.cpp
@@ -78,7 +78,12 @@ public:
         std::unique_ptr<_jstring, JObjectDeleter> jvalue(reinterpret_cast<jstring>(m_env->CallObjectMethod(m_javaXmlElementObject.get(), getPrefixFunc)));
         if (jvalue.get() != nullptr)
         {
-            return GetStringFromJString(jvalue.get());
+            std::string nodeName = GetStringFromJString(jvalue.get());
+            std::size_t semiColon = nodeName.find_first_of(':');
+            if (semiColon != std::string::npos)
+            {
+                return nodeName.substr(0, semiColon);
+            }
         }
         return {};
     }

--- a/src/msix/PAL/XML/Apple/NSXmlParserDelegateWrapper.mm
+++ b/src/msix/PAL/XML/Apple/NSXmlParserDelegateWrapper.mm
@@ -23,8 +23,13 @@
 
 - (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict {
     std::unique_ptr<MSIX::XmlNode> node(new MSIX::XmlNode());
-    
+
     node->NodeName = std::string([elementName UTF8String]);
+    std::size_t semiColon = node->NodeName.find_first_of(':');
+    if (semiColon != std::string::npos)
+    {
+        node->NodeName = node->NodeName.substr(semiColon + 1);
+    }
     if (qName)
     {
         node->QualifiedNodeName = std::string([qName UTF8String]);
@@ -41,7 +46,13 @@
 }
 
 - (void)parser:(NSXMLParser *)parser didEndElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName {
-     m_xmlDocumentReader->ProcessNodeEnd(std::string([elementName UTF8String]));
+    std::string name = std::string([elementName UTF8String]);
+    std::size_t semiColon = name.find_first_of(':');
+    if (semiColon != std::string::npos)
+    {
+        name = name.substr(semiColon + 1);
+    }
+     m_xmlDocumentReader->ProcessNodeEnd(name);
 }
 
 - (void) parserDidEndDocument:(NSXMLParser *)parser {

--- a/src/msix/PAL/XML/Apple/NSXmlParserDelegateWrapper.mm
+++ b/src/msix/PAL/XML/Apple/NSXmlParserDelegateWrapper.mm
@@ -24,11 +24,16 @@
 - (void)parser:(NSXMLParser *)parser didStartElement:(NSString *)elementName namespaceURI:(NSString *)namespaceURI qualifiedName:(NSString *)qName attributes:(NSDictionary *)attributeDict {
     std::unique_ptr<MSIX::XmlNode> node(new MSIX::XmlNode());
 
-    node->NodeName = std::string([elementName UTF8String]);
-    std::size_t semiColon = node->NodeName.find_first_of(':');
+    std::string nodeName = std::string([elementName UTF8String]);
+    std::size_t semiColon = nodeName.find_first_of(':');
     if (semiColon != std::string::npos)
     {
-        node->NodeName = node->NodeName.substr(semiColon + 1);
+        node->NodeName = nodeName.substr(semiColon + 1);
+        node->Prefix = nodeName.substr(0, semiColon);
+    }
+    else
+    {
+        node->NodeName = nodeName;
     }
     if (qName)
     {

--- a/src/msix/PAL/XML/Apple/XmlDocumentReader.hpp
+++ b/src/msix/PAL/XML/Apple/XmlDocumentReader.hpp
@@ -26,6 +26,7 @@ public:
     std::string Text;
     std::string NodeName;
     std::string QualifiedNodeName;
+    std::string Prefix;
     
     std::list<XmlNode*> FindElements(std::string xpath);
 private:

--- a/src/msix/PAL/XML/Apple/XmlObject.cpp
+++ b/src/msix/PAL/XML/Apple/XmlObject.cpp
@@ -54,6 +54,11 @@ public:
         return m_xmlNode->Text;
     }
 
+    std::string GetPrefix() override
+    {
+        return m_xmlNode->Prefix;
+    }
+
     // IAppleXmlElement
     XmlNode* GetXmlNode() override { return m_xmlNode; }
 

--- a/src/msix/PAL/XML/msxml6/XmlObject.cpp
+++ b/src/msix/PAL/XML/msxml6/XmlObject.cpp
@@ -163,6 +163,19 @@ public:
         return {};
     }
 
+    std::string GetPrefix() override
+    {
+        ComPtr<IXMLDOMNode> node;
+        ThrowHrIfFailed(m_element->QueryInterface(__uuidof(IXMLDOMNode), reinterpret_cast<void**>(&node)));
+        Bstr value;
+        ThrowHrIfFailed(node->get_prefix(value.AddressOf()));
+        if (value.Get() != nullptr)
+        {
+            return wstring_to_utf8(static_cast<WCHAR*>(value.Get()));
+        }
+        return {};
+    }
+
     // IMSXMLElement
     ComPtr<IXMLDOMNodeList> SelectNodes(XmlQueryName query) override
     {

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -399,6 +399,7 @@ public:
         auto entityResolver = std::make_unique<MsixEntityResolver>(m_factory, s_xmlNamespaces[static_cast<std::uint8_t>(footPrintType)]);
         m_parser->setErrorHandler(errorHandler.get());
         m_parser->setXMLEntityResolver(entityResolver.get());
+        m_parser->setDoNamespaces(true);
 
         if (!schemas.empty())
         {
@@ -410,7 +411,6 @@ public:
             m_parser->setValidationScheme(XERCES_CPP_NAMESPACE::AbstractDOMParser::ValSchemes::Val_Always);
             m_parser->cacheGrammarFromParse(true);
             m_parser->setDoSchema(true);
-            m_parser->setDoNamespaces(true);
             m_parser->setValidationSchemaFullChecking(true);
             // Disable DTD and prevent XXE attacks.  See https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#libxerces-c for additional details.
             m_parser->setIgnoreCachedDTD(true);

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -274,7 +274,22 @@ public:
     {
         DOMNode* node = dynamic_cast<DOMNode*>(m_element);
         XercesCharPtr value(XMLString::transcode(node->getTextContent()));
-        return std::string(value.Get());
+        if (value.Get() != nullptr)
+        {
+            return std::string(value.Get());
+        }
+        return {};
+    }
+
+    std::string GetPrefix() override
+    {
+        DOMNode* node = dynamic_cast<DOMNode*>(m_element);
+        XercesCharPtr value(XMLString::transcode(node->getPrefix()));
+        if (value.Get() != nullptr)
+        {
+            return std::string(value.Get());
+        }
+        return {};
     }
 
     // IXercesElement

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <map>
 #include <queue>
+#include <list>
 
 #include "Exceptions.hpp"
 #include "StreamBase.hpp"
@@ -204,7 +205,7 @@ public:
     XMLCh* Get() const { return m_ptr; }
 protected:
     inline void Swap(XercesXMLChPtr& right ) { std::swap(m_ptr, right.m_ptr); }
-    XMLCh* m_ptr = nullptr;              
+    XMLCh* m_ptr = nullptr;
 };
 
 class XercesXMLBytePtr
@@ -235,8 +236,8 @@ public:
     XMLByte* Get() const { return m_ptr; }
 protected:
     inline void Swap(XercesXMLBytePtr& right ) { std::swap(m_ptr, right.m_ptr); }
-    XMLByte* m_ptr = nullptr;             
-};    
+    XMLByte* m_ptr = nullptr;
+};
 
 class XercesElement final : public ComClass<XercesElement, IXmlElement, IXercesElement, IMsixElement>
 {
@@ -426,7 +427,6 @@ public:
         }
 
         m_parser->parse(*source);
-        m_resolver = XercesPtr<DOMXPathNSResolver>(m_parser->getDocument()->createNSResolver(m_parser->getDocument()));
 
         // TODO: Do semantic check for all the elements we modified to maxOcurrs=unbounded and xs:patterns
     }
@@ -439,21 +439,33 @@ public:
 
     bool ForEachElementIn(const ComPtr<IXmlElement>& root, XmlQueryName query, XmlVisitor& visitor) override
     {
-        ComPtr<IXercesElement> element = root.As<IXercesElement>();
+        DOMElement* element = root.As<IXercesElement>()->GetElement();
 
-        XercesXMLChPtr xPath(XMLString::transcode(GetQueryString(query)));
-        XercesPtr<DOMXPathResult> result(m_parser->getDocument()->evaluate(
-            xPath.Get(),
-            element->GetElement(),
-            m_resolver.Get(),
-            DOMXPathResult::ORDERED_NODE_SNAPSHOT_TYPE,
-            nullptr));
-        
-        for (XMLSize_t i = 0; i < result->getSnapshotLength(); i++)
+        std::list<DOMElement*> list;
+        std::string xpath(GetQueryString(query));
+
+        if (xpath.size() >= 2 && xpath[0] == '.' && xpath[1] == '/')
         {
-            result->snapshotItem(i);
-            auto node = static_cast<DOMElement*>(result->getNodeValue());
-            auto item = ComPtr<IXmlElement>::Make<XercesElement>(m_factory, node, m_parser.get());
+            FindChildElements(xpath.substr(2), element, list);
+        }
+        else if (xpath.size() > 1 && xpath[0] == '/')
+        {
+            // Get name of root element
+            std::size_t secondSlash =  xpath.find_first_of('/', 1);
+            XercesXMLChPtr firstElement(XMLString::transcode(xpath.substr(1, secondSlash - 1).c_str()));
+            if (XMLString::compareString(firstElement.Get(), static_cast<DOMNode*>(element)->getLocalName()) == 0)
+            {
+                FindChildElements(xpath.substr(secondSlash + 1), element, list);
+            }
+            else
+            {
+                ThrowErrorAndLog(Error::XmlFatal, "Invalid root element");
+            }
+        }
+
+        for(const auto& element : list)
+        {
+            auto item = ComPtr<IXmlElement>::Make<XercesElement>(m_factory, element, m_parser.get());
             if (!visitor(item))
             {
                 return false;
@@ -580,9 +592,37 @@ protected:
         }
     }
 
+    void FindChildElements(std::string xpath, DOMElement* root, std::list<DOMElement*>& list)
+    {
+        // The special value "*" matches all namespaces
+        XercesXMLChPtr allNS(XMLString::transcode("*"));
+
+        // Find next element to search
+        std::size_t nextSeparator = xpath.find_first_of('/');
+        XercesXMLChPtr nextElement(XMLString::transcode(xpath.substr(0, nextSeparator).c_str()));
+
+        DOMNodeList* childs = root->getElementsByTagNameNS(allNS.Get(), nextElement.Get());
+        XMLSize_t childsSize = childs->getLength();
+        for(XMLSize_t i = 0; i < childsSize; i++)
+        {
+            DOMNode* node = childs->item(i);
+            if (XMLString::compareString(nextElement.Get(), node->getLocalName()) == 0)
+            {
+                if (nextSeparator == std::string::npos)
+                {
+                    // This is the node we are looking for.
+                    list.emplace_back(static_cast<DOMElement*>(node));
+                }
+                else
+                {
+                    FindChildElements(xpath.substr(nextSeparator + 1), static_cast<DOMElement*>(node), list);
+                }
+            }
+        }
+    }
+
     IMsixFactory* m_factory;
     std::unique_ptr<XERCES_CPP_NAMESPACE::XercesDOMParser> m_parser;
-    XercesPtr<DOMXPathNSResolver> m_resolver;
     ComPtr<IStream> m_stream;
 };
 

--- a/src/msix/PAL/java/com/microsoft/msix/XmlElement.java
+++ b/src/msix/PAL/java/com/microsoft/msix/XmlElement.java
@@ -37,7 +37,7 @@ public class XmlElement {
     }
 
     public String GetPrefix() {
-        return m_element.getPrefix();
+        return m_element.getNodeName(); // getPrefix keep returning null
     }
 
     public XmlElement[] GetElementsByTagName(String name) {

--- a/src/msix/PAL/java/com/microsoft/msix/XmlElement.java
+++ b/src/msix/PAL/java/com/microsoft/msix/XmlElement.java
@@ -36,6 +36,10 @@ public class XmlElement {
         return m_element.getTextContent();
     }
 
+    public String GetPrefix() {
+        return m_element.getPrefix();
+    }
+
     public XmlElement[] GetElementsByTagName(String name) {
         List<XmlElement> elements = new ArrayList<>();
         try {

--- a/src/msix/common/AppxManifestObject.cpp
+++ b/src/msix/common/AppxManifestObject.cpp
@@ -208,14 +208,14 @@ namespace MSIX {
                 contextProperties->wasFound = true;
                 return true;
             });
-            context->self->m_dom->ForEachElementIn(propertiesNode, XmlQueryName::Package_Properties_Framework, visitorBool);
+            context->self->m_dom->ForEachElementIn(propertiesNode, XmlQueryName::Child_Framework, visitorBool);
             if (!contextPropertiesBool.wasFound)
             {   // False is default value for Framework
                 context->boolValues->insert(std::pair<std::string, bool>(contextPropertiesBool.value, false));
             }
             contextPropertiesBool.value = "ResourcePackage";
             contextPropertiesBool.wasFound = false;
-            context->self->m_dom->ForEachElementIn(propertiesNode, XmlQueryName::Package_Properties_ResourcePackage, visitorBool);
+            context->self->m_dom->ForEachElementIn(propertiesNode, XmlQueryName::Child_ResourcePackage, visitorBool);
             if (!contextPropertiesBool.wasFound)
             {   // False is default value for ResourcePackage
                 context->boolValues->insert(std::pair<std::string, bool>(contextPropertiesBool.value, false));

--- a/src/msix/common/IXml.cpp
+++ b/src/msix/common/IXml.cpp
@@ -61,6 +61,7 @@ static const MSIX::XmlQueryNameCharType* xPaths[] = {
     /* Package_Properties_Framework                  */L"/*[local-name()='Package']/*[local-name()='Properties']/*[local-name()='Framework']",
     /* Package_Properties_ResourcePackage            */L"/*[local-name()='Package']/*[local-name()='Properties']/*[local-name()='ResourcePackage']",
     /* Package_Properties_SupportedUsers             */L"/*[local-name()='Package']/*[local-name()='Properties']/*[local-name()='SupportedUsers']",
+    /* Package_Capabilities_CustomCapability         */L"/*[local-name()='Package']/*[local-name()='Capabilities']/*[local-name()='CustomCapability']",
 };
 #else
 
@@ -93,6 +94,7 @@ static const MSIX::XmlQueryNameCharType* xPaths[] = {
     /* Package_Properties_Framework                  */"/Package/Properties/Framework",
     /* Package_Properties_ResourcePackage            */"/Package/Properties/ResourcePackage",
     /* Package_Properties_SupportedUsers             */"/Package/Properties/SupportedUsers",
+    /* Package_Capabilities_CustomCapability         */"/Package/Capabilities/CustomCapability",
 };
 #endif
 

--- a/src/test/mobile/AndroidBVT/app/src/main/cpp/native-lib.cpp
+++ b/src/test/mobile/AndroidBVT/app/src/main/cpp/native-lib.cpp
@@ -87,6 +87,7 @@ Java_com_microsoft_androidbvt_MainActivity_RunTests(JNIEnv* env, jobject /* this
     CopyFilesFromAssets(env, assetManager, filePath, "testData/unpack/bundles");
     CopyFilesFromAssets(env, assetManager, filePath, "testData/unpack/flat");
     CopyFilesFromAssets(env, assetManager, filePath, "testData/unpack/महसुस");
+    CopyFilesFromAssets(env, assetManager, filePath, "testData/manifest");
 
     std::string outputFile = filePath + "TEST-MsixSDK-AOSP.xml";
     filePath = filePath.substr(0, filePath.size() - 1);

--- a/src/test/mobile/AndroidBVT/build.gradle
+++ b/src/test/mobile/AndroidBVT/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/src/test/mobile/AndroidBVT/gradle/wrapper/gradle-wrapper.properties
+++ b/src/test/mobile/AndroidBVT/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 16 19:11:10 PST 2018
+#Wed Jul 17 11:58:50 PDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/src/test/mobile/iOSBVT/iOSBVT.xcodeproj/project.pbxproj
+++ b/src/test/mobile/iOSBVT/iOSBVT.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		4C14834E228F69D800EAED24 /* libmsixtest.dylib in Copy Files */ = {isa = PBXBuildFile; fileRef = 4C14834C228F69C400EAED24 /* libmsixtest.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		4C14D5D52204CC2A0034C5CE /* libmsix.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C14D5D32204CC2A0034C5CE /* libmsix.dylib */; };
 		4C14D5D72204CC400034C5CE /* libmsix.dylib in Copy Files */ = {isa = PBXBuildFile; fileRef = 4C14D5D32204CC2A0034C5CE /* libmsix.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		4CD2FBB122E2733E0059BF30 /* Sample_AppxManifest.xml in Resources */ = {isa = PBXBuildFile; fileRef = 4CD2FBB022E2733E0059BF30 /* Sample_AppxManifest.xml */; };
+		4CD2FBB322E273680059BF30 /* Sample_AppxManifest.xml in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4CD2FBB022E2733E0059BF30 /* Sample_AppxManifest.xml */; };
 		EEE4055020225CDF007B25CE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE4054F20225CDF007B25CE /* AppDelegate.m */; };
 		EEE4055320225CDF007B25CE /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EEE4055220225CDF007B25CE /* ViewController.m */; };
 		EEE4055620225CDF007B25CE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EEE4055420225CDF007B25CE /* Main.storyboard */; };
@@ -220,6 +222,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4CD2FBB222E273560059BF30 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = testData/manifest;
+			dstSubfolderSpec = 7;
+			files = (
+				4CD2FBB322E273680059BF30 /* Sample_AppxManifest.xml in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EEE4056820225E11007B25CE /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -323,6 +335,7 @@
 		4C14834C228F69C400EAED24 /* libmsixtest.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmsixtest.dylib; path = ../../../../.vs/msixtest/libmsixtest.dylib; sourceTree = "<group>"; };
 		4C148353228F881000EAED24 /* msixtest.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = msixtest.hpp; path = ../../../msixtest/inc/msixtest.hpp; sourceTree = "<group>"; };
 		4C14D5D32204CC2A0034C5CE /* libmsix.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmsix.dylib; path = ../../../../.vs/lib/libmsix.dylib; sourceTree = "<group>"; };
+		4CD2FBB022E2733E0059BF30 /* Sample_AppxManifest.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = Sample_AppxManifest.xml; path = ../manifest/Sample_AppxManifest.xml; sourceTree = "<group>"; };
 		EEE4054B20225CDF007B25CE /* iOSBVT.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSBVT.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EEE4054E20225CDF007B25CE /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EEE4054F20225CDF007B25CE /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -351,6 +364,7 @@
 		4C14829F228F682100EAED24 /* testData */ = {
 			isa = PBXGroup;
 			children = (
+				4CD2FBAF22E2730D0059BF30 /* manifest */,
 				4C1482A0228F682100EAED24 /* unpack */,
 			);
 			name = testData;
@@ -498,6 +512,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		4CD2FBAF22E2730D0059BF30 /* manifest */ = {
+			isa = PBXGroup;
+			children = (
+				4CD2FBB022E2733E0059BF30 /* Sample_AppxManifest.xml */,
+			);
+			name = manifest;
+			path = "New Group";
+			sourceTree = "<group>";
+		};
 		EEE4054220225CDE007B25CE = {
 			isa = PBXGroup;
 			children = (
@@ -549,6 +572,7 @@
 				4C148321228F68BC00EAED24 /* CopyFiles */,
 				4C148336228F690D00EAED24 /* CopyFiles */,
 				4C148338228F695A00EAED24 /* CopyFiles */,
+				4CD2FBB222E273560059BF30 /* CopyFiles */,
 			);
 			buildRules = (
 			);
@@ -599,6 +623,7 @@
 			files = (
 				EEE4055820225CDF007B25CE /* Assets.xcassets in Resources */,
 				EEE4055620225CDF007B25CE /* Main.storyboard in Resources */,
+				4CD2FBB122E2733E0059BF30 /* Sample_AppxManifest.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/test/msixtest/api_manifestreader.cpp
+++ b/src/test/msixtest/api_manifestreader.cpp
@@ -14,12 +14,9 @@
 // Validates IAppxManifestReader::GetStream
 TEST_CASE("Api_AppxManifestReader_Stream", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IStream> stream;
     REQUIRE_SUCCEEDED(manifestReader->GetStream(&stream));
@@ -29,12 +26,9 @@ TEST_CASE("Api_AppxManifestReader_Stream", "[api]")
 // Validates application elements in the manifest. IAppxManifestApplicationsEnumerator and IAppxManifestApplication
 TEST_CASE("Api_AppxManifestReader_Applications", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IAppxManifestApplicationsEnumerator> enumerator;
     REQUIRE_SUCCEEDED(manifestReader->GetApplications(&enumerator));
@@ -46,7 +40,7 @@ TEST_CASE("Api_AppxManifestReader_Applications", "[api]")
         MsixTest::ComPtr<IAppxManifestApplication> app;
         REQUIRE_SUCCEEDED(enumerator->GetCurrent(&app));
 
-        std::string expectedAumid = "Microsoft.ZuneVideo_8wekyb3d8bbwe!Microsoft.ZuneVideo";
+        std::string expectedAumid = "SampleAppManifest_8wekyb3d8bbwe!Mca.App";
 
         MsixTest::Wrappers::Buffer<wchar_t> aumid;
         REQUIRE_SUCCEEDED(app->GetAppUserModelId(&aumid));
@@ -71,12 +65,9 @@ TEST_CASE("Api_AppxManifestReader_Applications", "[api]")
 // Validates manifest properties. IAppxManifestPropertie and IAppxManifestPropertiesUtf8
 TEST_CASE("Api_AppxManifestReader_Properties", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IAppxManifestProperties> properties;
     MsixTest::ComPtr<IAppxManifestPropertiesUtf8> propertiesUtf8;
@@ -104,10 +95,10 @@ TEST_CASE("Api_AppxManifestReader_Properties", "[api]")
 
     std::array<std::pair<std::string, std::string>, 4> testStringValues
     { {
-        { "DisplayName", "ms-resource:IDS_MANIFEST_VIDEO_APP_NAME" },
+        { "DisplayName", "Sample app manifest" },
         { "PublisherDisplayName", "Microsoft Corporation" },
-        { "Description", "ms-resource:IDS_MANIFEST_VIDEO_APP_DESCRIPTION" },
-        { "Logo", "Assets\\Movie-TVStoreLogo.png" }
+        { "Description", "This is a sample app manifest. It is not representative of what the manifest of a typical app would look like." },
+        { "Logo", "logo.jpeg" }
     } };
 
     for (const auto& test : testStringValues)
@@ -141,12 +132,9 @@ TEST_CASE("Api_AppxManifestReader_Properties", "[api]")
 // Validates package dependencies. IAppxManifestPackageDependency and IAppxManifestPackageDependencyUtf8
 TEST_CASE("Api_AppxManifestReader_PackageDependencies", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IAppxManifestPackageDependenciesEnumerator> dependencies;
     REQUIRE_SUCCEEDED(manifestReader->GetPackageDependencies(&dependencies));
@@ -194,12 +182,9 @@ TEST_CASE("Api_AppxManifestReader_PackageDependencies", "[api]")
 // Validates manifest capabilities IAppxManifestReader::GetCapabilities
 TEST_CASE("Api_AppxManifestReader_Capabilities", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     APPX_CAPABILITIES expected = static_cast<APPX_CAPABILITIES>(
         APPX_CAPABILITY_INTERNET_CLIENT |
@@ -215,64 +200,170 @@ TEST_CASE("Api_AppxManifestReader_Capabilities", "[api]")
 // Validates manifest capabilities IAppxManifestReader::GetCapabilitiesByCapabilityClass
 TEST_CASE("Api_AppxManifestReader_GetCapabilitiesByCapabilityClass", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
     MsixTest::ComPtr<IAppxManifestReader3> manifestReader3;
     REQUIRE_SUCCEEDED(manifestReader->QueryInterface(UuidOfImpl<IAppxManifestReader3>::iid, reinterpret_cast<void**>(&manifestReader3)));
 
-    std::vector<std::string> expectedValues = 
+    std::vector<std::string> expectedValuesDefaultAndGeneral = 
     {
         "internetClient",
         "privateNetworkClientServer",
         "videosLibrary",
         "removableStorage",
-        "enterpriseDataPolicy",
-        "previewStore",
     };
 
-    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilities;
-    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_ALL, &capabilities));
-    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesUtf8;
-    REQUIRE_SUCCEEDED(capabilities->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesUtf8)));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilitiesDefault;
+    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_GENERAL, &capabilitiesDefault));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesDefaultUtf8;
+    REQUIRE_SUCCEEDED(capabilitiesDefault->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesDefaultUtf8)));
 
     BOOL hasCurrent = FALSE;
-    REQUIRE_SUCCEEDED(capabilities->GetHasCurrent(&hasCurrent));
+    REQUIRE_SUCCEEDED(capabilitiesDefault->GetHasCurrent(&hasCurrent));
     std::size_t numOfCaps = 0;
     while (hasCurrent)
     {
         MsixTest::Wrappers::Buffer<wchar_t> capability;
-        REQUIRE_SUCCEEDED(capabilities->GetCurrent(&capability));
-        REQUIRE(expectedValues[numOfCaps] == capability.ToString());
+        REQUIRE_SUCCEEDED(capabilitiesDefault->GetCurrent(&capability));
+        REQUIRE(expectedValuesDefaultAndGeneral[numOfCaps] == capability.ToString());
 
         MsixTest::Wrappers::Buffer<char> capabilityUtf8;
-        REQUIRE_SUCCEEDED(capabilitiesUtf8->GetCurrent(&capabilityUtf8));
-        REQUIRE(expectedValues[numOfCaps] == capabilityUtf8.ToString());
+        REQUIRE_SUCCEEDED(capabilitiesDefaultUtf8->GetCurrent(&capabilityUtf8));
+        REQUIRE(expectedValuesDefaultAndGeneral[numOfCaps] == capabilityUtf8.ToString());
 
-        REQUIRE_SUCCEEDED(capabilities->MoveNext(&hasCurrent));
+        REQUIRE_SUCCEEDED(capabilitiesDefault->MoveNext(&hasCurrent));
         numOfCaps++;
     }
-    REQUIRE(expectedValues.size() == numOfCaps);
+    REQUIRE(expectedValuesDefaultAndGeneral.size() == numOfCaps);
+
+    std::vector<std::string> expectedValuesRestricted = 
+    {
+        "enterpriseDataPolicy",
+        "previewStore",
+    };
+
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilitiesRestricted;
+    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_RESTRICTED, &capabilitiesRestricted));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesRestrictedUtf8;
+    REQUIRE_SUCCEEDED(capabilitiesRestricted->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesRestrictedUtf8)));
+
+    hasCurrent = FALSE;
+    REQUIRE_SUCCEEDED(capabilitiesRestricted->GetHasCurrent(&hasCurrent));
+    numOfCaps = 0;
+    while (hasCurrent)
+    {
+        MsixTest::Wrappers::Buffer<wchar_t> capability;
+        REQUIRE_SUCCEEDED(capabilitiesRestricted->GetCurrent(&capability));
+        REQUIRE(expectedValuesRestricted[numOfCaps] == capability.ToString());
+
+        MsixTest::Wrappers::Buffer<char> capabilityUtf8;
+        REQUIRE_SUCCEEDED(capabilitiesRestrictedUtf8->GetCurrent(&capabilityUtf8));
+        REQUIRE(expectedValuesRestricted[numOfCaps] == capabilityUtf8.ToString());
+
+        REQUIRE_SUCCEEDED(capabilitiesRestricted->MoveNext(&hasCurrent));
+        numOfCaps++;
+    }
+    REQUIRE(expectedValuesRestricted.size() == numOfCaps);
+
+    std::vector<std::string> expectedValuesWindows = 
+    {
+        "shellExperience",
+    };
+
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilitiesWindows;
+    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_WINDOWS, &capabilitiesWindows));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesWindowsUtf8;
+    REQUIRE_SUCCEEDED(capabilitiesWindows->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesWindowsUtf8)));
+
+    hasCurrent = FALSE;
+    REQUIRE_SUCCEEDED(capabilitiesWindows->GetHasCurrent(&hasCurrent));
+    numOfCaps = 0;
+    while (hasCurrent)
+    {
+        MsixTest::Wrappers::Buffer<wchar_t> capability;
+        REQUIRE_SUCCEEDED(capabilitiesWindows->GetCurrent(&capability));
+        REQUIRE(expectedValuesWindows[numOfCaps] == capability.ToString());
+
+        MsixTest::Wrappers::Buffer<char> capabilityUtf8;
+        REQUIRE_SUCCEEDED(capabilitiesWindowsUtf8->GetCurrent(&capabilityUtf8));
+        REQUIRE(expectedValuesWindows[numOfCaps] == capabilityUtf8.ToString());
+
+        REQUIRE_SUCCEEDED(capabilitiesWindows->MoveNext(&hasCurrent));
+        numOfCaps++;
+    }
+    REQUIRE(expectedValuesWindows.size() == numOfCaps);
+
+    std::vector<std::string> expectedValuesCustom = 
+    {
+        "fabrikam.CustomCap_5w7kyb3d8bbwe",
+    };
+
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilitiesCustom;
+    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_CUSTOM, &capabilitiesCustom));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesCustomUtf8;
+    REQUIRE_SUCCEEDED(capabilitiesCustom->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesCustomUtf8)));
+
+    hasCurrent = FALSE;
+    REQUIRE_SUCCEEDED(capabilitiesCustom->GetHasCurrent(&hasCurrent));
+    numOfCaps = 0;
+    while (hasCurrent)
+    {
+        MsixTest::Wrappers::Buffer<wchar_t> capability;
+        REQUIRE_SUCCEEDED(capabilitiesCustom->GetCurrent(&capability));
+        REQUIRE(expectedValuesCustom[numOfCaps] == capability.ToString());
+
+        MsixTest::Wrappers::Buffer<char> capabilityUtf8;
+        REQUIRE_SUCCEEDED(capabilitiesCustomUtf8->GetCurrent(&capabilityUtf8));
+        REQUIRE(expectedValuesCustom[numOfCaps] == capabilityUtf8.ToString());
+
+        REQUIRE_SUCCEEDED(capabilitiesCustom->MoveNext(&hasCurrent));
+        numOfCaps++;
+    }
+    REQUIRE(expectedValuesCustom.size() == numOfCaps);
+
+    std::vector<std::string> expectedAll;
+    expectedAll.insert(expectedAll.end(), expectedValuesDefaultAndGeneral.begin(), expectedValuesDefaultAndGeneral.end());
+    expectedAll.insert(expectedAll.end(), expectedValuesWindows.begin(), expectedValuesWindows.end());
+    expectedAll.insert(expectedAll.end(), expectedValuesRestricted.begin(), expectedValuesRestricted.end());
+    expectedAll.insert(expectedAll.end(), expectedValuesCustom.begin(), expectedValuesCustom.end());
+
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumerator> capabilitiesAll;
+    REQUIRE_SUCCEEDED(manifestReader3->GetCapabilitiesByCapabilityClass(APPX_CAPABILITY_CLASS_ALL, &capabilitiesAll));
+    MsixTest::ComPtr<IAppxManifestCapabilitiesEnumeratorUtf8> capabilitiesAllUtf8;
+    REQUIRE_SUCCEEDED(capabilitiesAll->QueryInterface(UuidOfImpl<IAppxManifestCapabilitiesEnumeratorUtf8>::iid, reinterpret_cast<void**>(&capabilitiesAllUtf8)));
+
+    hasCurrent = FALSE;
+    REQUIRE_SUCCEEDED(capabilitiesAll->GetHasCurrent(&hasCurrent));
+    numOfCaps = 0;
+    while (hasCurrent)
+    {
+        MsixTest::Wrappers::Buffer<wchar_t> capability;
+        REQUIRE_SUCCEEDED(capabilitiesAll->GetCurrent(&capability));
+        REQUIRE(expectedAll[numOfCaps] == capability.ToString());
+
+        MsixTest::Wrappers::Buffer<char> capabilityUtf8;
+        REQUIRE_SUCCEEDED(capabilitiesAllUtf8->GetCurrent(&capabilityUtf8));
+        REQUIRE(expectedAll[numOfCaps] == capabilityUtf8.ToString());
+
+        REQUIRE_SUCCEEDED(capabilitiesAll->MoveNext(&hasCurrent));
+        numOfCaps++;
+    }
+    REQUIRE(expectedAll.size() == numOfCaps);
+
 }
 
 // Validates manifest resources. IAppxManifestResourcesEnumerator and IAppxManifestResourcesEnumeratorUtf8
 TEST_CASE("Api_AppxManifestReader_Resources", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
-    std::array<std::string, 3> expectedResources =
+    std::array<std::string, 2> expectedResources =
     {
-        "en",
-        "en-US",
-        "en-GB"
+        "en-us",
+        "es-mx",
     };
 
     MsixTest::ComPtr<IAppxManifestResourcesEnumerator> resources;
@@ -302,12 +393,9 @@ TEST_CASE("Api_AppxManifestReader_Resources", "[api]")
 // Validates manifest target family devices. IAppxManifestTargetDeviceFamily and IAppxManifestTargetDeviceFamilyUtf8
 TEST_CASE("Api_AppxManifestReader_Tdf", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IAppxManifestReader3> manifestReader3;
     REQUIRE_SUCCEEDED(manifestReader->QueryInterface(UuidOfImpl<IAppxManifestReader3>::iid, reinterpret_cast<void**>(&manifestReader3)));
@@ -351,12 +439,9 @@ TEST_CASE("Api_AppxManifestReader_Tdf", "[api]")
 // "Validates IMsixDocumentElement, IMsixElement and IMsixElementEnumerator"
 TEST_CASE("Api_AppxManifestReader_MsixDocument", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IMsixDocumentElement> msixDocument;
     REQUIRE_SUCCEEDED(manifestReader->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&msixDocument)));
@@ -429,12 +514,9 @@ TEST_CASE("Api_AppxManifestReader_MsixDocument", "[api]")
 
 TEST_CASE("Api_AppxManifestReader_PackageId", "[api]")
 {
-    std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(package, &packageReader);
+    std::string manifest = "Sample_AppxManifest.xml";
     MsixTest::ComPtr<IAppxManifestReader> manifestReader;
-    REQUIRE_SUCCEEDED(packageReader->GetManifest(&manifestReader));
-    REQUIRE_NOT_NULL(manifestReader.Get());
+    MsixTest::InitializeManifestReader(manifest, &manifestReader);
 
     MsixTest::ComPtr<IAppxManifestPackageId> packageId;
     REQUIRE_SUCCEEDED(manifestReader->GetPackageId(&packageId));
@@ -443,7 +525,7 @@ TEST_CASE("Api_AppxManifestReader_PackageId", "[api]")
     MsixTest::ComPtr<IAppxManifestPackageIdUtf8> packageIdUtf8;
     REQUIRE_SUCCEEDED(packageId->QueryInterface(UuidOfImpl<IAppxManifestPackageIdUtf8>::iid, reinterpret_cast<void**>(&packageIdUtf8)));
 
-    std::string expectedName = "Microsoft.ZuneVideo";
+    std::string expectedName = "SampleAppManifest";
     MsixTest::Wrappers::Buffer<wchar_t> name;
     REQUIRE_SUCCEEDED(packageId->GetName(&name));
     REQUIRE(expectedName == name.ToString());
@@ -480,11 +562,12 @@ TEST_CASE("Api_AppxManifestReader_PackageId", "[api]")
     REQUIRE_SUCCEEDED(packageId->GetVersion(&packageVersion));
     REQUIRE(expectedVersion == packageVersion);
 
+    std::string expectedResourceId = "NorthAmerica";
     MsixTest::Wrappers::Buffer<wchar_t> resourceId;
     REQUIRE_SUCCEEDED(packageId->GetResourceId(&resourceId));
-    REQUIRE(resourceId.Get() == nullptr);
+    REQUIRE(expectedResourceId == resourceId.ToString());
 
-    std::string expectedFull = "Microsoft.ZuneVideo_3.6.25071.0_x64__8wekyb3d8bbwe";
+    std::string expectedFull = "SampleAppManifest_3.6.25071.0_x64_NorthAmerica_8wekyb3d8bbwe";
     MsixTest::Wrappers::Buffer<wchar_t> packageFullName;
     REQUIRE_SUCCEEDED(packageId->GetPackageFullName(&packageFullName));
     REQUIRE(expectedFull == packageFullName.ToString());
@@ -493,7 +576,7 @@ TEST_CASE("Api_AppxManifestReader_PackageId", "[api]")
     REQUIRE_SUCCEEDED(packageIdUtf8->GetPackageFullName(&packageFullNameUtf8));
     REQUIRE(expectedFull == packageFullNameUtf8.ToString());
 
-    std::string expectedFamily = "Microsoft.ZuneVideo_8wekyb3d8bbwe";
+    std::string expectedFamily = "SampleAppManifest_8wekyb3d8bbwe";
     MsixTest::Wrappers::Buffer<wchar_t> packageFamilyName;
     REQUIRE_SUCCEEDED(packageId->GetPackageFamilyName(&packageFamilyName));
     REQUIRE(expectedFamily == packageFamilyName.ToString());

--- a/src/test/msixtest/api_manifestreader.cpp
+++ b/src/test/msixtest/api_manifestreader.cpp
@@ -192,10 +192,7 @@ TEST_CASE("Api_AppxManifestReader_PackageDependencies", "[api]")
 }
 
 // Validates manifest capabilities IAppxManifestReader::GetCapabilities
-// NOTE: There's currently a bug in non-windows devices were we only return
-// the elements that doesn't the same namespace as the xmlns of the manifest.
-// TODO: fix...
-TEST_CASE("Api_AppxManifestReader_Capabilities", "[api][!hide]")
+TEST_CASE("Api_AppxManifestReader_Capabilities", "[api]")
 {
     std::string package = "StoreSigned_Desktop_x64_MoviesTV.appx";
     MsixTest::ComPtr<IAppxPackageReader> packageReader;

--- a/src/test/msixtest/inc/msixtest_int.hpp
+++ b/src/test/msixtest/inc/msixtest_int.hpp
@@ -26,7 +26,8 @@ namespace MsixTest {
             Unbundle,
             Flat,
             BadFlat,
-            Pack
+            Pack,
+            Manifest,
         } Directory;
 
         static TestPath* GetInstance();
@@ -113,6 +114,7 @@ namespace MsixTest {
     void InitializePackageReader(const std::string& package, IAppxPackageReader** packageReader);
     void InitializePackageReader(IStream* stream, IAppxPackageReader** packageReader);
     void InitializeBundleReader(const std::string& package, IAppxBundleReader** bundleReader);
+    void InitializeManifestReader(const std::string& manifest, IAppxManifestReader** manifestReader);
 
     template <class T>
     class ComPtr

--- a/src/test/msixtest/msixtest.cpp
+++ b/src/test/msixtest/msixtest.cpp
@@ -56,6 +56,8 @@ namespace MsixTest {
                 return m_root + "testData/unpack/badFlat";
             case Pack:
                 return m_root + "testData/pack";
+            case Manifest:
+                return m_root + "testData/manifest";
         }
         return {};
     }
@@ -162,6 +164,19 @@ namespace MsixTest {
         REQUIRE_SUCCEEDED(bundleFactory->CreateBundleReader(inputStream.Get(), bundleReader));
         REQUIRE_NOT_NULL(*bundleReader);
         return;
+    }
+
+    void InitializeManifestReader(const std::string& manifest, IAppxManifestReader** manifestReader)
+    {
+        *manifestReader = nullptr;
+
+        auto manifestPath = TestPath::GetInstance()->GetPath(TestPath::Directory::Manifest) + "/" + manifest;
+        auto inputStream = StreamFile(manifestPath, true);
+
+        ComPtr<IAppxFactory> factory;
+        REQUIRE_SUCCEEDED(CoCreateAppxFactoryWithHeap(Allocators::Allocate, Allocators::Free, MSIX_VALIDATION_OPTION_SKIPSIGNATURE, &factory));
+        REQUIRE_SUCCEEDED(factory->CreateManifestReader(inputStream.Get(), manifestReader));
+        REQUIRE_NOT_NULL(*manifestReader);
     }
 
     StreamFile::StreamFile(std::string fileName, bool toRead, bool toDelete): m_toDelete(toDelete)

--- a/src/test/testData/manifest/Sample_AppxManifest.xml
+++ b/src/test/testData/manifest/Sample_AppxManifest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+         xmlns:f2="http://schemas.microsoft.com/appx/manifest/foundation/windows10/2"
+         xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
+         xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+         xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
+         xmlns:wincap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities"
+         xmlns:wincap2="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/2"
+         xmlns:wincap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"
+         xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+         xmlns:rescap2="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/2"
+         xmlns:rescap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"
+         xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
+         xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+         xmlns:mobile="http://schemas.microsoft.com/appx/manifest/mobile/windows10"
+         xmlns:iot="http://schemas.microsoft.com/appx/manifest/iot/windows10"
+         xmlns:holo="http://schemas.microsoft.com/appx/manifest/holographic/windows10"
+         xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+         IgnorableNamespaces="f f2 uap uap2 uap3 uap4 wincap wincap2 wincap3 rescap rescap2 rescap3 desktop desktop2 mobile iot holo com">
+
+  <Identity Name="SampleAppManifest"
+            ProcessorArchitecture="x64"
+            Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"
+            Version="3.6.25071.0"
+            ResourceId="NorthAmerica" />
+  <Properties>
+    <DisplayName>Sample app manifest</DisplayName>
+    <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+    <Description>This is a sample app manifest. It is not representative of what the manifest of a typical app would look like.</Description>
+    <Logo>logo.jpeg</Logo>
+  </Properties>
+
+  <Resources>
+    <Resource Language="en-us"/>
+    <Resource Language="es-mx"/>
+  </Resources>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.10240.0" MaxVersionTested="10.0.14300.0"/>
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="14.0.0.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US"/>
+  </Dependencies>
+
+  <Capabilities>
+    <Capability Name="internetClient"/>
+    <Capability Name="privateNetworkClientServer"/>
+    <uap:Capability Name="videosLibrary"/>
+    <uap:Capability Name="removableStorage"/>
+    <wincap:Capability Name="shellExperience"/>
+    <rescap:Capability Name="enterpriseDataPolicy"/>
+    <rescap:Capability Name="previewStore"/>
+    <uap4:CustomCapability Name="fabrikam.CustomCap_5w7kyb3d8bbwe"/>
+  </Capabilities>
+
+  <Applications>
+    <Application Id="Mca.App" Executable="MyMcaApp.exe" EntryPoint="Windows.FullTrustApplication" ResourceGroup="defaultGroup">
+
+      <uap:VisualElements DisplayName="App1" Square150x150Logo="images/150x150.png" Square44x44Logo="images/44x44.png" Description="App1" BackgroundColor="#777777" AppListEntry="default">
+        <uap:SplashScreen BackgroundColor="#777777" Image="images/splash.png"/>
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Extensions>
+    <Extension Category="windows.activatableClass.inProcessServer">
+      <InProcessServer>
+        <Path>EntPlat.dll</Path>
+        <ActivatableClass ActivatableClassId="Microsoft.Entertainment.Application.Application" ThreadingModel="both"/>
+        <ActivatableClass ActivatableClassId="Microsoft.Entertainment.Application.ApplicationStatics" ThreadingModel="both"/>
+      </InProcessServer>
+    </Extension>
+    <Extension Category="windows.activatableClass.inProcessServer">
+      <InProcessServer>
+        <Path>EntCommon.dll</Path>
+        <ActivatableClass ActivatableClassId="Microsoft.Entertainment.Common.Infrastructure.NetworkService" ThreadingModel="both"/>
+      </InProcessServer>
+    </Extension>
+    <Extension Category="windows.activatableClass.proxyStub">
+        <ProxyStub ClassId="FB06B882-46B8-4625-B239-AF768C8477E3">
+            <Path>entplat.dll</Path>
+            <Interface Name="Microsoft.Entertainment.Interop.ICallbackInvoker" InterfaceId="A2082232-0E67-42E1-8214-1BE73406F067"/>
+        </ProxyStub>
+    </Extension>
+  </Extensions>
+</Package>


### PR DESCRIPTION
We failed obtaining all the elements under different namespaces for Xerces, MacOS and iOS.

For example, from the xml below, we didn't get the elements that are under uap and rescap namespace.
```
<Capabilities>
  <Capability Name="internetClient"/>
  <Capability Name="privateNetworkClientServer"/>
  <uap:Capability Name="videosLibrary"/>
  <uap:Capability Name="removableStorage"/>
  <rescap:Capability Name="enterpriseDataPolicy"/>
  <rescap:Capability Name="previewStore"/>
</Capabilities>
```

For Xerces, stop using Xerces's xpath as it doesn't support getting all namespaces and walk through the elements via getElementsByTagNameNS using namespaceURI "*" that matches all namespaces. We need to turn-on setDoNamespaces, even for non-validation parser.

For Apple parser, didStartElement always had namespaceURI  and qualifiedName empty, so we need to parse the name and get rid of the namespace is present.

Turn on test Api_AppxManifestReader_Capabilities for all platforms, which validates this scenario.

Also, updated gradle properties for the Android BVTs as I had problems building it locally.