### PR TITLE
Isolate MSIX SDK build directory from other projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,14 @@ set(VERSION_MINOR "0")
 set(VERSION_PATCH "0")
 set(GIT_BRANCH_NAME "master")
 
+# CMake useful variables
+set(MSIX_PROJECT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+set(MSIX_BINARY_ROOT ${CMAKE_CURRENT_BINARY_DIR})
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
+
 ## Git (and its revision)
 find_package(Git) # QUIET) # if we don't find git or FindGit.cmake is not on the system we ignore it.
 
@@ -166,16 +174,6 @@ elseif(AOSP OR LINUX)
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif()
 
-# CMake useful variables
-set(CMAKE_PROJECT_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/lib")
-
-# Create a bin directory for samples and msixtest to be self contained
-set(MSIX_SAMPLE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/samples")
-set(MSIX_TEST_OUTPUT_DIRECTORY   "${CMAKE_CURRENT_BINARY_DIR}/msixtest")
-
 # Mac needed variables
 # [TODO: adapt as needed]
 set(CMAKE_MACOSX_RPATH ON)
@@ -188,8 +186,6 @@ add_subdirectory(lib)
 message(STATUS "libs processed")
 add_subdirectory(src)
 message(STATUS "src processed")
-ADD_DEPENDENCIES(SRC LIBS)
-message(STATUS "dependencies added")
 add_subdirectory(sample)
 message(STATUS "sample processed")
 message(STATUS "DONE!")

--- a/cmake/msix_resources.cmake
+++ b/cmake/msix_resources.cmake
@@ -11,7 +11,7 @@ set(RESOURCES_APPXTYPES)
 set(RESOURCES_APPXMANIFEST)
 set(RESOURCES_APPXBUNDLEMANIFEST)
 
-set(RESOURCES_DIR "${CMAKE_PROJECT_ROOT}/resources")
+set(RESOURCES_DIR "${MSIX_PROJECT_ROOT}/resources")
 
 if(CRYPTO_LIB MATCHES openssl) # Only OpenSSL needs to carry the certificates.
     list(APPEND RESOURCES_CERTS
@@ -339,5 +339,5 @@ foreach(FILE ${RESOURCES_CERTS})
     string(APPEND CERTS_HPP result.push_back(std::make_pair(\"${FILE}\", std::move(factory->GetResource(\"${FILE}\")))) ";\n\t\t\t\t")
 endforeach()
 
-configure_file(${CMAKE_PROJECT_ROOT}/src/inc/MSIXResource.hpp.cmakein ${CMAKE_PROJECT_ROOT}/src/inc/MSIXResource.hpp CRLF)
-configure_file(${CMAKE_PROJECT_ROOT}/src/msix/common/MSIXResource.cpp.cmakein ${CMAKE_PROJECT_ROOT}/src/msix/common/MSIXResource.cpp CRLF)
+configure_file(${MSIX_PROJECT_ROOT}/src/inc/MSIXResource.hpp.cmakein ${MSIX_PROJECT_ROOT}/src/inc/MSIXResource.hpp CRLF)
+configure_file(${MSIX_PROJECT_ROOT}/src/msix/common/MSIXResource.cpp.cmakein ${MSIX_PROJECT_ROOT}/src/msix/common/MSIXResource.cpp CRLF)

--- a/sample/BundleSample/CMakeLists.txt
+++ b/sample/BundleSample/CMakeLists.txt
@@ -6,7 +6,7 @@ project (BundleSample)
 
 if(WIN32)
     set(DESCRIPTION "BundleSample manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest)
 endif()
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -3,15 +3,22 @@
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 
+# For windows copy the library to the msix and samples directory
+if(WIN32)
+    add_custom_target(samples ALL
+        COMMAND ${CMAKE_COMMAND} -E copy "bin/msix.dll" "samples/msix.dll"
+        WORKING_DIRECTORY "${MSIX_BINARY_ROOT}"
+        DEPENDS msix)
+else()
+    add_custom_target(samples ALL DEPENDS msix)
+endif()
+
+set(MSIX_SAMPLE_OUTPUT_DIRECTORY "${MSIX_BINARY_ROOT}/samples")
+
 add_subdirectory(ExtractContentsSample)
 add_subdirectory(BundleSample)
 add_subdirectory(OverrideStreamSample)
 add_subdirectory(OverrideLanguageSample)
-
-add_dependencies(ExtractContentsSample msix)
-add_dependencies(BundleSample msix)
-add_dependencies(OverrideStreamSample msix)
-add_dependencies(OverrideLanguageSample msix)
 
 if (MSIX_PACK)
     add_subdirectory(PackSample)

--- a/sample/ExtractContentsSample/CMakeLists.txt
+++ b/sample/ExtractContentsSample/CMakeLists.txt
@@ -6,7 +6,7 @@ project (ExtractContentsSample)
 
 if(WIN32)
     set(DESCRIPTION "ExtractContentsSample manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest)
 endif()
 

--- a/sample/OverrideLanguageSample/CMakeLists.txt
+++ b/sample/OverrideLanguageSample/CMakeLists.txt
@@ -6,7 +6,7 @@ project (OverrideLanguageSample)
 
 if(WIN32)
     set(DESCRIPTION "OverrideLanguageSample manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest)
 endif()
 

--- a/sample/OverrideStreamSample/CMakeLists.txt
+++ b/sample/OverrideStreamSample/CMakeLists.txt
@@ -6,7 +6,7 @@ project (OverrideStreamSample)
 
 if(WIN32)
     set(DESCRIPTION "OverrideStreamSample manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${MSIX_SAMPLE_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest)
 endif()
 

--- a/sample/PackSample/CMakeLists.txt
+++ b/sample/PackSample/CMakeLists.txt
@@ -9,7 +9,7 @@ set(BINARY_NAME PackSample)
 
 if(WIN32)
     set(DESCRIPTION "PackSample manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${CMAKE_CURRENT_BINARY_DIR}/${BINARY_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${CMAKE_CURRENT_BINARY_DIR}/${BINARY_NAME}.exe.manifest CRLF)
     set(MANIFEST ${CMAKE_CURRENT_BINARY_DIR}/${BINARY_NAME}.exe.manifest)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # See LICENSE file in the project root for full license information.
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
-add_custom_target(SRC)
+
 add_subdirectory(msix)
 add_subdirectory(makemsix)
 add_subdirectory(test)

--- a/src/makemsix/CMakeLists.txt
+++ b/src/makemsix/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 if(WIN32)
     set(DESCRIPTION "makemsix manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.exe.manifest)
 endif()
 

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -219,6 +219,9 @@ add_library(${PROJECT_NAME} SHARED
     ${MsixSrc}
 )
 
+# Adding dependency to the third party libs directory
+add_dependencies(${PROJECT_NAME} LIBS)
+
 # Copy out public headers to <binary dir>/src/unpack
 configure_file(../inc/MSIXWindows.hpp   ${CMAKE_CURRENT_BINARY_DIR}/MSIXWindows.hpp  )
 configure_file(../inc/AppxPackaging.hpp ${CMAKE_CURRENT_BINARY_DIR}/AppxPackaging.hpp)
@@ -226,7 +229,7 @@ configure_file(../inc/MsixErrors.hpp ${CMAKE_CURRENT_BINARY_DIR}/MsixErrors.hpp)
 
 # Linker and includes
 # Include MSIX headers
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_ROOT}/src/inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_PROJECT_ROOT}/src/inc)
 
 if(WIN32)
     string(REPLACE "/GR" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
@@ -270,7 +273,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 # Compression
 if(((IOS) OR (MACOS)) AND (NOT USE_MSIX_SDK_ZLIB))
     # for macos and ios use the inbox libcompression zlib apis instead of zlib, unless zlib is explicitly requested.
-    target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_ROOT}/src/msix/PAL/DataCompression/Apple)
+    target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_PROJECT_ROOT}/src/msix/PAL/DataCompression/Apple)
     target_link_libraries(${PROJECT_NAME} PRIVATE libcompression.dylib)
 elseif((AOSP) AND (NOT USE_MSIX_SDK_ZLIB))
     # for AOSP, use the libz.so from the android ndk.
@@ -279,8 +282,8 @@ elseif((AOSP) AND (NOT USE_MSIX_SDK_ZLIB))
 else() # WIN32 or USE_MSIX_SDK_ZLIB
     target_include_directories(${PROJECT_NAME} PRIVATE 
             ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/zlib
-            ${CMAKE_PROJECT_ROOT}/lib/zlib
-            ${CMAKE_PROJECT_ROOT}/src/msix/PAL/DataCompression/Zlib
+            ${MSIX_PROJECT_ROOT}/lib/zlib
+            ${MSIX_PROJECT_ROOT}/src/msix/PAL/DataCompression/Zlib
         )
     if(USE_SHARED_ZLIB)
         message(STATUS "MSIX takes a dynamic dependency on zlib")
@@ -295,7 +298,7 @@ endif()
 if(XML_PARSER MATCHES xerces)
     target_include_directories(${PROJECT_NAME} PRIVATE
         ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/xerces/src
-        ${CMAKE_PROJECT_ROOT}/lib/xerces/src
+        ${MSIX_PROJECT_ROOT}/lib/xerces/src
     )
     target_link_libraries(${PROJECT_NAME} PRIVATE xerces-c)
 endif()
@@ -367,14 +370,4 @@ if(OpenSSL_FOUND)
     else()
         target_link_libraries(${PROJECT_NAME} PRIVATE crypto)
     endif()
-endif()
-
-# For windows copy the library to the msix and samples directory
-if(WIN32)
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "bin/${PROJECT_NAME}.dll" "msixtest/${PROJECT_NAME}.dll"
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "bin/${PROJECT_NAME}.dll" "samples/${PROJECT_NAME}.dll"
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 
+set(MSIX_TEST_OUTPUT_DIRECTORY "${MSIX_BINARY_ROOT}/msixtest")
+
 # Copy the test packages to the test output directory to don't have to use
 # ..\..\src\test\testData\<path>
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/testData" DESTINATION "${MSIX_TEST_OUTPUT_DIRECTORY}")

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -7,7 +7,7 @@ project (msixtest)
 
 if(WIN32)
     set(DESCRIPTION "msixtest manifest")
-    configure_file(${CMAKE_PROJECT_ROOT}/manifest.cmakein ${MSIX_TEST_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
+    configure_file(${MSIX_PROJECT_ROOT}/manifest.cmakein ${MSIX_TEST_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest CRLF)
     set(MANIFEST ${MSIX_TEST_OUTPUT_DIRECTORY}/${PROJECT_NAME}.exe.manifest)
     if(XML_PARSER MATCHES msxml6)
         add_definitions(-DMSIX_MSXML6=1)
@@ -81,7 +81,7 @@ else()
         )
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ${CMAKE_PROJECT_ROOT}/lib/catch2 ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ${MSIX_PROJECT_ROOT}/lib/catch2 ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
 # Output test binaries into a test directory
 set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -92,3 +92,10 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 
 add_dependencies(${PROJECT_NAME} msix)
 target_link_libraries(${PROJECT_NAME} msix)
+
+# For windows copy the library
+if(WIN32)
+    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy "bin/msix.dll" "msixtest/msix.dll"
+        WORKING_DIRECTORY "${MSIX_BINARY_ROOT}")
+endif()


### PR DESCRIPTION
Using CMAKE_BINARY_DIR makes the copies the msix.dll binary, for the test and samples output directory, in the wrong location when this project is added as a submodule/subtree

This fix sets MSIX_PROJECT_ROOT and MSIX_BINARY_ROOT to the correct project and binary directories in the top level CMakeLists.txt and use them instead of CMAKE_PROJECT_ROOT and CMAKE_BINARY_DIR  respectively across the entire project.

Also, moved copying msix.dll to <build dir>/samples and <build dir>/msixtest from src/msix/CMakeLists.txt to the CMakeLists.txt for tests and samples.