### PR TITLE
Registry devirtualizer fixes

### DIFF
--- a/preview/MsixCore/msixmgr/PSFScriptExecuter.cpp
+++ b/preview/MsixCore/msixmgr/PSFScriptExecuter.cpp
@@ -19,9 +19,14 @@ HRESULT PSFScriptExecuter::ExecuteForAddRequest()
 
     // Read script parameters from PSF config and update executionInfo
     RETURN_IF_FAILED(m_msixRequest->GetPackageInfo()->ProcessPSFIfNecessary());
-    
-    std::wstring workingDirectory = m_msixRequest->GetPackageInfo()->GetExecutionInfo()->workingDirectory;
+
     std::wstring scriptName = m_msixRequest->GetPackageInfo()->GetScriptSettings()->scriptPath;
+    if (scriptName.length() == 0)
+    {
+        return S_OK;
+    }
+
+    std::wstring workingDirectory = m_msixRequest->GetPackageInfo()->GetExecutionInfo()->workingDirectory;
 
     std::wstring scriptPath = workingDirectory + L"\\" + scriptName;
     std::wstring psArguments = L"-file \"" + scriptPath + L"\"";


### PR DESCRIPTION
Registry devirtualizer detokenize (handle the [{System}] etc tokens) was only happening in value data, but we would write the tokens in keynames and value names 

This change detokenizes keynames and value names before writing the data.

Also, need to null out the data buffers when they are re-used, as enumvalue may leave them unmodified when the data is null; this leads to writing whatever the previous value was multiple times instead of writing null.

Fix PSFScriptExecuter from logging nonsense when there's no psf by bailing early when we see there's no PSF. 