### PR TITLE
Displayname for package instead of app

### DIFF
--- a/preview/MsixCore/Tests/test.ps1
+++ b/preview/MsixCore/Tests/test.ps1
@@ -68,7 +68,7 @@ ShowTestHeader("Trusted Package succeeds")
 certutil -addstore root APPX_TEST_ROOT.cer > $null
 $output = & $executable -AddPackage notepadplus.msix -quietUx
 $notepadDir = "C:\program files (x86)\notepad++"
-$startLink = "$env:allusersprofile\Microsoft\Windows\Start Menu\Programs\notepad++.lnk"
+$startLink = "$env:allusersprofile\Microsoft\Windows\Start Menu\Programs\notepadplus.lnk"
 if ($output -eq $null)
 {
 	$notepadExists = (test-path $notepadDir\notepad++.exe)

--- a/preview/MsixCore/msixmgr/Package.hpp
+++ b/preview/MsixCore/msixmgr/Package.hpp
@@ -45,6 +45,7 @@ namespace MsixCoreLib
         std::wstring GetId() { return m_appUserModelId; }
         unsigned long long GetVersionNumber() { return m_version; }
         std::wstring GetVersion();
+        HRESULT GetElementTextFromQuery(IMsixElement * element, PCWSTR query, std::wstring & text);
         std::wstring GetPublisher() { return m_publisher; }
         std::wstring GetPublisherDisplayName() { return m_publisherName; }
         std::wstring GetApplicationId() { return m_applicationId; }


### PR DESCRIPTION
Grab package level variables from Properties element instead of the application element: Logo, PublisherDisplay and DisplayName are all available as properties of the package. This provides parity with what desktopappinstaller is doing on win10
#231