### PR TITLE
Fix for new cmake tar command that won't take no files

### DIFF
--- a/cmake/msix_resources.cmake
+++ b/cmake/msix_resources.cmake
@@ -307,13 +307,21 @@ foreach(FILE ${RESOURCES_CERTS})
     list(APPEND FILES_TO_ZIP "${FILE}")
 endforeach()
 
-execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar cvf "${MSIX_BINARY_ROOT}/resources.zip" --format=zip -- ${FILES_TO_ZIP}
-    WORKING_DIRECTORY "${RESOURCES_DIR}"
-    OUTPUT_QUIET
-)
+# Starting in cmake 3.15, the tar command will error if it receives no files.
+# So we catch that case and make the resulting resource blob even smaller.
+if(FILES_TO_ZIP STREQUAL "")
+    execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar cvf "${MSIX_BINARY_ROOT}/resources.zip" --format=zip -- ${FILES_TO_ZIP}
+        WORKING_DIRECTORY "${RESOURCES_DIR}"
+        OUTPUT_QUIET
+    )
+    file(READ "${MSIX_BINARY_ROOT}/resources.zip" RESOURCE_HEX HEX)
+else()
+    # If no files to zip, we will just create the smallest blob we can without angering C++ syntax
+    message(STATUS "\t<no resource files>")
+    set(RESOURCE_HEX "00")
+endif()
 
-file(READ "${MSIX_BINARY_ROOT}/resources.zip" RESOURCE_HEX HEX)
 # Create a list by matching every 2 charactes. CMake separates lists with ;
 string(REGEX MATCHALL ".." RESOURCE_HEX_LIST "${RESOURCE_HEX}")
 list(LENGTH RESOURCE_HEX_LIST RESOURCE_LENGTH)

--- a/cmake/msix_resources.cmake
+++ b/cmake/msix_resources.cmake
@@ -309,7 +309,8 @@ endforeach()
 
 # Starting in cmake 3.15, the tar command will error if it receives no files.
 # So we catch that case and make the resulting resource blob even smaller.
-if(FILES_TO_ZIP STREQUAL "")
+list(LENGTH FILES_TO_ZIP FILES_TO_ZIP_LENGTH)
+if(FILES_TO_ZIP_LENGTH GREATER 0)
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar cvf "${MSIX_BINARY_ROOT}/resources.zip" --format=zip -- ${FILES_TO_ZIP}
         WORKING_DIRECTORY "${RESOURCES_DIR}"

--- a/src/msix/common/AppxFactory.cpp
+++ b/src/msix/common/AppxFactory.cpp
@@ -164,6 +164,12 @@ namespace MSIX {
 
     ComPtr<IStream> AppxFactory::GetResource(const std::string& resource)
     {
+        // Short-circuit the case where there were no resources and throw not found immediately.
+        if (Resource::resourceLength <= 1)
+        {
+            ThrowErrorAndLog(Error::FileNotFound, resource.c_str());
+        }
+
         if(!m_resourcezip) // Initialize it when first needed.
         {
             // Get stream of the resource zip file generated at CMake processing.


### PR DESCRIPTION
Starting in cmake 3.15, the tar command will error if given no files to work on.  This change will work across all version by cutting off that scenario and instead generating a 1 byte resource array.  The code is then updated to recognize that scenario and short circuit to returning a file not found for any resources requested.