### PR TITLE
Change msixmgr name to MSIX Core per feedback

### DIFF
--- a/preview/MsixCore/MsixMgrWix/Product.wxs
+++ b/preview/MsixCore/MsixMgrWix/Product.wxs
@@ -8,7 +8,7 @@
 <?endif ?>
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
-	<Product Id="*" Name="msixmgr" Language="1033" Version="!(bind.FileVersion.MsixMgrExe)" Manufacturer="Microsoft" UpgradeCode="2fe180f8-3fb8-48a0-b01e-68f47fc0ec34">
+	<Product Id="*" Name="MSIX Core" Language="1033" Version="!(bind.FileVersion.MsixMgrExe)" Manufacturer="Microsoft" UpgradeCode="2fe180f8-3fb8-48a0-b01e-68f47fc0ec34">
 		<Package InstallerVersion="200" Compressed="yes" InstallScope="perMachine" />
 
 		<MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />


### PR DESCRIPTION
The product name msixmgr shows up in the UI for MSI dialogs. MSIX Core is preferred as the name that shows up.