### PR TITLE
Fix adding multiple files with the same name via AppxPackaging apis

### DIFF
--- a/src/inc/public/MsixErrors.hpp
+++ b/src/inc/public/MsixErrors.hpp
@@ -61,7 +61,7 @@ namespace MSIX {
         MissingAppxManifestXML      = ERROR_FACILITY + 0x0034,
         DuplicateFootprintFile      = ERROR_FACILITY + 0x0035,
         UnknownFileNameEncoding     = ERROR_FACILITY + 0x0036,
-        DuplicatePayloadFile        = ERROR_FACILITY + 0x0037,
+        DuplicateFile               = ERROR_FACILITY + 0x0037,
 
         // Signature errors
         SignatureInvalid            = ERROR_FACILITY + 0x0041,

--- a/src/inc/public/MsixErrors.hpp
+++ b/src/inc/public/MsixErrors.hpp
@@ -61,6 +61,7 @@ namespace MSIX {
         MissingAppxManifestXML      = ERROR_FACILITY + 0x0034,
         DuplicateFootprintFile      = ERROR_FACILITY + 0x0035,
         UnknownFileNameEncoding     = ERROR_FACILITY + 0x0036,
+        DuplicatePayloadFile        = ERROR_FACILITY + 0x0037,
 
         // Signature errors
         SignatureInvalid            = ERROR_FACILITY + 0x0041,

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -164,6 +164,18 @@ namespace MSIX {
     void AppxPackageWriter::AddFileToPackage(const std::string& name, IStream* stream, bool toCompress,
         bool addToBlockMap, const char* contentType, bool forceContentTypeOverride)
     {
+        std::string opcFileName;
+        // Don't encode [Content Type].xml
+        if (contentType != nullptr)
+        {
+            opcFileName = Encoding::EncodeFileName(name);
+        }
+        else
+        {
+            opcFileName = name;
+        }
+        auto fileInfo = m_zipWriter->PrepareToAddFile(opcFileName, toCompress);
+
         // Add content type to [Content Types].xml
         if (contentType != nullptr)
         {
@@ -176,18 +188,6 @@ namespace MSIX {
         ThrowHrIfFailed(stream->Seek(start, StreamBase::Reference::END, &end));
         ThrowHrIfFailed(stream->Seek(start, StreamBase::Reference::START, nullptr));
         std::uint64_t uncompressedSize = static_cast<std::uint64_t>(end.QuadPart);
-
-        std::string opcFileName;
-        // Don't encode [Content Type].xml
-        if (contentType != nullptr)
-        {
-            opcFileName = Encoding::EncodeFileName(name);
-        }
-        else
-        {
-            opcFileName = name;
-        }
-        auto fileInfo = m_zipWriter->PrepareToAddFile(opcFileName, toCompress);
 
         // Add file to block map.
         if (addToBlockMap)

--- a/src/msix/pack/ZipObjectWriter.cpp
+++ b/src/msix/pack/ZipObjectWriter.cpp
@@ -10,6 +10,7 @@
 #include "ZipFileStream.hpp"
 #include "DeflateStream.hpp"
 #include "StreamHelper.hpp"
+#include "Encoding.hpp"
 
 namespace MSIX {
 
@@ -69,7 +70,11 @@ namespace MSIX {
         ThrowErrorIf(Error::InvalidState, m_state != ZipObjectWriter::State::ReadyForLfhOrClose, "Invalid zip writer state");
 
         auto result = m_centralDirectories.find(name);
-        ThrowErrorIf(Error::DuplicatePayloadFile, result != m_centralDirectories.end(), std::string("Adding duplicated file " + name + "to package").c_str());
+        if (result != m_centralDirectories.end())
+        {
+            auto message = "Adding duplicated file " + Encoding::DecodeFileName(name) + "to package";
+            ThrowErrorAndLog(Error::DuplicateFile, message.c_str());
+        }
 
         // Get position were the lfh is going to be written
         ULARGE_INTEGER pos = {0};

--- a/src/msix/pack/ZipObjectWriter.cpp
+++ b/src/msix/pack/ZipObjectWriter.cpp
@@ -68,6 +68,9 @@ namespace MSIX {
     {
         ThrowErrorIf(Error::InvalidState, m_state != ZipObjectWriter::State::ReadyForLfhOrClose, "Invalid zip writer state");
 
+        auto result = m_centralDirectories.find(name);
+        ThrowErrorIf(Error::DuplicatePayloadFile, result != m_centralDirectories.end(), std::string("Adding duplicated file " + name + "to package").c_str());
+
         // Get position were the lfh is going to be written
         ULARGE_INTEGER pos = {0};
         ThrowHrIfFailed(m_stream->Seek({0}, StreamBase::Reference::CURRENT, &pos));

--- a/src/test/msixtest/api_packagewriter.cpp
+++ b/src/test/msixtest/api_packagewriter.cpp
@@ -379,7 +379,7 @@ TEST_CASE("Api_AppxPackageWriter_add_same_payload_file")
     // The package should be in an invalid state now.
     REQUIRE_HR(static_cast<HRESULT>(MSIX::Error::InvalidState),
         packageWriter->AddPayloadFile(
-        TestConstants::GoodFileNames[1].second.c_str(),
+        TestConstants::GoodFileNames[0].second.c_str(),
         TestConstants::ContentType.c_str(),
         APPX_COMPRESSION_OPTION_NORMAL,
         contentStream.Get()));

--- a/src/test/msixtest/api_packagewriter.cpp
+++ b/src/test/msixtest/api_packagewriter.cpp
@@ -369,7 +369,7 @@ TEST_CASE("Api_AppxPackageWriter_add_same_payload_file")
         APPX_COMPRESSION_OPTION_NORMAL,
         contentStream.Get()));
 
-    REQUIRE_HR(static_cast<HRESULT>(MSIX::Error::DuplicatePayloadFile),
+    REQUIRE_HR(static_cast<HRESULT>(MSIX::Error::DuplicateFile),
         packageWriter->AddPayloadFile(
         TestConstants::GoodFileNames[1].second.c_str(),
         TestConstants::ContentType.c_str(),


### PR DESCRIPTION
We used to allow adding a file with the same name to the package. The resulting package would seem valid, but it is actually invalid and unpacking will fail, as the blockmap contains multiple entries with the same name. 

This fixes this scenario to fail at packaging time.