### PR TITLE
Shared dll handling

### DIFF
--- a/preview/MsixCore/msixmgr/Constants.hpp
+++ b/preview/MsixCore/msixmgr/Constants.hpp
@@ -3,6 +3,7 @@
 
 static const std::wstring uninstallKeyPath = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall";
 static const std::wstring uninstallKeySubPath = L"Microsoft\\Windows\\CurrentVersion\\Uninstall"; // this subpath could be under Software or Software\Wow6432Node
+static const std::wstring sharedDllsKeyPath = L"Software\\Microsoft\\Windows\\CurrentVersion\\SharedDLLs"; 
 static const std::wstring registryDatFile = L"\\registry.dat";
 static const std::wstring blockMapFile = L"\\AppxBlockMap.xml";
 static const std::wstring manifestFile = L"\\AppxManifest.xml";

--- a/preview/MsixCore/msixmgr/MsixRequest.hpp
+++ b/preview/MsixCore/msixmgr/MsixRequest.hpp
@@ -26,6 +26,9 @@ private:
     /// Filled by PopulatePackageInfo
     std::shared_ptr<PackageBase> m_packageInfo;
 
+    /// Filled by ProcessPotentialUpdate
+    bool m_isReinstall = false;
+
     /// MsixResponse object populated by handlers
     std::shared_ptr<MsixResponse> m_msixResponse;
 
@@ -64,6 +67,9 @@ public:
     /// Called by PopulatePackageInfo
     void SetPackageInfo(std::shared_ptr<PackageBase> packageInfo);
     std::wstring GetPackageDirectoryPath();
+
+    void SetIsReinstall();
+    bool IsReinstall() { return m_isReinstall;  }
 
     /// @return can return null if called before PopulatePackageInfo.
     std::shared_ptr<PackageBase> GetPackageInfo() { return m_packageInfo; }

--- a/preview/MsixCore/msixmgr/MsixRequest.hpp
+++ b/preview/MsixCore/msixmgr/MsixRequest.hpp
@@ -68,7 +68,7 @@ public:
     void SetPackageInfo(std::shared_ptr<PackageBase> packageInfo);
     std::wstring GetPackageDirectoryPath();
 
-    void SetIsReinstall();
+    void SetIsReinstall(bool isReinstall) { m_isReinstall = isReinstall; }
     bool IsReinstall() { return m_isReinstall;  }
 
     /// @return can return null if called before PopulatePackageInfo.

--- a/preview/MsixCore/msixmgr/ProcessPotentialUpdate.cpp
+++ b/preview/MsixCore/msixmgr/ProcessPotentialUpdate.cpp
@@ -18,11 +18,19 @@ HRESULT ProcessPotentialUpdate::ExecuteForAddRequest()
         if (std::experimental::filesystem::is_directory(p.path()))
         {
             std::wstring installedPackageFamilyName = GetFamilyNameFromFullName(p.path().filename());
-            if (CaseInsensitiveEquals(currentPackageFamilyName, installedPackageFamilyName)
-                && !CaseInsensitiveEquals(m_msixRequest->GetPackageInfo()->GetPackageFullName(), p.path().filename()))
+            if (CaseInsensitiveEquals(currentPackageFamilyName, installedPackageFamilyName))
             {
-                RETURN_IF_FAILED(RemovePackage(p.path().filename()));
-                return S_OK;
+                if (CaseInsensitiveEquals(m_msixRequest->GetPackageInfo()->GetPackageFullName(), p.path().filename()))
+                {
+                    m_msixRequest->SetIsReinstall();
+                    TraceLoggingWrite(g_MsixTraceLoggingProvider, "Reinstalling package.");
+                    return S_OK;
+                }
+                else
+                {
+                    RETURN_IF_FAILED(RemovePackage(p.path().filename()));
+                    return S_OK;
+                }
             }
         }
     }

