### PR TITLE
Block wrong architecture installs, increase space for removal warning

### DIFF
--- a/preview/MsixCore/MsixMgrWix/Product.wxs
+++ b/preview/MsixCore/MsixMgrWix/Product.wxs
@@ -83,7 +83,7 @@
 				<Control Id="RemoveButton" Type="PushButton" X="40" Y="171" Width="80" Height="17" ToolTip="!(loc.MaintenanceTypeDlgRemoveButtonTooltip)" Text="!(loc.MaintenanceTypeDlgRemoveButton)">
 					<Publish Property="WixUI_InstallMode" Value="Remove">1</Publish>
 				</Control>
-				<Control Id="WarningText" Type="Text" X="40" Y="81" Width="280" Height="40" NoPrefix="yes" Text="{\WixUI_Font_Title}!(loc.OrphanedPackageWarning)" Hidden="yes">
+				<Control Id="WarningText" Type="Text" X="40" Y="81" Width="280" Height="80" NoPrefix="yes" Text="{\WixUI_Font_Title}!(loc.OrphanedPackageWarning)" Hidden="yes">
 					<Condition Action="show">MSIXMGR_PRODUCTS</Condition>
 				</Control>
 				<Control Id="RemoveText" Type="Text" X="60" Y="191" Width="280" Height="20" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgRemoveText)">

--- a/preview/MsixCore/msixmgr/MsixRequest.cpp
+++ b/preview/MsixCore/msixmgr/MsixRequest.cpp
@@ -31,6 +31,7 @@
 #include "ProcessPotentialUpdate.hpp"
 #include "InstallComplete.hpp"
 #include "ErrorHandler.hpp"
+#include "ValidateArchitecture.hpp"
 #include "ValidateTargetDeviceFamily.hpp"
 #include "PrepareDevirtualizedRegistry.hpp"
 #include "WriteDevirtualizedRegistry.hpp"
@@ -70,7 +71,8 @@ struct RemoveHandlerInfo
 std::map<PCWSTR, AddHandlerInfo> AddHandlers =
 {
     //HandlerName                               Function to create                            NextHandler (on success)                   ErrorHandlingMode    ErrorHandler (when ExecuteErrorHandler)
-    {PopulatePackageInfo::HandlerName,          {PopulatePackageInfo::CreateHandler,          ValidateTargetDeviceFamily::HandlerName,   ReturnError,         nullptr}},
+    {PopulatePackageInfo::HandlerName,          {PopulatePackageInfo::CreateHandler,          ValidateArchitecture::HandlerName,         ReturnError,         nullptr}},
+    {ValidateArchitecture::HandlerName,         {ValidateArchitecture::CreateHandler,         ValidateTargetDeviceFamily::HandlerName,   ReturnError,         nullptr}},
     {ValidateTargetDeviceFamily::HandlerName,   {ValidateTargetDeviceFamily::CreateHandler,   ProcessPotentialUpdate::HandlerName,       ReturnError,         nullptr}},
     {ProcessPotentialUpdate::HandlerName,       {ProcessPotentialUpdate::CreateHandler,       Extractor::HandlerName,                    ReturnError,         nullptr}},
     {Extractor::HandlerName,                    {Extractor::CreateHandler,                    PrepareDevirtualizedRegistry::HandlerName, ExecuteErrorHandler, ErrorHandler::HandlerName}},

--- a/preview/MsixCore/msixmgr/Package.cpp
+++ b/preview/MsixCore/msixmgr/Package.cpp
@@ -338,6 +338,8 @@ HRESULT PackageBase::SetManifestReader(IAppxManifestReader * manifestReader)
 
     RETURN_IF_FAILED(manifestId->GetVersion(&m_version));
 
+    RETURN_IF_FAILED(manifestId->GetArchitecture(&m_architecture));
+
     Text<WCHAR> packageFullName;
     RETURN_IF_FAILED(manifestId->GetPackageFullName(&packageFullName));
     m_packageFullName = packageFullName.Get();

--- a/preview/MsixCore/msixmgr/Package.hpp
+++ b/preview/MsixCore/msixmgr/Package.hpp
@@ -23,6 +23,7 @@ namespace MsixCoreLib
         std::wstring m_publisherName;
         std::wstring m_relativeLogoPath;
         std::wstring m_packageDirectoryPath;
+        APPX_PACKAGE_ARCHITECTURE m_architecture;
 
         std::vector<std::wstring> m_capabilities;
 
@@ -56,6 +57,7 @@ namespace MsixCoreLib
             m_packageDirectoryPath = FilePathMappings::GetInstance().GetMsixCoreDirectory() + m_packageFullName + L"\\";
             return m_packageDirectoryPath;
         }
