### PR TITLE
Fix decoding problems and add support for unpacking large files on Windows

### DIFF
--- a/src/inc/internal/FileStream.hpp
+++ b/src/inc/internal/FileStream.hpp
@@ -17,7 +17,7 @@ namespace MSIX {
     {
     public:
         enum Mode { READ = 0, WRITE, APPEND, READ_UPDATE, WRITE_UPDATE, APPEND_UPDATE };
-        
+
         FileStream(const std::string& name, Mode mode) : m_name(name)
         {
             static const char* modes[] = { "rb", "wb", "ab", "r+b", "w+b", "a+b" };

--- a/src/msix/common/Encoding.cpp
+++ b/src/msix/common/Encoding.cpp
@@ -137,8 +137,8 @@ namespace MSIX { namespace Encoding {
     {   EncodingChar(L"20", ' '), EncodingChar(L"21", '!'), EncodingChar(L"23", '#'),  EncodingChar(L"24", '$'),
         EncodingChar(L"25", '%'), EncodingChar(L"26", '&'), EncodingChar(L"27", '\''), EncodingChar(L"28", '('),
         EncodingChar(L"29", ')'), EncodingChar(L"2B", '+'), EncodingChar(L"2C", ','),  EncodingChar(L"3B", ';'),
-        EncodingChar(L"3D", '='), EncodingChar(L"40", '@'),  EncodingChar(L"5B", '['), EncodingChar(L"5D", ']'),
-        EncodingChar(L"5E", '^'), EncodingChar(L"60", '`'), EncodingChar(L"7B", '{'), EncodingChar(L"7D", '}')
+        EncodingChar(L"3D", '='), EncodingChar(L"40", '@'), EncodingChar(L"5B", '['),  EncodingChar(L"5D", ']'),
+        EncodingChar(L"5E", '^'), EncodingChar(L"60", '`'), EncodingChar(L"7B", '{'),  EncodingChar(L"7D", '}')
     };
 
     // Convert a single hex digit to its corresponding value

--- a/src/msix/common/Encoding.cpp
+++ b/src/msix/common/Encoding.cpp
@@ -136,9 +136,9 @@ namespace MSIX { namespace Encoding {
     const EncodingChar EncodingToChar[] =
     {   EncodingChar(L"20", ' '), EncodingChar(L"21", '!'), EncodingChar(L"23", '#'),  EncodingChar(L"24", '$'),
         EncodingChar(L"25", '%'), EncodingChar(L"26", '&'), EncodingChar(L"27", '\''), EncodingChar(L"28", '('),
-        EncodingChar(L"29", ')'), EncodingChar(L"25", '+'), EncodingChar(L"2B", '%'),  EncodingChar(L"2C", ','),
-        EncodingChar(L"3B", ';'), EncodingChar(L"3D", '='), EncodingChar(L"40", '@'),  EncodingChar(L"5B", '['),
-        EncodingChar(L"5D", ']'), EncodingChar(L"7B", '{'), EncodingChar(L"7D", '}')
+        EncodingChar(L"29", ')'), EncodingChar(L"2B", '+'), EncodingChar(L"2C", ','),  EncodingChar(L"3B", ';'),
+        EncodingChar(L"3D", '='), EncodingChar(L"40", '@'),  EncodingChar(L"5B", '['), EncodingChar(L"5D", ']'),
+        EncodingChar(L"5E", '^'), EncodingChar(L"60", '`'), EncodingChar(L"7B", '{'), EncodingChar(L"7D", '}')
     };
 
     // Convert a single hex digit to its corresponding value

--- a/src/msix/unpack/AppxPackageObject.cpp
+++ b/src/msix/unpack/AppxPackageObject.cpp
@@ -399,10 +399,9 @@ namespace MSIX {
         for (const auto& fileName : fileNames)
         {   // Don't extract packages files
             auto file = std::find(std::begin(m_applicablePackagesNames), std::end(m_applicablePackagesNames), fileName);
-            auto decodedFileName = Encoding::DecodeFileName(fileName);
             if (file == std::end(m_applicablePackagesNames))
             {
-                std::string targetName;
+                std::string targetName = Encoding::DecodeFileName(fileName);
                 if ((options & MSIX_PACKUNPACK_OPTION_CREATEPACKAGESUBFOLDER) || options & MSIX_PACKUNPACK_OPTION_UNPACKWITHFLATSTRUCTURE)
                 {
                     ComPtr<IAppxManifestPackageId> packageId;
@@ -420,11 +419,7 @@ namespace MSIX {
                     // by looking at "/" in the string. If to->GetPathSeparator() is used the subfolder with
                     // the package full name won't be created on Windows, but it will on other platforms.
                     // This means that we have different behaviors in non-Win platforms.
-                    targetName = packageId.As<IAppxManifestPackageIdInternal>()->GetPackageFullName() + "/" + decodedFileName;
-                }
-                else
-                {
-                    targetName = decodedFileName;
+                    targetName = packageId.As<IAppxManifestPackageIdInternal>()->GetPackageFullName() + "/" + targetName;
                 }
 
                 auto deleteFile = MSIX::scope_exit([&targetName]

--- a/src/msix/unpack/AppxPackageObject.cpp
+++ b/src/msix/unpack/AppxPackageObject.cpp
@@ -399,6 +399,7 @@ namespace MSIX {
         for (const auto& fileName : fileNames)
         {   // Don't extract packages files
             auto file = std::find(std::begin(m_applicablePackagesNames), std::end(m_applicablePackagesNames), fileName);
+            auto decodedFileName = Encoding::DecodeFileName(fileName);
             if (file == std::end(m_applicablePackagesNames))
             {
                 std::string targetName;
@@ -419,11 +420,11 @@ namespace MSIX {
                     // by looking at "/" in the string. If to->GetPathSeparator() is used the subfolder with
                     // the package full name won't be created on Windows, but it will on other platforms.
                     // This means that we have different behaviors in non-Win platforms.
-                    targetName = packageId.As<IAppxManifestPackageIdInternal>()->GetPackageFullName() + "/" + fileName;
+                    targetName = packageId.As<IAppxManifestPackageIdInternal>()->GetPackageFullName() + "/" + decodedFileName;
                 }
                 else
                 {
-                    targetName = Encoding::DecodeFileName(fileName);
+                    targetName = decodedFileName;
                 }
 
                 auto deleteFile = MSIX::scope_exit([&targetName]


### PR DESCRIPTION
- Adds support for unpacking extremely large files on Windows. Previously, this would fail in FileStream.hpp's Seek() because the function would call std::fseek and try to pass in a very large value for the offset parameter. This value is first cast to a long, but on Windows a long is 32 bits, but the original value is 64 bits. As a result, the offset value becomes negative after being cast to a long, and the call to std::fseek fails because you can’t specify a negative offset. The fix was to call _fseeki64 instead of std::fseek and _ftelli64 instead of std::ftell.
- Fixes the EncodingToChar array in Encoding.cpp. Previously, some of the values did not match up with what's defined in the std::array PercentageEncoding
- Ensures that filenames are always decoded during unpacking, not just when the unpack option is MSIX_PACKUNPACK_OPTION_CREATEPACKAGESUBFOLDER or MSIX_PACKUNPACK_OPTION_UNPACKWITHFLATSTRUCTURE