--- a/preview/MsixCore/msixmgr/ProcessPotentialUpdate.cpp
+++ b/preview/MsixCore/msixmgr/ProcessPotentialUpdate.cpp
@@ -22,7 +22,7 @@ HRESULT ProcessPotentialUpdate::ExecuteForAddRequest()
             {
                 if (CaseInsensitiveEquals(m_msixRequest->GetPackageInfo()->GetPackageFullName(), p.path().filename()))
                 {
-                    m_msixRequest->SetIsReinstall();
+                    m_msixRequest->SetIsReinstall(true);
                     TraceLoggingWrite(g_MsixTraceLoggingProvider, "Reinstalling package.");
                     return S_OK;
                 }

--- a/preview/MsixCore/msixmgr/RegistryDevirtualizer.cpp
+++ b/preview/MsixCore/msixmgr/RegistryDevirtualizer.cpp
@@ -117,7 +117,7 @@ bool RegistryDevirtualizer::IsExcludeKey(RegistryKey* realKey)
 
     for (auto excludeKey : excludeKeys)
     {
-        if (realKey->GetPath().find(excludeKey) != std::string::npos)
+        if (CaseInsensitiveIsSubString(realKey->GetPath(), excludeKey))
         {
             return true;
         }
@@ -217,14 +217,32 @@ HRESULT RegistryDevirtualizer::DetokenizeData(std::wstring& data)
         std::wstring token = data.substr(beginToken + 2, (endToken - beginToken - 2)); // +2 to skip over [{ characters, -2 to omit }] characters
 
         std::map<std::wstring, std::wstring> map = FilePathMappings::GetInstance().GetMap();
-        for (auto& pair : map)
+        auto it = map.find(token);
+        if (it != map.end())
         {
-            if (token.find(pair.first) != std::wstring::npos)
+            // replace the entire braces [{token}] with what it represents
+            data.replace(beginToken, endToken + 2 - beginToken, it->second); // +2 to include the }] characters
+            foundToken = true;
+        }
+
+        if (!foundToken)
+        {
+            for (auto& pair : map)
             {
-                // replace the entire braces [{token}] with what it represents
-                data.replace(beginToken, endToken + 2 - beginToken, pair.second); // +2 to include the }] characters
-                foundToken = true;
-                break;
+                if (token.find(pair.first) != std::wstring::npos)
+                {
+                    // replace the entire braces [{token}] with what it represents
+                    data.replace(beginToken, endToken + 2 - beginToken, pair.second); // +2 to include the }] characters
+                    foundToken = true;
+
+                    TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                        "Failed to find exact match for token; using approximation",
+                        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                        TraceLoggingValue(token.c_str(), "token"),
+                        TraceLoggingValue(pair.first.c_str(), "VFS"),
+                        TraceLoggingValue(pair.second.c_str(), "real"));
+                    break;
+                }
             }
         }
 

--- a/preview/MsixCore/msixmgr/RegistryDevirtualizer.cpp
+++ b/preview/MsixCore/msixmgr/RegistryDevirtualizer.cpp
@@ -112,6 +112,7 @@ bool RegistryDevirtualizer::IsExcludeKey(RegistryKey* realKey)
     const std::wstring excludeKeys[] = 
     {
         uninstallKeySubPath,   // uninstall key will be written by MsixInstaller itself, no need to copy from package
+        sharedDllsKeyPath,     // virtual file handler will handle writing changes to this path
     };
 
     for (auto excludeKey : excludeKeys)

--- a/preview/MsixCore/msixmgr/RegistryKey.cpp
+++ b/preview/MsixCore/msixmgr/RegistryKey.cpp
@@ -162,7 +162,7 @@ HRESULT RegistryKey::GetUInt32ValueIfExists(
     _Out_ bool & exists)
 {
     DWORD size = sizeof(value);
-    LONG rc = RegQueryValueExW(m_hkey, name, nullptr, nullptr, reinterpret_cast<BYTE *>(value), &size);
+    LONG rc = RegQueryValueExW(m_hkey, name, nullptr, nullptr, reinterpret_cast<BYTE *>(&value), &size);
     if (rc == ERROR_SUCCESS)
     {
         exists = true;

--- a/preview/MsixCore/msixmgr/RegistryKey.cpp
+++ b/preview/MsixCore/msixmgr/RegistryKey.cpp
@@ -155,3 +155,24 @@ HRESULT RegistryKey::SetUInt32Value(
 {
     return SetValue(name, &value, static_cast<DWORD>(sizeof(value)), REG_DWORD);
 }
+
+HRESULT RegistryKey::GetUInt32ValueIfExists(
+    _In_ PCWSTR name,
+    _Out_ UINT32 & value,
+    _Out_ bool & exists)
+{
+    DWORD size = sizeof(value);
+    LONG rc = RegQueryValueExW(m_hkey, name, nullptr, nullptr, reinterpret_cast<BYTE *>(value), &size);
+    if (rc == ERROR_SUCCESS)
+    {
+        exists = true;
+        return S_OK;
+    }
+    else if ((rc == ERROR_FILE_NOT_FOUND) || (rc == ERROR_PATH_NOT_FOUND))
+    {
+        value = 0;
+        exists = false;
+        return S_OK;
+    }
+    return HRESULT_FROM_WIN32(rc);
+}

--- a/preview/MsixCore/msixmgr/RegistryKey.hpp
+++ b/preview/MsixCore/msixmgr/RegistryKey.hpp
@@ -133,6 +133,11 @@ public:
         _In_opt_ PCWSTR name,
         _In_ UINT32 value);
 
+    HRESULT GetUInt32ValueIfExists(
+        _In_ PCWSTR name,
+        _Out_ UINT32 & value,
+        _Out_ bool & exists);
+
     template<typename TAction> static HRESULT EnumKeyAndDoActionForAllSubkeys(
         _In_ RegistryKey* registryKey,
         _In_ TAction subkeyActionFunction)

--- a/preview/MsixCore/msixmgr/VirtualFileHandler.cpp
+++ b/preview/MsixCore/msixmgr/VirtualFileHandler.cpp
@@ -17,6 +17,8 @@ using namespace MsixCoreLib;
 
 const PCWSTR VirtualFileHandler::HandlerName = L"VirtualFileHandler";
 
+std::map < std::wstring, DWORD > m_sharedDllMap;
+
 HRESULT VirtualFileHandler::ExecuteForAddRequest()
 {
     auto vfsDirectoryPath = m_msixRequest->GetPackageDirectoryPath() + L"\\VFS";
@@ -28,7 +30,17 @@ HRESULT VirtualFileHandler::ExecuteForAddRequest()
             RETURN_IF_FAILED(CopyVfsFileToLocal(p.path()));
         }
     }
-    
+
+    // Cases for incrementing. For simplicity, we ignore the count in registry.dat as we treat the .msix package as having one reference to the file
+    // 
+    // File exists, Not in SharedDLLs in registry.dat, already exists in current system SharedDLLs => increment current SharedDLLs + 1
+    // File exists, Not in SharedDLLs in registry.dat, not in current system SharedDLLs => create new SharedDLLs
+    // File exists, exists in SharedDLLs in registry.dat, already exists in current system SharedDLLs => increment current SharedDLLs + 1
+    // File exists, exists in SharedDLLs in registry.dat, not in current system SharedDLLs => create new SharedDLLs(count=1)
+    // File does not exist, does not exist in SharedDLLs in registry.dat, => no SharedDLLs
+    // File does not exist, exists in SharedDLLs in registry.dat => create new SharedDLLs(count=1)
+
+    RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->GetSharedDlls(false));
     
     return S_OK;
 }
