### PR TITLE
App Execution Alias DEH

### DIFF
--- a/preview/MsixCore/msixmgr/AppExecutionAlias.cpp
+++ b/preview/MsixCore/msixmgr/AppExecutionAlias.cpp
@@ -92,6 +92,26 @@ HRESULT AppExecutionAlias::ProcessAliasForAdd(std::wstring & aliasName)
 
     RETURN_IF_FAILED(aliasKey.SetStringValue(L"Path", executableDirectoryPath));
 
+    std::wstring aliasDirectory = FilePathMappings::GetInstance().GetMsixCoreDirectory() + m_msixRequest->GetPackageInfo()->GetPackageFullName();
+    std::wstring aliasFile = aliasDirectory + L"\\" + aliasName;
+
+    HANDLE aliasFileHandle = INVALID_HANDLE_VALUE;
+    aliasFileHandle = CreateFile(aliasFile.c_str(), GENERIC_READ, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+
+    if (aliasFileHandle == INVALID_HANDLE_VALUE)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    BOOL result = CreateHardLink(executableFilePath.c_str(), aliasFile.c_str(), 0);
+    if (!result)
+    {
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
+
+    //can do this only once to add to the registry
+    //SetEnvironmentVariable(L"Path", aliasDirectory.c_str());
+
     return S_OK;
 }
 

--- a/preview/MsixCore/msixmgr/AppExecutionAlias.cpp
+++ b/preview/MsixCore/msixmgr/AppExecutionAlias.cpp
@@ -1,0 +1,92 @@
+#include <windows.h>
+#include "GeneralUtil.hpp"
+#include <TraceLoggingProvider.h>
+#include "MsixTraceLoggingProvider.hpp"
+#include "Constants.hpp"
+#include "AppExecutionAlias.hpp"
+
+using namespace MsixCoreLib;
+
+const PCWSTR AppExecutionAlias::HandlerName = L"AppExecutionAlias";
+
+HRESULT AppExecutionAlias::ExecuteForAddRequest()
+{
+    for (auto executionAlias = m_appExecutionAliases.begin(); executionAlias != m_appExecutionAliases.end(); ++executionAlias)
+    {
+        RETURN_IF_FAILED(ProcessAliasForAdd(*executionAlias));
+    }
+    return S_OK;
+}
+
+HRESULT AppExecutionAlias::ExecuteForRemoveRequest()
+{
+    return S_OK;
+}
+
+HRESULT MsixCoreLib::AppExecutionAlias::ParseManifest()
+{
+    ComPtr<IMsixDocumentElement> domElement;
+    RETURN_IF_FAILED(m_msixRequest->GetPackageInfo()->GetManifestReader()->QueryInterface(UuidOfImpl<IMsixDocumentElement>::iid, reinterpret_cast<void**>(&domElement)));
+
+    ComPtr<IMsixElement> element;
+    RETURN_IF_FAILED(domElement->GetDocumentElement(&element));
+
+    ComPtr<IMsixElementEnumerator> extensionEnum;
+    RETURN_IF_FAILED(element->GetElements(extensionQuery.c_str(), &extensionEnum));
+    BOOL hasCurrent = FALSE;
+    RETURN_IF_FAILED(extensionEnum->GetHasCurrent(&hasCurrent));
+
+    while (hasCurrent)
+    {
+        ComPtr<IMsixElement> extensionElement;
+        RETURN_IF_FAILED(extensionEnum->GetCurrent(&extensionElement));
+        Text<wchar_t> extensionCategory;
+        RETURN_IF_FAILED(extensionElement->GetAttributeValue(categoryAttribute.c_str(), &extensionCategory));
+
+        if (wcscmp(extensionCategory.Get(), appExecutionAliasCategory.c_str()) == 0)
+        {
+            BOOL hc_executionAlias = FALSE;
+            ComPtr<IMsixElementEnumerator> executionAliasEnum;
+            RETURN_IF_FAILED(extensionElement->GetElements(executionAliasQuery.c_str(), &executionAliasEnum));
+            RETURN_IF_FAILED(executionAliasEnum->GetHasCurrent(&hc_executionAlias));
+
+            while (hc_executionAlias)
+            {
+                ComPtr<IMsixElement> executionAliasElement;
+                RETURN_IF_FAILED(executionAliasEnum->GetCurrent(&executionAliasElement));
+
+                //AppExecutionAliasObject appExecutionAlias;
+
+                //alias
+                Text<wchar_t> alias;
+                RETURN_IF_FAILED(executionAliasElement->GetAttributeValue(executionAliasName.c_str(), &alias));
+                m_appExecutionAliases.push_back(alias.Get());
+                //appExecutionAlias.key = alias.Get();
+
+                //package family name
+
+                //aumid
+
+                //app full executable path
+            }
+        }
+    }
+    return S_OK;
+}
+
+HRESULT AppExecutionAlias::ProcessAliasForAdd(std::wstring aliasName)
+{
+    return S_OK;
+}
+
+HRESULT AppExecutionAlias::CreateHandler(MsixRequest * msixRequest, IPackageHandler ** instance)
+{
+    std::unique_ptr<AppExecutionAlias > localInstance(new AppExecutionAlias(msixRequest));
+    if (localInstance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+    *instance = localInstance.release();
+
+    return S_OK;
+}

--- a/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
+++ b/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
@@ -34,7 +34,7 @@ namespace MsixCoreLib
 
         HRESULT ParseManifest();
 
-        HRESULT ProcessAliasForAdd(std::wstring aliasName);
+        HRESULT ProcessAliasForAdd(std::wstring & aliasName);
 
     };
 }

