### PR TITLE
update path to custom action for x64 change

### DIFF
--- a/preview/MsixCore/MsixMgrWix/Product.wxs
+++ b/preview/MsixCore/MsixMgrWix/Product.wxs
@@ -152,7 +152,7 @@
 	<Fragment>
 		<!--This custom action populates MSIXMGR_PRODUCTS with the list of msixmgr-installed packages still installed-->
 		<CustomAction Id='GetMsixmgrProductsCA' BinaryKey='GetMsixmgrProducts' DllEntry='GetMsixmgrProducts' Execute='immediate' Return='check'/>
-		<Binary Id='GetMsixmgrProducts' SourceFile='$(var.SolutionDir)\GetMsixmgrProductsCA\bin\Release\GetMsixmgrProducts.CA.dll'/>
+		<Binary Id='GetMsixmgrProducts' SourceFile='$(var.SolutionDir)\GetMsixmgrProductsCA\bin\$(var.Platform)\$(var.Configuration)\GetMsixmgrProducts.CA.dll'/>
 	</Fragment>
 
 </Wix>


### PR DESCRIPTION
More fixup for the broken build -- my local clone did not clean before changing the x64 path, (clean after does not remove the changed location binaries) and so the files still existed in the original location, and so locally it built just fine, but fails on the CI build machine