### PR TITLE
Johnmcpms/fixabsolutepaths

### DIFF
--- a/src/inc/DirectoryObject.hpp
+++ b/src/inc/DirectoryObject.hpp
@@ -42,7 +42,7 @@ namespace MSIX {
     class DirectoryObject final : public ComClass<DirectoryObject, IStorageObject, IDirectoryObject>
     {
     public:
-        DirectoryObject(std::string root) : m_root(std::move(root)) {}
+        DirectoryObject(const std::string& root, bool createRootIfNecessary = false);
 
         // IStorageObject methods
         std::vector<std::string> GetFileNames(FileNameOptions options) override;
@@ -58,8 +58,9 @@ namespace MSIX {
         ComPtr<IStream> OpenFile(const std::string& fileName, MSIX::FileStream::Mode mode) override;
         std::multimap<std::uint64_t, std::string> GetFilesByLastModDate() override;
 
+        static const char* GetPathSeparator();
+
     protected:
-        const char* GetPathSeparator();
         std::string m_root;
 
     };//class DirectoryObject

--- a/src/msix/PAL/FileSystem/POSIX/DirectoryObject.cpp
+++ b/src/msix/PAL/FileSystem/POSIX/DirectoryObject.cpp
@@ -56,9 +56,9 @@ namespace MSIX {
     }
 
     #define DEFAULT_MODE S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH
-    void mkdirp(std::string& path, mode_t mode = DEFAULT_MODE)
+    void mkdirp(std::string& path, size_t startPos = 0, mode_t mode = DEFAULT_MODE)
     {
-        char* p = const_cast<char*>(path.c_str());
+        char* p = &path[startPos];
         if (*p == '/') { p++; }
         while (*p != '\0')
         {
@@ -74,12 +74,20 @@ namespace MSIX {
 
     const char* DirectoryObject::GetPathSeparator() { return "/"; }
 
+    DirectoryObject::DirectoryObject(const std::string& root, bool createRootIfNecessary) : m_root(root)
+    {
+        if (createRootIfNecessary)
+        {
+            mkdirp(m_root);
+        }
+    }
+
     ComPtr<IStream> DirectoryObject::OpenFile(const std::string& fileName, MSIX::FileStream::Mode mode)
     {
         std::string name = m_root + GetPathSeparator() + fileName;
         auto lastSlash = name.find_last_of(GetPathSeparator());
         std::string path = name.substr(0, lastSlash);
-        mkdirp(path);
+        mkdirp(path, m_root.size());
         auto result = ComPtr<IStream>::Make<FileStream>(std::move(name), mode);
         return result;
     }

--- a/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
+++ b/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
@@ -105,7 +105,158 @@ namespace MSIX {
             "FindNextFile");
     }
 
+    static std::string GetFullPath(const std::string& path)
+    {
+        const std::wstring longPathPrefix = LR"(\\?\)";
+
+        auto pathWide = utf8_to_wstring(path);
+
+        std::wstring result = longPathPrefix;
+        size_t prefixChars = longPathPrefix.size();
+        if (pathWide.substr(0, longPathPrefix.size()) == longPathPrefix)
+        {
+            // Already begins with long path prefix, so don't add it
+            result = L"";
+            prefixChars = 0;
+        }
+
+        // We aren't going to go out of our way to support crazy incoming paths.
+        // This means that path here is limited to MAX_PATH, but the resulting path won't be.
+        DWORD length = GetFullPathNameW(pathWide.c_str(), 0, nullptr, nullptr);
+
+        // Any errors result in 0
+        ThrowLastErrorIf(length == 0, "Failed to get necessary char count for GetFullPathNameW");
+
+        // When requesting size, length accounts for null char
+        result.resize(prefixChars + length, L' ');
+
+        DWORD newlength = GetFullPathNameW(pathWide.c_str(), length, &result[prefixChars], nullptr);
+
+        // On success, length does not account for null char
+        ThrowLastErrorIf(length == 0, "Failed to get necessary char count for GetFullPathNameW");
+        ThrowErrorIf(Error::Unexpected, (length - 1) != newlength, "Result length was unexpected");
+        result.resize(prefixChars + newlength);
+
+        return wstring_to_utf8(result);
+    }
+
+    struct DirectoryInfo
+    {
+        std::string Name;
+        bool Create;
+
+        DirectoryInfo(std::string&& name, bool create) : Name(std::move(name)), Create(create) {}
+    };
+
+    static void SplitDirectories(const std::string& path, std::queue<DirectoryInfo>& directories, bool forCreate)
+    {
+        static char const* const Delims = "\\/";
+        const std::string longPathPrefix = R"(\\?\)";
+
+        size_t copyPos = 0;
+        size_t searchPos = 0;
+        size_t lastPos = 0;
+
+        if (path.substr(0, longPathPrefix.size()) == longPathPrefix)
+        {
+            // Absolute path, we need to skip it
+            searchPos = longPathPrefix.size();
+        }
+
+        while (lastPos != std::string::npos)
+        {
+            lastPos = path.find_first_of(Delims, searchPos);
+
+            std::string temp = path.substr(copyPos, lastPos - copyPos);
+            if (!temp.empty())
+            {
+                directories.emplace(std::move(temp), forCreate);
+            }
+
+            copyPos = searchPos = lastPos + 1;
+        }
+    }
+
+    // Destroys directories
+    static void EnsureDirectoryStructureExists(const std::string& root, std::queue<DirectoryInfo>& directories, bool lastIsFile, std::string* resultingPath = nullptr)
+    {
+        ThrowErrorIf(Error::Unexpected, directories.empty(), "Some path must be given");
+
+        auto PopFirst = [&directories]()
+        {
+            auto result = directories.front();
+            directories.pop();
+            return result;
+        };
+
+        std::string path = root;
+        bool isFirst = true;
+
+        while (!directories.empty())
+        {
+            auto dirInfo = PopFirst();
+            if (!path.empty())
+            {
+                path += DirectoryObject::GetPathSeparator();
+            }
+            path += dirInfo.Name;
+
+            bool shouldWeCreateDir = dirInfo.Create;
+
+            // When the last entry is a file, and we are on the last entry, never create
+            if (lastIsFile && directories.empty())
+            {
+                shouldWeCreateDir = false;
+            }
+            // If this is a rooted list of directories, the first one will be a device
+            else if (root.empty() && isFirst)
+            {
+                shouldWeCreateDir = false;
+            }
+
+            if (shouldWeCreateDir)
+            {
+                bool found = false;
+
+                std::wstring utf16Name = utf8_to_wstring(path);
+                DWORD attr = GetFileAttributesW(utf16Name.c_str());
+
+                if (attr == INVALID_FILE_ATTRIBUTES)
+                {
+                    if (!CreateDirectory(utf16Name.c_str(), nullptr))
+                    {
+                        auto lastError = GetLastError();
+                        ThrowWin32ErrorIfNot(lastError, (lastError == ERROR_ALREADY_EXISTS), std::string("Call to CreateDirectory failed creating: " + path).c_str());
+                    }
+                }
+                else
+                {
+                    ThrowWin32ErrorIfNot(ERROR_ALREADY_EXISTS, attr & FILE_ATTRIBUTE_DIRECTORY, ("A file at this path already exists: " + path).c_str());
+                }
+            }
+
+            isFirst = false;
+        }
+
+        if (resultingPath)
+        {
+            *resultingPath = std::move(path);
+        }
+    }
+
     const char* DirectoryObject::GetPathSeparator() { return "\\"; }
+
+    DirectoryObject::DirectoryObject(const std::string& root, bool createRootIfNecessary)
+    {
+        m_root = GetFullPath(root);
+
+        if (createRootIfNecessary)
+        {
+            std::queue<DirectoryInfo> directories;
+            SplitDirectories(m_root, directories, true);
+            EnsureDirectoryStructureExists({}, directories, false);
+        }
+    }
 
     std::vector<std::string> DirectoryObject::GetFileNames(FileNameOptions)
     {
@@ -116,62 +267,16 @@ namespace MSIX {
     // IDirectoryObject
     ComPtr<IStream> DirectoryObject::OpenFile(const std::string& fileName, FileStream::Mode mode)
     {
-        DWORD absPathSize = GetCurrentDirectory(0, NULL);
-        std::wstring absPath;
-        absPath.resize(absPathSize-1);
-        ThrowLastErrorIf(GetCurrentDirectory(absPathSize, const_cast<wchar_t*>(absPath.data())) == 0, "Failed getting full path.");
-        absPath = L"\\\\?\\" + absPath;
+        std::queue<DirectoryInfo> directories;
 
-        std::queue<std::string> directories;
-        auto PopFirst = [&directories]()
-        {
-            auto result = directories.front();
-            directories.pop();
-            return result;
-        };
+        // Enforce that directory structure exists before creating file at specified location;
+        // but only if we are going to write the file.  If reading, the file should already exist.
+        bool modeWillCreateFile = (mode != FileStream::Mode::READ && mode != FileStream::Mode::READ_UPDATE);
+        SplitDirectories(fileName, directories, modeWillCreateFile);
 
-        // Add the root directory and build a list of directory names to ensure exist
-        std::istringstream stream(m_root + "/" + fileName);
-        std::string directory;
-        while (getline(stream, directory, '/'))
-        {
-            directories.push(std::move(directory));
-        }
+        std::string path;
+        EnsureDirectoryStructureExists(m_root, directories, true, &path);
 
-        // Enforce that directory structure exists before creating file at specified location.
-        bool found = false;
-        std::string path = wstring_to_utf8(absPath) + GetPathSeparator() +PopFirst();
-        do
-        {
-            WalkDirectory(path, WalkOptions::Directories, [&](
-                std::string,
-                WalkOptions option,
-                std::string&& name,
-                std::uint64_t)
-            {
-                found = false;
-                if (directories.front() == name)
-                {
-                    found = true;
-                    return false;
-                }
-
-                return true;
-            });
-
-            if(!found)
-            {
-                std::wstring utf16Name = utf8_to_wstring(path);
-                if (!CreateDirectory(utf16Name.c_str(), nullptr))
-                {
-                    auto lastError = GetLastError();
-                    ThrowWin32ErrorIfNot(lastError, (lastError == ERROR_ALREADY_EXISTS), std::string("Call to CreateDirectory failed creating: " + path).c_str());
-                }
-            }
-            path = path + GetPathSeparator() + PopFirst();
-            found = false;
-        }
-        while(directories.size() > 0);
         auto result = ComPtr<IStream>::Make<FileStream>(std::move(utf8_to_wstring(path)), mode);
         return result;
     }
@@ -185,12 +290,12 @@ namespace MSIX {
                 std::string root,
                 WalkOptions option,
                 std::string&& name,
-                std::uint64_t size)
+                std::uint64_t lastWrite)
             {
                 std::string fileName = root + GetPathSeparator() + name;
                 // root contains the top level directory, which we don't need
                 fileName = fileName.substr(rootSize);
-                files.insert(std::make_pair(size, std::move(fileName)));
+                files.insert(std::make_pair(lastWrite, std::move(fileName)));
                 return true;
             });
         return files;

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -163,7 +163,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackPackageFromStream(
     MSIX::ComPtr<IAppxPackageReader> reader;
     ThrowHrIfFailed(factory->CreatePackageReader(stream, &reader));
 
-    auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination);
+    auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination, true);
     reader.As<IPackage>()->Unpack(packUnpackOptions, to);
     return static_cast<HRESULT>(MSIX::Error::OK);
 } CATCH_RETURN();
@@ -208,7 +208,7 @@ MSIX_API HRESULT STDMETHODCALLTYPE UnpackBundleFromStream(
     MSIX::ComPtr<IAppxBundleReader> reader;
     ThrowHrIfFailed(factory->CreateBundleReader(stream, &reader));
 
-    auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination);
+    auto to = MSIX::ComPtr<IDirectoryObject>::Make<MSIX::DirectoryObject>(utf8Destination, true);
     reader.As<IPackage>()->Unpack(packUnpackOptions, to);
     return static_cast<HRESULT>(MSIX::Error::OK);
 } CATCH_RETURN();

--- a/src/msix/unpack/AppxPackageObject.cpp
+++ b/src/msix/unpack/AppxPackageObject.cpp
@@ -454,7 +454,7 @@ namespace MSIX {
                 ThrowHrIfFailed(manifest->GetPackageId(&packageId));
                 std::string newLocation = to.As<IStorageObject>()->GetFileName() + "/" + 
                     packageId.As<IAppxManifestPackageIdInternal>()->GetPackageFullName();
-                toPackages = MSIX::ComPtr<IDirectoryObject>::Make<DirectoryObject>(newLocation);
+                toPackages = MSIX::ComPtr<IDirectoryObject>::Make<DirectoryObject>(newLocation, true);
             }
             else
             {

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -125,7 +125,7 @@ namespace MsixTest {
         std::string PathAsAbsolute(const std::string& path)
         {
             char result[PATH_MAX];
-            REQUIRE(realpath(path.c_str(), result));
+            REQUIRE_NOT_NULL(realpath(path.c_str(), result));
             return std::string{ result };
         }
     }

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -16,6 +16,8 @@
 #include <errno.h>
 #include <fts.h>
 #include <dirent.h>
+#include <limits.h>
+#include <stdlib.h>
 
 namespace MsixTest {
 
@@ -116,6 +118,14 @@ namespace MsixTest {
             std::string result(path);
             std::replace(result.begin(), result.end(), '\\', '/');
             return result;
+        }
+
+        // Ensures that the path is an absolute one
+        std::string PathAsAbsolute(const std::string& path)
+        {
+            char result[PATH_MAX];
+            REQUIRE(realpath(path.c_str(), result));
+            return std::string{ result };
         }
     }
 }

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -147,7 +147,19 @@ namespace MsixTest {
             }
 
             char result[PATH_MAX];
-            REQUIRE_NOT_NULL(realpath(cwdStr.c_str(), result));
+            result[0] = '\0';
+            char* returnVal = realpath(cwdStr.c_str(), result);
+            
+            if (returnVal == nullptr && result[0] != '\0' && errno == ENOENT)
+            {
+                // Some systems will treat a missing file as an error,
+                // but still give you the answer.  If they do that, use the path.
+            }
+            else
+            {
+                REQUIRE_NOT_NULL(returnVal);
+            }
+            
             return std::string{ result };
         }
     }

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -124,8 +124,29 @@ namespace MsixTest {
         // Ensures that the path is an absolute one
         std::string PathAsAbsolute(const std::string& path)
         {
+            if (path.empty())
+            {
+                return path;
+            }
+
+            std::string cwdStr;
+
+            if (path[0] == '/')
+            {
+                cwdStr = path;
+            }
+            else
+            {
+                char cwdArr[PATH_MAX];
+                REQUIRE_NOT_NULL(getcwd(cwdArr, PATH_MAX));
+
+                cwdStr = cwdArr;
+                cwdStr += '/';
+                cwdStr += path;
+            }
+
             char result[PATH_MAX];
-            REQUIRE_NOT_NULL(realpath(path.c_str(), result));
+            REQUIRE_NOT_NULL(realpath(cwdStr.c_str(), result));
             return std::string{ result };
         }
     }

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -4,6 +4,7 @@
 // 
 #include "msixtest_int.hpp"
 #include "FileHelpers.hpp"
