### PR TITLE
Rename variable to indicate semantics

### DIFF
--- a/src/inc/public/AppxPackaging.hpp
+++ b/src/inc/public/AppxPackaging.hpp
@@ -1202,7 +1202,7 @@ interface IMsixApplicabilityLanguagesEnumerator;
             /* [retval][string][out] */ LPWSTR* value) noexcept = 0;
 
         virtual HRESULT STDMETHODCALLTYPE GetElements(
-            /* [in] */ LPCWSTR name,
+            /* [in] */ LPCWSTR xpath,
             /* [retval][out] */ IMsixElementEnumerator** elements) noexcept = 0;
 
         virtual HRESULT STDMETHODCALLTYPE GetAttributeValueUtf8(
@@ -1213,7 +1213,7 @@ interface IMsixApplicabilityLanguagesEnumerator;
             /* [retval][string][out] */ LPSTR* value) noexcept = 0;
 
         virtual HRESULT STDMETHODCALLTYPE GetElementsUtf8(
-            /* [in] */ LPCSTR name,
+            /* [in] */ LPCSTR xpath,
             /* [retval][out] */ IMsixElementEnumerator** elements) noexcept= 0;
     };
 #endif  /* __IMsixElement_INTERFACE_DEFINED__ */

--- a/src/msix/PAL/XML/AOSP/XmlObject.cpp
+++ b/src/msix/PAL/XML/AOSP/XmlObject.cpp
@@ -107,9 +107,9 @@ public:
         return m_factory->MarshalOutString(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
-        return GetElementsUtf8(wstring_to_utf8(name).c_str(), elements);
+        return GetElementsUtf8(wstring_to_utf8(xpath).c_str(), elements);
     } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE GetAttributeValueUtf8(LPCSTR name, LPSTR* value) noexcept override try
@@ -127,10 +127,10 @@ public:
         return m_factory->MarshalOutStringUtf8(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
         ThrowErrorIf(Error::InvalidParameter, (elements == nullptr || *elements != nullptr), "bad pointer.");
-        std::unique_ptr<_jstring, JObjectDeleter> jname(m_env->NewStringUTF(name));
+        std::unique_ptr<_jstring, JObjectDeleter> jname(m_env->NewStringUTF(xpath));
         std::unique_ptr<_jobjectArray, JObjectDeleter> javaElements(reinterpret_cast<jobjectArray>(m_env->CallObjectMethod(m_javaXmlElementObject.get(), getElementsFunc, jname.get())));
         std::vector<ComPtr<IMsixElement>> elementsEnum;
         // Note: if the number of elements are large, JNI might barf due to too many local refs alive. This should only be used for small lists.

--- a/src/msix/PAL/XML/Apple/XmlObject.cpp
+++ b/src/msix/PAL/XML/Apple/XmlObject.cpp
@@ -78,9 +78,9 @@ public:
         return m_factory->MarshalOutString(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
-        return GetElementsUtf8(wstring_to_utf8(name).c_str(), elements);
+        return GetElementsUtf8(wstring_to_utf8(xpath).c_str(), elements);
     } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE GetAttributeValueUtf8(LPCSTR name, LPSTR* value) noexcept override try
@@ -98,10 +98,10 @@ public:
         return m_factory->MarshalOutStringUtf8(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
         ThrowErrorIf(Error::InvalidParameter, (elements == nullptr || *elements != nullptr), "bad pointer.");
-        auto attribute = std::string(name);
+        auto attribute = std::string(xpath);
         auto elementsFound = m_xmlNode->FindElements(attribute);
         std::vector<ComPtr<IMsixElement>> elementsEnum;
         for(auto element : elementsFound)

--- a/src/msix/PAL/XML/msxml6/XmlObject.cpp
+++ b/src/msix/PAL/XML/msxml6/XmlObject.cpp
@@ -214,10 +214,10 @@ public:
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
         ComPtr<IXMLDOMNodeList> list;
-        Bstr xPath(name);
+        Bstr xPath(xpath);
         ThrowHrIfFailed(m_element->selectNodes(xPath, &list));
 
         long count = 0;
@@ -266,9 +266,9 @@ public:
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
-        return GetElements(utf8_to_wstring(name).c_str(), elements);
+        return GetElements(utf8_to_wstring(xpath).c_str(), elements);
     } CATCH_RETURN();
 
 protected:
@@ -280,10 +280,10 @@ protected:
         return (variant->vt == VT_BSTR);
     }
 
-    ComPtr<IMsixElementEnumerator> GetElementsHelper(std::wstring& name)
+    ComPtr<IMsixElementEnumerator> GetElementsHelper(std::wstring& xpath)
     {
         ComPtr<IXMLDOMNodeList> list;
-        Bstr xPath(name);
+        Bstr xPath(xpath);
         ThrowHrIfFailed(m_element->selectNodes(xPath, &list));
 
         long count = 0;

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -318,9 +318,9 @@ public:
         return m_factory->MarshalOutString(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElements(LPCWSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
-        return GetElementsUtf8(wstring_to_utf8(name).c_str(), elements);
+        return GetElementsUtf8(wstring_to_utf8(xpath).c_str(), elements);
     } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE GetAttributeValueUtf8(LPCSTR name, LPSTR* value) noexcept override try
@@ -338,12 +338,12 @@ public:
         return m_factory->MarshalOutStringUtf8(text, value);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR name, IMsixElementEnumerator** elements) noexcept override try
+    HRESULT STDMETHODCALLTYPE GetElementsUtf8(LPCSTR xpath, IMsixElementEnumerator** elements) noexcept override try
     {
         ThrowErrorIf(Error::InvalidParameter, (elements == nullptr || *elements != nullptr), "bad pointer.");
         // Note: getElementsByTagName only returns the childs of a DOMElement and doesn't 
         // support xPath. For this reason we need the XercesDomParser in this object.
-        XercesXMLChPtr xPath(XMLString::transcode(name));
+        XercesXMLChPtr xPath(XMLString::transcode(xpath));
         XercesPtr<DOMXPathResult> result(m_parser->getDocument()->evaluate(
             xPath.Get(),
             m_element,


### PR DESCRIPTION
Rename the XML interface variable to indicate that it is an xpath query and not just an element name.