+        APPX_PACKAGE_ARCHITECTURE GetArchitecture() { return m_architecture; }
 
         std::vector<std::wstring> GetCapabilities()
         {
@@ -116,6 +118,7 @@ namespace MsixCoreLib
         std::wstring GetPublisherDisplayName() { return m_publisherName; }
         std::unique_ptr<IStream> GetLogo();
         std::wstring GetApplicationId() { return m_applicationId; }
+        APPX_PACKAGE_ARCHITECTURE GetArchitecture() { return m_architecture; }
 
         std::vector<std::wstring> GetCapabilities()
         {
@@ -165,7 +168,9 @@ namespace MsixCoreLib
         {
             return FilePathMappings::GetInstance().GetExecutablePath(m_relativeExecutableFilePath, m_packageFullName.c_str());
         }
-        
+
+        APPX_PACKAGE_ARCHITECTURE GetArchitecture() { return m_architecture; }
+
         std::vector<std::wstring> GetCapabilities()
         {
             return m_capabilities;

--- a/preview/MsixCore/msixmgr/ValidateArchitecture.cpp
+++ b/preview/MsixCore/msixmgr/ValidateArchitecture.cpp
@@ -1,0 +1,70 @@
+#include <windows.h>
+
+#include <shlobj_core.h>
+#include <CommCtrl.h>
+
+#include "FilePaths.hpp"
+#include "ValidateArchitecture.hpp"
+#include "GeneralUtil.hpp"
+#include <TraceLoggingProvider.h>
+#include "MsixTraceLoggingProvider.hpp"
+#include <VersionHelpers.h>
+#include "Constants.hpp"
+
+using namespace MsixCoreLib;
+
+const PCWSTR ValidateArchitecture::HandlerName = L"ValidateArchitecture";
+
+HRESULT ValidateArchitecture::ExecuteForAddRequest()
+{
+    if (!IsArchitectureCompatibleWithOS())
+    {
+        return HRESULT_FROM_WIN32(ERROR_INSTALL_WRONG_PROCESSOR_ARCHITECTURE);
+    }
+
+    return S_OK;
+}
+
+bool ValidateArchitecture::IsArchitectureCompatibleWithOS()
+{
+    APPX_PACKAGE_ARCHITECTURE packageArchitecture = m_msixRequest->GetPackageInfo()->GetArchitecture();
+
+    if (packageArchitecture == APPX_PACKAGE_ARCHITECTURE_NEUTRAL)
+    {
+        return true;
+    }
+
+    SYSTEM_INFO systemInfo;
+    GetSystemInfo(&systemInfo);
+    APPX_PACKAGE_ARCHITECTURE machineArchitecture = static_cast<APPX_PACKAGE_ARCHITECTURE>(systemInfo.wProcessorArchitecture);
+
+    if (packageArchitecture == machineArchitecture)
+    {
+        return true;
+    }
+
+    // Allow x86 packages to install on x64 machines
+    if (machineArchitecture == APPX_PACKAGE_ARCHITECTURE_X64 &&
+        packageArchitecture == APPX_PACKAGE_ARCHITECTURE_X86)
+    {
+        return true;
+    }
+
+    TraceLoggingWrite(g_MsixTraceLoggingProvider,
+        "Incompatible Architecture",
+        TraceLoggingValue(static_cast<DWORD>(packageArchitecture), "packageArchitecture"),
+        TraceLoggingValue(static_cast<DWORD>(machineArchitecture), "machineArchitecture"));
+    return false;
+}
+
+HRESULT ValidateArchitecture::CreateHandler(MsixRequest * msixRequest, IPackageHandler ** instance)
+{
+    std::unique_ptr<ValidateArchitecture> localInstance(new ValidateArchitecture(msixRequest));
+    if (localInstance == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+    *instance = localInstance.release();
+
+    return S_OK;
+}

--- a/preview/MsixCore/msixmgr/ValidateArchitecture.hpp
+++ b/preview/MsixCore/msixmgr/ValidateArchitecture.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "GeneralUtil.hpp"
+#include "IPackageHandler.hpp"
+
+namespace MsixCoreLib
+{
+    class ValidateArchitecture : IPackageHandler
+    {
+    public:
+        HRESULT ExecuteForAddRequest();
+
+        static const PCWSTR HandlerName;
+        static HRESULT CreateHandler(_In_ MsixRequest* msixRequest, _Out_ IPackageHandler** instance);
+        ~ValidateArchitecture() {}
+    private:
+        MsixRequest * m_msixRequest = nullptr;
+
+        ValidateArchitecture() {}
+        ValidateArchitecture(_In_ MsixRequest* msixRequest) : m_msixRequest(msixRequest) {}
+
+        /// This function returns true if the package architecture is compatible with the operating system
+        bool IsArchitectureCompatibleWithOS();
+    };
+}

--- a/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
+++ b/preview/MsixCore/msixmgrLib/inc/IPackage.hpp
@@ -2,12 +2,15 @@
 #include <Windows.h>
 #include <vector>
 #include <memory>
+#include "AppxPackaging.hpp"
+
 namespace MsixCoreLib {
 
     class IPackage {
     public:
         virtual unsigned long long GetVersionNumber() = 0;
         virtual std::wstring GetVersion() = 0;
+        virtual APPX_PACKAGE_ARCHITECTURE GetArchitecture() = 0;
         virtual std::wstring GetPublisherDisplayName() = 0;
         virtual std::wstring GetPackageFullName() = 0;
         virtual std::wstring GetPackageFamilyName() = 0;

--- a/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
+++ b/preview/MsixCore/msixmgrLib/msixmgrLib.vcxproj
@@ -189,6 +189,7 @@
     <ClInclude Include="..\msixmgr\ErrorHandler.hpp" />
     <ClInclude Include="..\msixmgr\PSFScriptExecuter.hpp" />
     <ClInclude Include="..\msixmgr\StartupTask.hpp" />
+    <ClInclude Include="..\msixmgr\ValidateArchitecture.hpp" />
     <ClInclude Include="..\msixmgr\ValidateTargetDeviceFamily.hpp" />
     <ClInclude Include="..\msixmgr\FirewallRules.hpp" />
     <ClInclude Include="..\msixmgr\Windows10Redirector.hpp" />
@@ -235,6 +236,7 @@
     <ClCompile Include="..\msixmgr\MsixRequest.cpp" />
     <ClCompile Include="..\msixmgr\PSFScriptExecuter.cpp" />
     <ClCompile Include="..\msixmgr\StartupTask.cpp" />
+    <ClCompile Include="..\msixmgr\ValidateArchitecture.cpp" />
     <ClCompile Include="..\msixmgr\ValidateTargetDeviceFamily.cpp" />
     <ClCompile Include="..\msixmgr\FirewallRules.cpp" />
     <ClCompile Include="..\msixmgr\Windows10Redirector.cpp" />


### PR DESCRIPTION
Add a ValidateArchitecture handler to block wrong processor architecture installs (i.e. x64 on x86)

Increase size of removal warning in MSI package so it's not cut off.