+#include "catch.hpp"
 
 #include <memory>
 #include <algorithm>

--- a/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/POSIX/FileHelpers.cpp
@@ -19,6 +19,7 @@
 #include <dirent.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 namespace MsixTest {
 

--- a/src/test/msixtest/PAL/File/WIN32/FileHelpers.cpp
+++ b/src/test/msixtest/PAL/File/WIN32/FileHelpers.cpp
@@ -6,6 +6,7 @@
 #include "FileHelpers.hpp"
 
 #include "Windows.h"
+#include "catch.hpp"
 
 #include <algorithm>
 #include <string>
@@ -146,6 +147,27 @@ namespace MsixTest {
             std::string result(path);
             std::replace(result.begin(), result.end(), '/', '\\');
             return result;
+        }
+
+        // Ensures that the path is an absolute one
+        std::string PathAsAbsolute(const std::string& path)
+        {
+            auto pathUtf16 = String::utf8_to_utf16(path);
+            DWORD length = GetFullPathNameW(pathUtf16.c_str(), 0, nullptr, nullptr);
+
+            // Any errors result in 0
+            REQUIRE(length != 0);
+
+            // When requesting size, length accounts for null char
+            std::wstring result(length, ' ');
+
+            DWORD newlength = GetFullPathNameW(pathUtf16.c_str(), length, &result[0], nullptr);
+
+            // On success, length does not account for null char
+            REQUIRE((length - 1) == newlength);
+            result.resize(newlength);
+
+            return String::utf16_to_utf8(result);
         }
     }
 }

--- a/src/test/msixtest/inc/FileHelpers.hpp
+++ b/src/test/msixtest/inc/FileHelpers.hpp
@@ -13,5 +13,6 @@ namespace MsixTest {
         bool CompareDirectory(const std::string& directory, const std::map<std::string, std::uint64_t>& files);
 
         std::string PathAsCurrentPlatform(const std::string& path);
+        std::string PathAsAbsolute(const std::string& path);
     }
 }

--- a/src/test/msixtest/msixtest.cpp
+++ b/src/test/msixtest/msixtest.cpp
@@ -202,9 +202,7 @@ namespace MsixTest {
         {
             // best effort to delete the file. If someone else has a reference to this stream
             // and this object is deleted, the file WILL NOT be deleted.
-            auto ref = m_stream->Release();
-            m_stream = nullptr;
-            if (ref == 0)
+            if (m_stream.Release())
             {
                 remove(m_fileName.c_str());
             }


### PR DESCRIPTION
This change redoes directory creation (especially on Windows) to better handle absolute paths.  It should only affect unpack, as pack doesn't use these functions to open the files.

A new test is added that passes in the absolute paths to the target locations.