### PR TITLE
Find package by family name and wildcard support

### DIFF
--- a/preview/MsixCore/README.md
+++ b/preview/MsixCore/README.md
@@ -57,13 +57,12 @@ Querying for Installed MSIX Packages -
 ```
 msixmgr.exe -FindAllPackages
 ```
-Querying for a specific MSIX Package. Searching for a specific package is possible by packageFullName, packageFamilyName and/or using wildcards as well *(match any character) and ?(match single character) are the supported wildcards. -
+Querying for a specific MSIX Package. Searching for a specific package is possible by packageFullName, packageFamilyName and/or using wildcards as well. Supported wilcards are *(match any character) and ?(match single character). -
 ```
 msixmgr.exe -FindPackage notepadplus_0.0.0.1_x64__8wekyb3d8bbwe
 msixmgr.exe -FindPackage notepadplus_0.0.0.1_x64__8wekyb3d8bbwe
 msixmgr.exe -FindPackage *padplus_0.0.*
 msixmgr.exe -FindPackage *adplus_8wekyb3d8bbw?
-
 ```
 Uninstallation - The -quietUX parameter can also be used here.
 ```

--- a/preview/MsixCore/README.md
+++ b/preview/MsixCore/README.md
@@ -57,9 +57,13 @@ Querying for Installed MSIX Packages -
 ```
 msixmgr.exe -FindAllPackages
 ```
-Querying for a specific MSIX Package -
+Querying for a specific MSIX Package. Searching for a specific package is possible by packageFullName, packageFamilyName and/or using wildcards as well *(match any character) and ?(match single character) are the supported wildcards. -
 ```
 msixmgr.exe -FindPackage notepadplus_0.0.0.1_x64__8wekyb3d8bbwe
+msixmgr.exe -FindPackage notepadplus_0.0.0.1_x64__8wekyb3d8bbwe
+msixmgr.exe -FindPackage *padplus_0.0.*
+msixmgr.exe -FindPackage *adplus_8wekyb3d8bbw?
+
 ```
 Uninstallation - The -quietUX parameter can also be used here.
 ```

--- a/preview/MsixCore/Tests/test.ps1
+++ b/preview/MsixCore/Tests/test.ps1
@@ -100,9 +100,53 @@ else
 	writeFail
 }
 
-ShowTestHeader("FindPackage succeeds")
+ShowTestHeader("FindPackageByFullName succeeds")
 $output = & $executable  -FindPackage notepadplus_0.0.0.0_x64__8wekyb3d8bbwe
 if (($output -match "notepadplus_0.0.0.0_x64__8wekyb3d8bbwe").count -gt 0)
+{
+	writeSuccess
+}
+else
+{
+	writeFail
+}
+
+ShowTestHeader("FindPackageByFamilyName succeeds")
+$output = & $executable  -FindPackage notepadplus_8wekyb3d8bbwe
+if (($output -match "notepadplus_0.0.0.0_x64__8wekyb3d8bbwe").count -gt 0)
+{
+	writeSuccess
+}
+else
+{
+	writeFail
+}
+
+ShowTestHeader("FindPackageByFullName with wildcards")
+$output = & $executable  -FindPackage *padplus_0.0.*
+if (($output -match "notepadplus_0.0.0.0_x64__8wekyb3d8bbwe").count -gt 0)
+{
+	writeSuccess
+}
+else
+{
+	writeFail
+}
+
+ShowTestHeader("FindPackageByFamilyName with wildcards")
+$output = & $executable  -FindPackage *adplus_8wekyb3d8bbw?
+if (($output -match "notepadplus_0.0.0.0_x64__8wekyb3d8bbwe").count -gt 0)
+{
+	writeSuccess
+}
+else
+{
+	writeFail
+}
+
+ShowTestHeader("FindPackage returns No Packages found")
+$output = & $executable  -FindPackage test
+if (($output -match "No packages found").count -gt 0)
 {
 	writeSuccess
 }

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -106,17 +106,17 @@ int main(int argc, char * argv[])
             shared_ptr<IInstalledPackage> packageInfo;
             HRESULT hr = packageManager->FindPackage(cli.GetPackageFullName(), packageInfo);
 
