### PR TITLE
Use MSIX_BINARY_ROOT instead of CMAKE_BINARY_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE file in the project root for full license information.
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+project(msix-sdk)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 message(STATUS "--------------------------------")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,14 +98,14 @@ else()
     set(MSIX_NUGET_NAME "Microsoft.MSIX.Packaging.Linux")
 endif()
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Package.nuspec.cmakein ${CMAKE_CURRENT_BINARY_DIR}/Package.nuspec CRLF)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Microsoft.MSIX.Packaging.targets ${CMAKE_BINARY_DIR}/build/native/${MSIX_NUGET_NAME}.targets)
+configure_file(${MSIX_PROJECT_ROOT}/Package.nuspec.cmakein ${MSIX_BINARY_ROOT}/Package.nuspec CRLF)
+configure_file(${MSIX_PROJECT_ROOT}/Microsoft.MSIX.Packaging.targets ${MSIX_BINARY_ROOT}/build/native/${MSIX_NUGET_NAME}.targets)
 message(STATUS "Package.Nuspec created")
 message(STATUS "--------------------------------")
 
 # Configure license txt
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/LICENSE ${CMAKE_BINARY_DIR}/build/LICENSE)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/THIRD\ PARTY\ CODE\ NOTICE ${CMAKE_BINARY_DIR}/build/THIRD\ PARTY\ CODE\ NOTICE)
+configure_file(${MSIX_PROJECT_ROOT}/LICENSE ${MSIX_BINARY_ROOT}/build/LICENSE)
+configure_file(${MSIX_PROJECT_ROOT}/THIRD\ PARTY\ CODE\ NOTICE ${MSIX_BINARY_ROOT}/build/THIRD\ PARTY\ CODE\ NOTICE)
 message(STATUS "LICENSE created")
 message(STATUS "--------------------------------")
 
@@ -120,7 +120,7 @@ list(APPEND CERTS_TO_PUBLISH
     Microsoft_MarketPlace_PCA_2011.cer
 )
 foreach(CERT_TO_PUBLISH ${CERTS_TO_PUBLISH})
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resources/certs/${CERT_TO_PUBLISH} ${CMAKE_BINARY_DIR}/build/certs/${CERT_TO_PUBLISH})
+    configure_file(${MSIX_PROJECT_ROOT}/resources/certs/${CERT_TO_PUBLISH} ${MSIX_BINARY_ROOT}/build/certs/${CERT_TO_PUBLISH})
 endforeach()
 message(STATUS "Certificates published")
 message(STATUS "--------------------------------")

--- a/cmake/msix_resources.cmake
+++ b/cmake/msix_resources.cmake
@@ -308,12 +308,12 @@ foreach(FILE ${RESOURCES_CERTS})
 endforeach()
 
 execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar cvf "${CMAKE_BINARY_DIR}/resources.zip" --format=zip -- ${FILES_TO_ZIP}
+    COMMAND ${CMAKE_COMMAND} -E tar cvf "${MSIX_BINARY_ROOT}/resources.zip" --format=zip -- ${FILES_TO_ZIP}
     WORKING_DIRECTORY "${RESOURCES_DIR}"
     OUTPUT_QUIET
 )
 
-file(READ "${CMAKE_BINARY_DIR}/resources.zip" RESOURCE_HEX HEX)
+file(READ "${MSIX_BINARY_ROOT}/resources.zip" RESOURCE_HEX HEX)
 # Create a list by matching every 2 charactes. CMake separates lists with ;
 string(REGEX MATCHALL ".." RESOURCE_HEX_LIST "${RESOURCE_HEX}")
 list(LENGTH RESOURCE_HEX_LIST RESOURCE_LENGTH)

--- a/sample/BundleSample/CMakeLists.txt
+++ b/sample/BundleSample/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(${PROJECT_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ../inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ../inc)
 
 target_link_libraries(${PROJECT_NAME} msix)
 

--- a/sample/ExtractContentsSample/CMakeLists.txt
+++ b/sample/ExtractContentsSample/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(${PROJECT_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ../inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ../inc)
 
 target_link_libraries(${PROJECT_NAME} msix)
 

--- a/sample/OverrideLanguageSample/CMakeLists.txt
+++ b/sample/OverrideLanguageSample/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(${PROJECT_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ../inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ../inc)
 
 if (LINUX OR AOSP)
     target_link_libraries(${PROJECT_NAME} PRIVATE -latomic)

--- a/sample/OverrideStreamSample/CMakeLists.txt
+++ b/sample/OverrideStreamSample/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(${PROJECT_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ../inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ../inc)
 
 if (LINUX OR AOSP)
     target_link_libraries(${PROJECT_NAME} PRIVATE -latomic)

--- a/sample/PackSample/CMakeLists.txt
+++ b/sample/PackSample/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${BINARY_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${BINARY_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ../inc)
+target_include_directories(${BINARY_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ../inc)
 
 add_dependencies(${BINARY_NAME} msix)
 target_link_libraries(${BINARY_NAME} PUBLIC msix)

--- a/src/makemsix/CMakeLists.txt
+++ b/src/makemsix/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(${PROJECT_NAME}
     ${MANIFEST}
     )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix)
 
 add_dependencies(${PROJECT_NAME} msix)
 target_link_libraries(${PROJECT_NAME} msix)

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -147,6 +147,7 @@ if(NOT SKIP_BUNDLES)
 endif()
 
 # Compression option
+
 if(((IOS) OR (MACOS)) AND (NOT USE_MSIX_SDK_ZLIB))
     list(APPEND MsixSrc PAL/DataCompression/Apple/CompressionObject.cpp)
 else()
@@ -283,7 +284,6 @@ else() # WIN32 or USE_MSIX_SDK_ZLIB
     target_include_directories(${PROJECT_NAME} PRIVATE 
             ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/zlib
             ${MSIX_PROJECT_ROOT}/lib/zlib
-            ${MSIX_PROJECT_ROOT}/src/msix/PAL/DataCompression/Zlib
         )
     if(USE_SHARED_ZLIB)
         message(STATUS "MSIX takes a dynamic dependency on zlib")

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -147,7 +147,6 @@ if(NOT SKIP_BUNDLES)
 endif()
 
 # Compression option
-
 if(((IOS) OR (MACOS)) AND (NOT USE_MSIX_SDK_ZLIB))
     list(APPEND MsixSrc PAL/DataCompression/Apple/CompressionObject.cpp)
 else()

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -81,7 +81,7 @@ else()
         )
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_BINARY_DIR}/src/msix ${MSIX_PROJECT_ROOT}/lib/catch2 ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_BINARY_ROOT}/src/msix ${MSIX_PROJECT_ROOT}/lib/catch2 ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 
 # Output test binaries into a test directory
 set_target_properties(${PROJECT_NAME} PROPERTIES


### PR DESCRIPTION
makemsix, msixtest and samples include the headers the sdk publishs via ${CMAKE_BINARY_DIR}/src/msix. When this project is added as a submodule, CMAKE_BINARY_DIR points to the root binary location which is not were the headers are published. This changes uses MSIX_BINARY_ROOT instead of CMAKE_BINARY_DIR to resolve this. 

Also, remove extra include that isn't needed and output the resource zip to MSIX_BINARY_ROOT