### PR TITLE
Replace substring check with full string check

### DIFF
--- a/preview/MsixCore/msixmgr/FilePaths.cpp
+++ b/preview/MsixCore/msixmgr/FilePaths.cpp
@@ -50,19 +50,18 @@ std::wstring FilePathMappings::GetExecutablePath(std::wstring packageExecutableP
     if (executionPathWSTR.find(L"VFS") != std::wstring::npos)
     {
         MsixCoreLib_GetPathChild(executionPathWSTR);
+
         //Checks if the executable is in one of the known folders
-        for (auto pair : m_map) 
+        auto it = m_map.find(executionPathWSTR);
+        if(it != m_map.end())
         {
-            if (executionPathWSTR.find(pair.first) != std::wstring::npos)
-            {
-                //The executable exists in an unpacked directory
-                std::wstring executablePath = pair.second;
+            //The executable exists in an unpacked directory
+            std::wstring executablePath = it->second;
                 
-                MsixCoreLib_GetPathChild(executionPathWSTR);
-                executablePath.push_back(L'\\');
-                executablePath.append(executionPathWSTR);
-                return executablePath;
-            }
+            MsixCoreLib_GetPathChild(executionPathWSTR);
+            executablePath.push_back(L'\\');
+            executablePath.append(executionPathWSTR);
+            return executablePath;
         }
     }
 

--- a/preview/MsixCore/msixmgr/FilePaths.cpp
+++ b/preview/MsixCore/msixmgr/FilePaths.cpp
@@ -51,8 +51,9 @@ std::wstring FilePathMappings::GetExecutablePath(std::wstring packageExecutableP
     {
         MsixCoreLib_GetPathChild(executionPathWSTR);
 
+        std::wstring executionPathDirectory = executionPathWSTR.substr(0, executionPathWSTR.find_first_of(L'\\'));
         //Checks if the executable is in one of the known folders
-        auto it = m_map.find(executionPathWSTR);
+        auto it = m_map.find(executionPathDirectory);
         if(it != m_map.end())
         {
             //The executable exists in an unpacked directory


### PR DESCRIPTION
Replacing substring check from map with whole string check. Some apps were looking at the wrong path for a file due to this issue after install.