-            if (packageInfo == NULL || hr == ERROR_NOT_FOUND)
+            if (packageInfo == NULL)
             {
                 hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
                 if (FAILED(hr))
                 {
                     std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
                 }
-                else if (packageInfo == NULL || hr == ERROR_NOT_FOUND)
+                else if (packageInfo == NULL)
                 {
                     std::wcout << std::endl;
-                    std::wcout << L"No packages found " << HRESULT_FROM_WIN32(hr) << std::endl;
+                    std::wcout << L"No packages found " << std::endl;
                     std::wcout << std::endl;
                 }
             }

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -109,15 +109,15 @@ int main(int argc, char * argv[])
             if (packageInfo == NULL)
             {
                 hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
-                if (FAILED(hr))
-                {
-                    std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
-                }
-                else if (packageInfo == NULL)
+                if (packageInfo == NULL)
                 {
                     std::wcout << std::endl;
                     std::wcout << L"No packages found " << std::endl;
                     std::wcout << std::endl;
+                }
+                else if (FAILED(hr))
+                {
+                    std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
                 }
             }
 

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -113,8 +113,7 @@ int main(int argc, char * argv[])
                 {
                     std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
                 }
-
-                if (packageInfo == NULL)
+                else if (packageInfo == NULL)
                 {
                     std::wcout << std::endl;
                     std::wcout << L"No packages found " << hr << std::endl;

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -107,11 +107,17 @@ int main(int argc, char * argv[])
             HRESULT hr = packageManager->FindPackage(cli.GetPackageFullName(), packageInfo);
             if (packageInfo == NULL || FAILED(hr))
             {
-                std::wcout << std::endl;
-                std::wcout << L"No packages found " << hr << std::endl;
-                std::wcout << std::endl;
+                hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
+                if (packageInfo == NULL || FAILED(hr))
+                {
+                    std::wcout << std::endl;
+                    std::wcout << L"No packages found " << hr << std::endl;
+                    std::wcout << std::endl;
+                    return hr;
+                }
             }
-            else
+
+            if (packageInfo != nullptr)
             {
                 std::wcout << std::endl;
                 std::wcout << L"PackageFullName: " << packageInfo->GetPackageFullName().c_str() << std::endl;
@@ -119,8 +125,9 @@ int main(int argc, char * argv[])
 
                 std::wcout << L"DirectoryPath: " << packageInfo->GetInstalledLocation().c_str() << std::endl;
                 std::wcout << std::endl;
+
+                return S_OK;
             }
-            return S_OK;
         }
         case OperationType::FindAllPackages:
         {

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -106,7 +106,7 @@ int main(int argc, char * argv[])
             shared_ptr<IInstalledPackage> packageInfo;
             HRESULT hr = packageManager->FindPackage(cli.GetPackageFullName(), packageInfo);
 
-            if (packageInfo == NULL)
+            if (packageInfo == NULL || hr == ERROR_NOT_FOUND)
             {
                 hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
                 if (FAILED(hr))

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -113,10 +113,10 @@ int main(int argc, char * argv[])
                 {
                     std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
                 }
-                else if (packageInfo == NULL)
+                else if (packageInfo == NULL || hr == ERROR_NOT_FOUND)
                 {
                     std::wcout << std::endl;
-                    std::wcout << L"No packages found " << hr << std::endl;
+                    std::wcout << L"No packages found " << HRESULT_FROM_WIN32(hr) << std::endl;
                     std::wcout << std::endl;
                 }
             }

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -105,15 +105,20 @@ int main(int argc, char * argv[])
 
             shared_ptr<IInstalledPackage> packageInfo;
             HRESULT hr = packageManager->FindPackage(cli.GetPackageFullName(), packageInfo);
-            if (packageInfo == NULL || FAILED(hr))
+
+            if (packageInfo == NULL)
             {
                 hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
-                if (packageInfo == NULL || FAILED(hr))
+                if (FAILED(hr))
+                {
+                    std::wcout << L"Failed to determine findpackage results" << hr << std::endl;
+                }
+
+                if (packageInfo == NULL)
                 {
                     std::wcout << std::endl;
                     std::wcout << L"No packages found " << hr << std::endl;
                     std::wcout << std::endl;
-                    return hr;
                 }
             }
 
@@ -126,8 +131,9 @@ int main(int argc, char * argv[])
                 std::wcout << L"DirectoryPath: " << packageInfo->GetInstalledLocation().c_str() << std::endl;
                 std::wcout << std::endl;
 
-                return S_OK;
             }
+
+            return S_OK;
         }
         case OperationType::FindAllPackages:
         {

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -109,7 +109,7 @@ int main(int argc, char * argv[])
             if (packageInfo == NULL)
             {
                 hr = packageManager->FindPackageByFamilyName(cli.GetPackageFullName(), packageInfo);
-                if (packageInfo == NULL)
+                if (hr == HRESULT_FROM_WIN32(ERROR_NOT_FOUND))
                 {
                     std::wcout << std::endl;
                     std::wcout << L"No packages found " << std::endl;

--- a/preview/MsixCore/msixmgrLib/PackageManager.cpp
+++ b/preview/MsixCore/msixmgrLib/PackageManager.cpp
@@ -221,7 +221,7 @@ HRESULT PackageManager::FindPackageByFamilyName(const wstring & packageFamilyNam
             }
         }
     }
-    return S_OK;
+    return ERROR_NOT_FOUND;
 }
 
 HRESULT PackageManager::FindPackages(unique_ptr<vector<shared_ptr<IInstalledPackage>>> & installedPackages)

