### PR TITLE
Load package from programFiles location

### DIFF
--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -240,7 +240,7 @@ HRESULT UI::LaunchInstalledApp()
     shared_ptr<IInstalledPackage> installedPackage;
     RETURN_IF_FAILED(m_packageManager->FindPackage(m_packageInfo->GetPackageFullName(), installedPackage));
     
-    HRESULT hrShellExecute = ShellExecuteFromExplorer(installedPackage->GetFullExecutableFilePath().c_str());
+    HRESULT hrShellExecute = ShellExecuteFromExplorer(installedPackage->GetResolvedExecutableFilePath().c_str());
     if (FAILED(hrShellExecute))
     {
         TraceLoggingWrite(g_MsixUITraceLoggingProvider,

--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -239,7 +239,7 @@ HRESULT UI::LaunchInstalledApp()
 {
     shared_ptr<IInstalledPackage> installedPackage;
     RETURN_IF_FAILED(m_packageManager->FindPackage(m_packageInfo->GetPackageFullName(), installedPackage));
-    
+
     HRESULT hrShellExecute = ShellExecuteFromExplorer(installedPackage->GetResolvedExecutableFilePath().c_str());
     if (FAILED(hrShellExecute))
     {

--- a/preview/MsixCore/msixmgr/Package.hpp
+++ b/preview/MsixCore/msixmgr/Package.hpp
@@ -145,6 +145,10 @@ namespace MsixCoreLib
         {
             return m_packageDirectoryPath;
         }
+        virtual std::wstring GetResolvedExecutableFilePath()
+        {
+            return FilePathMappings::GetInstance().GetExecutablePath(m_relativeExecutableFilePath, m_packageFullName.c_str());
+        }
         std::vector<std::wstring> GetCapabilities()
         {
             return m_capabilities;

--- a/preview/MsixCore/msixmgr/Package.hpp
+++ b/preview/MsixCore/msixmgr/Package.hpp
@@ -137,10 +137,6 @@ namespace MsixCoreLib
 
         std::unique_ptr<IStream> GetLogo();
 
-        virtual std::wstring GetFullExecutableFilePath()
-        {
-            return m_packageDirectoryPath + m_relativeExecutableFilePath;
-        }
         virtual std::wstring GetInstalledLocation()
         {
             return m_packageDirectoryPath;

--- a/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
+++ b/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
@@ -26,6 +26,7 @@ namespace MsixCoreLib {
     public:
         virtual std::wstring GetFullExecutableFilePath() = 0;
         virtual std::wstring GetInstalledLocation() = 0;
+        virtual std::wstring GetResolvedExecutableFilePath() = 0;
         virtual ~IInstalledPackage() {}
     protected:
         IInstalledPackage() {}

--- a/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
+++ b/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
@@ -24,7 +24,6 @@ namespace MsixCoreLib {
     class IInstalledPackage : public IPackage
     {
     public:
-        virtual std::wstring GetFullExecutableFilePath() = 0;
         virtual std::wstring GetInstalledLocation() = 0;
         virtual std::wstring GetResolvedExecutableFilePath() = 0;
         virtual ~IInstalledPackage() {}


### PR DESCRIPTION
The package was loading the exe from the VFS location. It should ideally launch from the actual file location. Updated to reflect this.