### PR TITLE
Implement CreateBundleManifestReader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 # See LICENSE file in the project root for full license information.
 
 cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
+project(msix-sdk)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 message(STATUS "--------------------------------")

--- a/src/msix/AppxFactory.cpp
+++ b/src/msix/AppxFactory.cpp
@@ -100,10 +100,8 @@ namespace MSIX {
     {
         #ifdef BUNDLE_SUPPORT
             ThrowErrorIf(Error::InvalidParameter, (manifestReader == nullptr || *manifestReader != nullptr), "Invalid parameter");
-            ComPtr<IMsixFactory> self;
-            ThrowHrIfFailed(QueryInterface(UuidOfImpl<IMsixFactory>::iid, reinterpret_cast<void**>(&self)));
             ComPtr<IStream> input(inputStream);
-            auto result = ComPtr<IAppxBundleManifestReader>::Make<AppxBundleManifestObject>(self.Get(), input);
+            auto result = ComPtr<IAppxBundleManifestReader>::Make<AppxBundleManifestObject>(this, input);
             *manifestReader = result.Detach();
             return static_cast<HRESULT>(Error::OK);
         #else


### PR DESCRIPTION
Added implementation for the CreateBundleManifestReader API.

These changes will enable the application of ACLs to package folders, which is new functionality we are adding to msixmgr.exe. 