--- a/preview/MsixCore/msixmgrLib/PackageManager.cpp
+++ b/preview/MsixCore/msixmgrLib/PackageManager.cpp
@@ -176,12 +176,12 @@ HRESULT PackageManager::FindPackage(const wstring & packageFullName, shared_ptr<
     packageFullNameCopy = std::regex_replace(packageFullNameCopy, std::wregex(L"\\*"), L".*");
     packageFullNameCopy = std::regex_replace(packageFullNameCopy, std::wregex(L"\\?"), L".");
 
-    std::string exp(packageFullNameCopy.begin(), packageFullNameCopy.end());
-    std::regex regExp(exp);
+    std::string packageFullNameString(packageFullNameCopy.begin(), packageFullNameCopy.end());
+    std::regex packageFullNameRegExp(packageFullNameString);
 
     for (auto& p : experimental::filesystem::directory_iterator(msixCoreDirectory))
     {
-        if (std::regex_match(p.path().filename().string(), regExp))
+        if (std::regex_match(p.path().filename().string(), packageFullNameRegExp))
         {
             wstring packageDirectoryPath = msixCoreDirectory + p.path().filename().c_str();
             RETURN_IF_FAILED(GetPackageInfo(packageDirectoryPath, installedPackage));
@@ -198,12 +198,22 @@ HRESULT PackageManager::FindPackageByFamilyName(const wstring & packageFamilyNam
     RETURN_IF_FAILED(filemapping.GetInitializationResult());
     auto msixCoreDirectory = filemapping.GetMsixCoreDirectory();
 
+    wstring packageFamilyNameCopy = packageFamilyName;
+
+    packageFamilyNameCopy = std::regex_replace(packageFamilyNameCopy, std::wregex(L"\\*"), L".*");
+    packageFamilyNameCopy = std::regex_replace(packageFamilyNameCopy, std::wregex(L"\\?"), L".");
+
+    std::string packageFamilyNameString(packageFamilyNameCopy.begin(), packageFamilyNameCopy.end());
+    std::regex packageFamilyNameRegExp(packageFamilyNameString);
+
     for (auto& p : experimental::filesystem::directory_iterator(msixCoreDirectory))
     {
         if (experimental::filesystem::is_directory(p.path()))
         {
-            auto installedAppFamilyName = GetFamilyNameFromFullName(p.path().filename());
-            if (CaseInsensitiveEquals(installedAppFamilyName, packageFamilyName))
+            wstring installedAppFamilyName = GetFamilyNameFromFullName(p.path().filename());
+            std::string installedAppFamilyNameString(installedAppFamilyName.begin(), installedAppFamilyName.end());
+
+            if (std::regex_match(installedAppFamilyNameString, packageFamilyNameRegExp))
             {
                 wstring packageDirectoryPath = msixCoreDirectory + std::wstring(p.path().filename());
                 RETURN_IF_FAILED(GetPackageInfo(packageDirectoryPath, installedPackage));

--- a/preview/MsixCore/msixmgrLib/PackageManager.cpp
+++ b/preview/MsixCore/msixmgrLib/PackageManager.cpp
@@ -189,7 +189,7 @@ HRESULT PackageManager::FindPackage(const wstring & packageFullName, shared_ptr<
         }
     }
 
-    return ERROR_NOT_FOUND;
+    return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
 }
 
 HRESULT PackageManager::FindPackageByFamilyName(const wstring & packageFamilyName, shared_ptr<IInstalledPackage>& installedPackage)
@@ -221,7 +221,7 @@ HRESULT PackageManager::FindPackageByFamilyName(const wstring & packageFamilyNam
             }
         }
     }
-    return ERROR_NOT_FOUND;
+    return HRESULT_FROM_WIN32(ERROR_NOT_FOUND);
 }
 
 HRESULT PackageManager::FindPackages(unique_ptr<vector<shared_ptr<IInstalledPackage>>> & installedPackages)


### PR DESCRIPTION
Modified code to enable search by package family name. Also , enabled searching by wildcards(*(match any character) and ?(match single character)). 
When packageFullName or packageFamilyName is passed using wildcards, such as,
msixmgr.exe -FindPackage ***photos***, 
msixmgr.exe -FindPackage *adplus_8wekyb3d8bbw? (PackageFamilyName using wildcards)

it should return the appropriate results. 