### PR TITLE
Bug: Close installer window after launching app when launch checkbox is unchecked

### DIFF
--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -116,6 +116,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         case IDC_LAUNCHBUTTON:
         {
             ui->LaunchInstalledApp();
+            ui->CloseUI();
             break;
         }
         }


### PR DESCRIPTION
When launch checkbox is unchecked after clicking on install button, the app should launch and the installer window should close.