@@ -92,6 +104,8 @@ HRESULT VirtualFileHandler::CreateHandler(MsixRequest * msixRequest, IPackageHan
     {
         return E_OUTOFMEMORY;
     }
+    RETURN_IF_FAILED(localInstance->m_sharedDllsKey.Open(HKEY_LOCAL_MACHINE, uninstallKeyPath.c_str(), KEY_WRITE));
+
     *instance = localInstance.release();
 
     return S_OK;
@@ -281,38 +295,85 @@ HRESULT VirtualFileHandler::RemoveVfsFile(std::wstring fileName)
         return S_OK;
     }
 
-    bool success = DeleteFile(fullPath.c_str());
-    if (!success)
+    // Check if file is referenced in SharedDLLs key.
+    // If it is, then just decrement instead of delete; or delete the reg value if it's 0 after decrement
+    UINT32 count = 0;
+    bool sharedDllValueExists = false;
+    bool shouldDelete = true;
+    HRESULT hrGetUInt32Value = m_sharedDllsKey.GetUInt32ValueIfExists(fullPath.c_str(), count, sharedDllValueExists);
+    if (FAILED(hrGetUInt32Value))
     {
         TraceLoggingWrite(g_MsixTraceLoggingProvider,
-            "Unable to Delete file",
+            "Unable to determine if file is shared -- not deleting file",
             TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
             TraceLoggingValue(fullPath.c_str(), "FullPath"),
-            TraceLoggingValue(GetLastError(), "error"));
+            TraceLoggingValue(hrGetUInt32Value, "hr"));
+        shouldDelete = false;
     }
-
-    while (success)
+    else if (sharedDllValueExists)
     {
-        MsixCoreLib_GetPathParent(fullPath);
-
-        // instead of checking if the directory is empty, just try to delete it.
-        // if it's not empty it'll fail with expected error code that we can ignore
-        success = RemoveDirectory(fullPath.c_str());
-        if (!success)
+        if (count > 1)
         {
-            DWORD error = GetLastError();
-            if (error != ERROR_DIR_NOT_EMPTY)
+            shouldDelete = false;
+            HRESULT hrSetUInt32Value = m_sharedDllsKey.SetUInt32Value(fullPath.c_str(), count - 1);
+            if (FAILED(hrSetUInt32Value))
             {
                 TraceLoggingWrite(g_MsixTraceLoggingProvider,
-                    "Unable to Delete directory",
+                    "Unable to decrement sharedDLL key",
                     TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
                     TraceLoggingValue(fullPath.c_str(), "FullPath"),
-                    TraceLoggingValue(GetLastError(), "error"));
+                    TraceLoggingValue(hrSetUInt32Value, "hr"));
             }
         }
