### PR TITLE
fix paths for x86 build.

### DIFF
--- a/preview/MsixCore/ClickOnceWrapper/msixmgrClickOnceWrapper.csproj
+++ b/preview/MsixCore/ClickOnceWrapper/msixmgrClickOnceWrapper.csproj
@@ -26,7 +26,7 @@
     <InstallUrl>https://appinstallerdemo.azurewebsites.net/MSIXCore/</InstallUrl>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
     <TrustUrlParameters>true</TrustUrlParameters>
-    <ApplicationRevision>10</ApplicationRevision>
+    <ApplicationRevision>11</ApplicationRevision>
     <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
@@ -199,6 +199,6 @@
   </PropertyGroup>
   <Target Name="CreateLocOutputDirectoryStructure">
     <MakeDir Directories="$(OutDir)en-us" />
-    <Copy SourceFiles="..\$(PlatformName)\$(ConfigurationName)\msixmgr.exe.mui" DestinationFolder="$(OutDir)en-us" />
+    <Copy SourceFiles="..\$(PlatformTarget)\$(ConfigurationName)\msixmgr.exe.mui" DestinationFolder="$(OutDir)en-us" />
   </Target>
 </Project>

--- a/preview/MsixCore/GetMsixmgrProductsCA/GetMsixmgrProducts.csproj
+++ b/preview/MsixCore/GetMsixmgrProductsCA/GetMsixmgrProducts.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\x86\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,7 +25,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\x86\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/preview/MsixCore/MsixMgrWix/MsixMgrWix.wixproj
+++ b/preview/MsixCore/MsixMgrWix/MsixMgrWix.wixproj
@@ -12,17 +12,18 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;SourceDir=..\msixmgr\loc</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
     <SuppressValidation>True</SuppressValidation>
+    <DefineConstants>SourceDir=..\msixmgr\loc</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;SourceDir=..\msixmgr\loc</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>bin\$(Platform)\$(Configuration)\</OutputPath>

--- a/preview/MsixCore/msixmgr/msixmgr.vcxproj
+++ b/preview/MsixCore/msixmgr/msixmgr.vcxproj
@@ -72,12 +72,16 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>No</LinkIncremental>
+    <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
+    <IntDir>x86\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>No</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>No</LinkIncremental>
+    <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
+    <IntDir>x86\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>No</LinkIncremental>
@@ -105,7 +109,7 @@
     </Link>
     <PostBuildEvent>
       <Command>xcopy /Y /D "..\..\..\.vs\bin\msix.dll" "$(OutDir)"
-"$(WDKBinRoot)\$(Platform)\muirct.exe" -q "..\msixmgrLib\resourceConfig.rcconfig.xml" -v 2 -x 0x0409 -g 0x0409 "$(OutDir)msixmgr.exe" "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe.mui"
+"$(WDKBinRoot)\x86\muirct.exe" -q "..\msixmgrLib\resourceConfig.rcconfig.xml" -v 2 -x 0x0409 -g 0x0409 "$(OutDir)msixmgr.exe" "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe.mui"
 copy /y "$(OutDir)msixmgr.exe" "$(OutDir)msixmgrOriginal.exe"
 copy /y "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe"
 del "$(OutDir)msixmgr_LN.exe"
@@ -174,7 +178,7 @@ del "$(OutDir)msixmgr_LN.exe"
     </Link>
     <PostBuildEvent>
       <Command>xcopy /Y /D "..\..\..\.vs\bin\msix.dll" "$(OutDir)"
-"$(WDKBinRoot)\$(Platform)\muirct.exe" -q "..\msixmgrLib\resourceConfig.rcconfig.xml" -v 2 -x 0x0409 -g 0x0409 "$(OutDir)msixmgr.exe" "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe.mui"
+"$(WDKBinRoot)\x86\muirct.exe" -q "..\msixmgrLib\resourceConfig.rcconfig.xml" -v 2 -x 0x0409 -g 0x0409 "$(OutDir)msixmgr.exe" "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe.mui"
 copy /y "$(OutDir)msixmgr.exe" "$(OutDir)msixmgrOriginal.exe"
 copy /y "$(OutDir)msixmgr_LN.exe" "$(OutDir)msixmgr.exe"
 del "$(OutDir)msixmgr_LN.exe"

--- a/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
+++ b/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
@@ -73,12 +73,16 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>No</LinkIncremental>
+    <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
+    <IntDir>x86\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>No</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>No</LinkIncremental>
+    <IntDir>x86\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)x86\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>No</LinkIncremental>
@@ -135,7 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>msixmgrLib_EXPORTS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
-      <AdditionalIncludeDirectories>.;..\msixmgr;inc;..\..\..\.vs\src\msix;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\msixmgr;inc;..\..\..\.vs\src\msix;..\msixmgr\include\rapidjson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/await</AdditionalOptions>


### PR DESCRIPTION
Fixing recent updates (json and localization) that did not build x86 to reference the correct directories, and also putting the x86 in its own directory similar to x64.
Referencing $platform doesn't work because vs treats the x86 platform as "Win32". So these are hardcoded to x86.