### PR TITLE
Added warnings for required dependency packages/required license files

### DIFF
--- a/preview/MsixCore/msixmgr/UnpackProvider.hpp
+++ b/preview/MsixCore/msixmgr/UnpackProvider.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 #include <vector>
+#include "MSIXWindows.hpp"
+#include "..\msixmgrLib\GeneralUtil.hpp"
 
 namespace MsixCoreLib
 {
@@ -13,4 +15,9 @@ namespace MsixCoreLib
         _In_ std::wstring packageFilePath,
         _In_ std::wstring destination,
         _In_ bool isApplyACLs);
+
+    HRESULT OutputPackageDependencies(
+        _In_ IAppxManifestReader* manifestReader,
+        _In_ LPWSTR packageFullName);
+
 }

--- a/preview/MsixCore/msixmgr/msixmgr.cpp
+++ b/preview/MsixCore/msixmgr/msixmgr.cpp
@@ -183,6 +183,17 @@ int main(int argc, char * argv[])
                 {
                     std::wcout << L"Please confirm that the certificate has been installed for this package" << std::endl;
                 }
+                else if (hr == static_cast<HRESULT>(MSIX::Error::FileWrite))
+                {
+                    std::wcout << L"The tool encountered a file write error. If you are unpacking to a VHD, please try again with a larger VHD, as file write errors may be caused by insufficient disk space." << std::endl;
+                }
+                std::wcout << std::endl;
+            }
+            else
+            {
+                std::wcout << std::endl;
+                std::wcout << "Successfully unpacked and applied ACLs for package: " << packageFilePath << std::endl;
+                std::wcout << "If your package is a store-signed package, please note that store-signed apps require a license file to be included, which can be downloaded from the Microsoft Store for Business"  << std::endl;
                 std::wcout << std::endl;
             }
 


### PR DESCRIPTION
Added warning informing the user that if the package is a store-signed package, they'll need to include a license file.

Added warning informing the user what framework packages the package depends on. 

Added suggestion to unpack to a larger VHD when a FileWrite error occurs. 