### PR TITLE
Case insensitive TDF comparison

### DIFF
--- a/preview/MsixCore/msixmgr/Constants.hpp
+++ b/preview/MsixCore/msixmgr/Constants.hpp
@@ -7,6 +7,8 @@ static const std::wstring registryDatFile = L"\\registry.dat";
 static const std::wstring blockMapFile = L"\\AppxBlockMap.xml";
 static const std::wstring manifestFile = L"\\AppxManifest.xml";
 static const std::wstring classesKeyPath = L"SOFTWARE\\Classes";
+static const std::wstring desktopTargetDeviceFamilyName = L"MSIXCore.Desktop";
+static const std::wstring serverTargetDeviceFamilyName = L"MSIXCore.Server";
 
 static const std::wstring msixCoreProgIDPrefix = L"MsixCore";
 static const std::wstring openWithProgIdsKeyName = L"OpenWithProgids";

--- a/preview/MsixCore/msixmgr/ValidateTargetDeviceFamily.cpp
+++ b/preview/MsixCore/msixmgr/ValidateTargetDeviceFamily.cpp
@@ -9,6 +9,8 @@
 #include <TraceLoggingProvider.h>
 #include "MsixTraceLoggingProvider.hpp"
 #include <VersionHelpers.h>
+#include "Constants.hpp"
+
 using namespace MsixCoreLib;
 
 const PCWSTR ValidateTargetDeviceFamily::HandlerName = L"ValidateTargetDeviceFamily";
@@ -105,14 +107,14 @@ bool ValidateTargetDeviceFamily::IsTargetDeviceFamilyNameCompatibleWithOS()
 {
     if (IsWindowsProductTypeServer()) /// Server OS
     {
-        if (m_targetDeviceFamilyName == L"MsixCore.Server" || m_targetDeviceFamilyName == L"MsixCore.Desktop")
+        if(CaseInsensitiveEquals(m_targetDeviceFamilyName, serverTargetDeviceFamilyName) || CaseInsensitiveEquals(m_targetDeviceFamilyName, desktopTargetDeviceFamilyName))
         {
             return true;
         }
     }
     else if (IsWindowsProductTypeDesktop()) /// Desktop OS
     {
-        if (m_targetDeviceFamilyName == L"MsixCore.Desktop")
+        if (CaseInsensitiveEquals(m_targetDeviceFamilyName, desktopTargetDeviceFamilyName))
         {
             return true;
         }


### PR DESCRIPTION
Updated ValidateTargetDeviceFamily.cpp to perform CaseInsensitive comparison when matching Target device family from manifest to either of MSIXCore.Desktop or MSIXCore.Server