### PR TITLE
Convert display percent from float to int

### DIFF
--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -691,7 +691,7 @@ void UI::SendInstallCompleteMsg()
 void UI::UpdateDisplayPercent(float displayPercent)
 {
     std::wstringstream ss;
-    ss << displayPercent << "%...";
+    ss << (int)displayPercent << "%...";
     SetWindowText(g_staticPercentText, ss.str().c_str());
     ShowWindow(g_staticPercentText, SW_HIDE);
     ShowWindow(g_staticPercentText, SW_SHOW);


### PR DESCRIPTION
UI used to display detailed percentage while installing an app. Converted this to int, so display is in the format, 50% without decimals.