-        // if we're successfull in deleting the directory, try to delete the containing directory too, in case it's now empty
+        else
+        {
+            HRESULT hrDeleteValue = m_sharedDllsKey.DeleteValue(fullPath.c_str());
+            if (FAILED(hrDeleteValue))
+            {
+                TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                    "Unable to delete sharedDLL key",
+                    TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                    TraceLoggingValue(fullPath.c_str(), "FullPath"),
+                    TraceLoggingValue(hrDeleteValue, "hr"));
+                shouldDelete = false;
+            }
+        }
     }
-    
+
+    if (shouldDelete)
+    {
+        bool success = DeleteFile(fullPath.c_str());
+        if (!success)
+        {
+            TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                "Unable to Delete file",
+                TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                TraceLoggingValue(fullPath.c_str(), "FullPath"),
+                TraceLoggingValue(GetLastError(), "error"));
+        }
+
+        while (success)
+        {
+            MsixCoreLib_GetPathParent(fullPath);
+
+            // instead of checking if the directory is empty, just try to delete it.
+            // if it's not empty it'll fail with expected error code that we can ignore
+            success = RemoveDirectory(fullPath.c_str());
+            if (!success)
+            {
+                DWORD error = GetLastError();
+                if (error != ERROR_DIR_NOT_EMPTY)
+                {
+                    TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                        "Unable to Delete directory",
+                        TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                        TraceLoggingValue(fullPath.c_str(), "FullPath"),
+                        TraceLoggingValue(GetLastError(), "error"));
+                }
+            }
+            // if we're successfull in deleting the directory, try to delete the containing directory too, in case it's now empty
+        }
+    }
     return S_OK;
 }
 

--- a/preview/MsixCore/msixmgr/VirtualFileHandler.hpp
+++ b/preview/MsixCore/msixmgr/VirtualFileHandler.hpp
@@ -3,6 +3,7 @@
 #include "GeneralUtil.hpp"
 #include "IPackageHandler.hpp"
 #include "MsixRequest.hpp"
+#include "RegistryKey.hpp"
 
 namespace MsixCoreLib
 {

--- a/preview/MsixCore/msixmgr/VirtualFileHandler.hpp
+++ b/preview/MsixCore/msixmgr/VirtualFileHandler.hpp
@@ -23,6 +23,7 @@ namespace MsixCoreLib
         ~VirtualFileHandler() {}
     private:
         MsixRequest* m_msixRequest = nullptr;
+        RegistryKey m_sharedDllsKey;
 
         VirtualFileHandler() {}
         VirtualFileHandler(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}

--- a/preview/MsixCore/msixmgrLib/GeneralUtil.cpp
+++ b/preview/MsixCore/msixmgrLib/GeneralUtil.cpp
@@ -53,6 +53,16 @@ namespace MsixCoreLib
         return (_wcsicmp(left.c_str(), right.c_str()) == 0);
     }
 
+    bool CaseInsensitiveIsSubString(const std::wstring & string, const std::wstring & substring)
+    {
+        auto it = std::search(
+            string.begin(), string.end(),
+            substring.begin(), substring.end(),
+            [](wchar_t ch1, wchar_t ch2) { return std::toupper(ch1, std::locale()) == std::toupper(ch2, std::locale()); }
+        );
+        return (it != substring.end());
+    }
+
     HRESULT GetAttributeValueFromElement(IMsixElement * element, const std::wstring attributeName, std::wstring & attributeValue)
     {
         Text<wchar_t> textValue;

--- a/preview/MsixCore/msixmgrLib/GeneralUtil.hpp
+++ b/preview/MsixCore/msixmgrLib/GeneralUtil.hpp
@@ -53,6 +53,13 @@ namespace MsixCoreLib
     /// @return true if the strings equal, false otherwise
     bool CaseInsensitiveEquals(const std::wstring& left, const std::wstring& right);
 
+    /// Determines if a string contains a substring, insensitive to case
+    ///
+    /// @param string
+    /// @param substring
+    /// @return true if string contains substring, false otherwise
+    bool CaseInsensitiveIsSubString(const std::wstring& string, const std::wstring& substring);
+
     /// Returns the current user sid as a string.
     ///
     /// @param userSidString - current user sid string


### PR DESCRIPTION
Add refcount to SharedDLLs key if we're devirtualizing a file to a path that already exists.
When removing a devirtualized file, first check SharedDLLs key and decrement; only delete if decremented to 0.

Also fixing substring matching problem when determining devirtualized folder.
Before: SystemX86 would match into System folder due to System being a substring of SystemX86; resulting in files being sprayed into c:\windows\system32 on 64-bit machine for SystemX86.
After: SystemX86 only matches with SystemX86 as we only match on whole token now.

Registry devirtualization also has same substring matching problem; we will display warnings when there's an incomplete match instead of just blissfully erroneous-matching and not logging anything. 