### PR TITLE
Append filepath with long length support

### DIFF
--- a/preview/MsixCore/msixmgr/Extractor.cpp
+++ b/preview/MsixCore/msixmgr/Extractor.cpp
@@ -20,7 +20,8 @@ HRESULT Extractor::GetOutputStream(LPCWSTR path, LPCWSTR fileName, IStream** str
 {
     std::wstring fullFileName = path + std::wstring(L"\\") + fileName;
     RETURN_IF_FAILED(HRESULT_FROM_WIN32(mkdirp(fullFileName)));
-    RETURN_IF_FAILED(CreateStreamOnFileUTF16(fullFileName.c_str(), false, stream));
+    std::wstring longFileName = std::wstring(L"\\\\?\\") + fullFileName;
+    RETURN_IF_FAILED(CreateStreamOnFileUTF16(longFileName.c_str(), false, stream));
     return S_OK;
 }
 


### PR DESCRIPTION
Apps were failing to install because the filename being passed to the CreateStreamOnFileUTF16 function were longer than 256 characters. Resolved this by appending the passed filename with \\?\.

Tested by installing an app which was failing previously and verified that it now launches.