--- a/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
+++ b/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "GeneralUtil.hpp"
+#include "IPackageHandler.hpp"
+#include "MsixRequest.hpp"
+
+namespace MsixCoreLib
+{
+    /// the AppExecutionAlias structure
+    /*struct AppExecutionAliasObject
+    {
+        std::wstring key;
+        std::wstring executableFullPath;
+
+
+    };*/
+
+    class AppExecutionAlias : IPackageHandler
+    {
+    public:
+        HRESULT ExecuteForAddRequest();
+
+        HRESULT ExecuteForRemoveRequest();
+
+        static const PCWSTR HandlerName;
+        static HRESULT CreateHandler(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
+        ~AppExecutionAlias() {}
+    private:
+        MsixRequest * m_msixRequest = nullptr;
+        std::vector<std::wstring> m_appExecutionAliases;
+
+        AppExecutionAlias() {}
+        AppExecutionAlias(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}
+
+        HRESULT ParseManifest();
+
+        HRESULT ProcessAliasForAdd(std::wstring aliasName);
+
+    };
+}

--- a/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
+++ b/preview/MsixCore/msixmgr/AppExecutionAlias.hpp
@@ -6,15 +6,6 @@
 
 namespace MsixCoreLib
 {
-    /// the AppExecutionAlias structure
-    /*struct AppExecutionAliasObject
-    {
-        std::wstring key;
-        std::wstring executableFullPath;
-
-
-    };*/
-
     class AppExecutionAlias : IPackageHandler
     {
     public:

--- a/preview/MsixCore/msixmgr/AutoPlay.cpp
+++ b/preview/MsixCore/msixmgr/AutoPlay.cpp
@@ -1,7 +1,4 @@
 #include <windows.h>
-
-#include <shlobj_core.h>
-#include <CommCtrl.h>
 #include <iostream>
 #include <algorithm>
 

--- a/preview/MsixCore/msixmgr/Constants.hpp
+++ b/preview/MsixCore/msixmgr/Constants.hpp
@@ -108,10 +108,6 @@ static const std::wstring directionOut = L"out";
 
 /// Constants for AutoPlay DEH
 static const std::wstring desktopAppXExtensionCategory = L"windows.autoPlayHandler";
-
-static const std::wstring desktopAppXContentSubCategory = L"Windows.AutoPlayDesktopAppX.Content";
-static const std::wstring desktopAppXDeviceSubCategory = L"Windows.AutoPlayDesktopAppX.Device";
-
 static const std::wstring idAttributeName = L"Verb";
 static const std::wstring actionAttributeName = L"ActionDisplayName";
 static const std::wstring providerAttributeName = L"ProviderDisplayName";
@@ -128,6 +124,11 @@ static const wchar_t desktopAppXProtocolDelegateExecuteValue[] = L"{BFEC0C93-0B7
 static const std::wstring explorerRegKeyName = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
 static const std::wstring handlerKeyName = L"AutoPlayHandlers\\Handlers";
 static const std::wstring eventHandlerRootRegKeyName = L"AutoPlayHandlers\\EventHandlers";
+
+/// Constants for AppExecutionAlias DEH
+static const std::wstring appExecutionAliasCategory = L"windows.appExecutionAlias";
+static const std::wstring executionAliasQuery = L"*[local-name()='AppExecutionAlias']/*[local-name()='ExecutionAlias']";
+static const std::wstring executionAliasName = L"Alias";
 
 static const std::wstring clsidKeyName = L"CLSID";
 static const std::wstring inprocHandlerKeyName = L"InprocHandler32";

--- a/preview/MsixCore/msixmgr/Constants.hpp
+++ b/preview/MsixCore/msixmgr/Constants.hpp
@@ -129,6 +129,7 @@ static const std::wstring eventHandlerRootRegKeyName = L"AutoPlayHandlers\\Event
 static const std::wstring appExecutionAliasCategory = L"windows.appExecutionAlias";
 static const std::wstring executionAliasQuery = L"*[local-name()='AppExecutionAlias']/*[local-name()='ExecutionAlias']";
 static const std::wstring executionAliasName = L"Alias";
+static const std::wstring appPathsRegKeyName = L"Software\\Microsoft\\Windows\\CurrentVersion\\App Paths";
 
 static const std::wstring clsidKeyName = L"CLSID";
 static const std::wstring inprocHandlerKeyName = L"InprocHandler32";

--- a/preview/MsixCore/msixmgr/MsixRequest.cpp
+++ b/preview/MsixCore/msixmgr/MsixRequest.cpp
@@ -37,6 +37,7 @@
 #include "FirewallRules.hpp"
 #include "AutoPlay.hpp"
 #include "VirtualFileHandler.hpp"
+#include "AppExecutionAlias.hpp"
 
 #include "Constants.hpp"
 
@@ -83,7 +84,8 @@ std::map<PCWSTR, AddHandlerInfo> AddHandlers =
     {StartupTask::HandlerName,                  {StartupTask::CreateHandler,                  FileTypeAssociation::HandlerName,          ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {FileTypeAssociation::HandlerName,          {FileTypeAssociation::CreateHandler,          FirewallRules::HandlerName,                ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {FirewallRules::HandlerName,                {FirewallRules::CreateHandler,                AutoPlay::HandlerName,                     ExecuteErrorHandler, ErrorHandler::HandlerName}},
-    {AutoPlay::HandlerName,                     {AutoPlay::CreateHandler,                     InstallComplete::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {AutoPlay::HandlerName,                     {AutoPlay::CreateHandler,                     AppExecutionAlias::HandlerName,            ExecuteErrorHandler, ErrorHandler::HandlerName}},
+    {AppExecutionAlias::HandlerName,            {AppExecutionAlias::CreateHandler,            InstallComplete::HandlerName,              ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {InstallComplete::HandlerName,              {InstallComplete::CreateHandler,              nullptr,                                   ExecuteErrorHandler, ErrorHandler::HandlerName}},
     {ErrorHandler::HandlerName,                 {ErrorHandler::CreateHandler,                 nullptr,                                   ReturnError,         nullptr}},
 };

--- a/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
+++ b/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
@@ -192,6 +192,7 @@
     <ClInclude Include="..\msixmgr\CryptoProvider.hpp" />
     <ClInclude Include="..\msixmgr\Base32Encoding.hpp" />
     <ClInclude Include="..\msixmgr\VirtualFileHandler.hpp" />
+    <ClInclude Include="..\msixmgr\AppExecutionAlias.hpp" />
     <ClInclude Include="inc\IMsixResponse.hpp" />
     <ClInclude Include="inc\DeploymentOptions.hpp" />
     <ClInclude Include="..\msixmgr\Extractor.hpp" />
@@ -236,6 +237,7 @@
     <ClCompile Include="..\msixmgr\CryptoProvider.cpp" />
     <ClCompile Include="..\msixmgr\Base32Encoding.cpp" />
     <ClCompile Include="..\msixmgr\VirtualFileHandler.cpp" />
+    <ClCompile Include="..\msixmgr\AppExecutionAlias.cpp" />
     <ClCompile Include="GeneralUtil.cpp" />
     <ClCompile Include="..\msixmgr\MsixResponse.cpp" />
     <ClCompile Include="MsixTraceLoggingProvider.cpp" />


### PR DESCRIPTION
Parse the manifest for "windows.appExecutionAlias" extension and write related keys to the registry so the app can launch by just specifying the aliasname.
Test: Edited notepad test package to include the alias name and ran through the debugger.
WorkInProgress: The app only launches from Win+R dialog and not the command prompt yet.