### PR TITLE
Various UX fixes 

### DIFF
--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -22,6 +22,7 @@
 #define max std::max
 #define min std::min
 #include <GdiPlus.h>
+#include <Uxtheme.h>
 using namespace std;
 using namespace MsixCoreLib;
 
@@ -37,6 +38,12 @@ static const int g_height = 400; // height of window
 
 HRESULT UI::DrawPackageInfo(HWND hWnd, RECT windowRect)
 {
+    if (SUCCEEDED(m_loadingPackageInfoCode) && !m_loadedPackageInfo)
+    {
+        DisplayLoadingPackage(hWnd);
+        return S_OK;
+    }
+
     if (SUCCEEDED(m_loadingPackageInfoCode))
     {
         auto displayText = m_installOrUpdateText + L" " + m_displayName + L"?";
@@ -267,37 +274,9 @@ HRESULT UI::LaunchInstalledApp()
     return S_OK;
 }
 
-void StartParseFile(HWND hWnd)
-{
-    int result = 0;
-
-    if (result != 0)
-    {
-        std::cout << "Error: " << std::hex << result << " while extracting the appx package" << std::endl;
-        Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
-        if (0 == logResult)
-        {
-            std::cout << "LOG:" << std::endl << text.content << std::endl;
-        }
-        else
-        {
-            std::cout << "UNABLE TO GET LOG WITH HR=" << std::hex << logResult << std::endl;
-        }
-    }
-}
-
-void CommandFunc(HWND hWnd, RECT windowRect) {
-    std::thread t1(StartParseFile, hWnd);
-    t1.detach();
-    return;
-}
-
 void StartUIThread(UI* ui)
 {
-    // Free the console that we started with
-    FreeConsole();
-
+    InitCommonControls();
     // Register WindowClass and create the window
     HINSTANCE hInstance = GetModuleHandle(NULL);
 
@@ -366,11 +345,14 @@ HRESULT UI::ParseInfoFromPackage()
     //Obtain package capabilities
     m_capabilities = m_packageInfo->GetCapabilities();
 
+    m_loadedPackageInfo = true;
     return S_OK;
 }
 
 HRESULT UI::ShowUI()
 {
+    // Free the console that we started with
+    FreeConsole();
 
     std::thread thread(StartUIThread, this);
     thread.detach();
@@ -448,6 +430,10 @@ BOOL UI::CreateCheckbox(HWND parentHWnd, RECT parentRect)
         (HMENU)IDC_LAUNCHCHECKBOX, // menu
         reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
         NULL);
+
+    // Disable visual styles for this control. Common controls 6 doesn't allow this control to be transparent via WM_CTLCOLORSTATIC
+    // Without disabling styles, on aero theme, this'll have an ugly gray background on the otherwise white dialog.
+    SetWindowTheme(g_checkboxHWnd, L" ", L" ");
 
     //Set default checkbox state to checked
     SendMessage(g_checkboxHWnd, BM_SETCHECK, BST_CHECKED, 0);
@@ -608,7 +594,7 @@ BOOL UI::ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring mess
     graphics.DrawString(capabilitiesHeading.c_str(), -1, &messageFont, layoutRect, &format, &textBrush);
 
     layoutRect.Y += 17;
-    for (std::wstring capability : m_capabilities)
+    if (m_capabilities.size() > 0)
     {
         std::wstring capabilityString = L"\x2022 " + GetStringResource(IDS_RUNFULLTRUST_CAPABILITY);
         graphics.DrawString(capabilityString.c_str(), -1, &messageFont, layoutRect, &format, &textBrush);
@@ -629,6 +615,31 @@ BOOL UI::ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring mess
     EndPaint(parentHWnd, &paint);
 
     return TRUE;
+}
+
+BOOL UI::DisplayLoadingPackage(HWND parentHWnd)
+{
+    ShowWindow(g_checkboxHWnd, SW_HIDE);
+    ShowWindow(g_buttonHWnd, SW_HIDE);
+    PAINTSTRUCT paint;
+    HDC deviceContext = BeginPaint(parentHWnd, &paint);
+
+    Gdiplus::Graphics graphics(deviceContext);
+
+    Gdiplus::RectF layoutRect(50, (g_height / 2) - 50, g_width - 144, 100);
+    
+    Gdiplus::Font messageFont(L"Arial", 10);
+    Gdiplus::StringFormat format;
+    format.SetAlignment(Gdiplus::StringAlignmentCenter);
+    auto windowsTextColor = Gdiplus::Color();
+    windowsTextColor.SetFromCOLORREF(GetSysColor(COLOR_WINDOWTEXT));
+    Gdiplus::SolidBrush textBrush(windowsTextColor);
+
+    auto messageText = GetStringResource(IDS_STRING_LOADING_PACKAGE);
+    graphics.DrawString(messageText.c_str(), -1, &messageFont, layoutRect, &format, &textBrush);
+
+    EndPaint(parentHWnd, &paint);
+    return true;
 }
 
 int UI::CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& windowClass, const std::wstring& title)
@@ -655,9 +666,17 @@ int UI::CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& 
     SetHwnd(hWnd);
     SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)this);
     ShowWindow(hWnd, nCmdShow);
+    UpdateWindow(hWnd);
     PreprocessRequest();
+    
     ShowWindow(hWnd, nCmdShow);
     UpdateWindow(hWnd);
+    if (SUCCEEDED(m_loadingPackageInfoCode))
+    {
+        ShowWindow(g_checkboxHWnd, SW_SHOW);
+        ShowWindow(g_buttonHWnd, SW_SHOW);
+    }
+    InvalidateRect(hWnd, 0, TRUE);
 
     // Main message loop:
     MSG msg;

--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -371,7 +371,6 @@ HRESULT UI::ParseInfoFromPackage()
 
 HRESULT UI::ShowUI()
 {
-    m_loadingPackageInfoCode = ParseInfoFromPackage();
 
     std::thread thread(StartUIThread, this);
     thread.detach();
@@ -383,6 +382,7 @@ HRESULT UI::ShowUI()
 
 void UI::PreprocessRequest()
 {
+    m_loadingPackageInfoCode = ParseInfoFromPackage();
     if (FAILED(m_loadingPackageInfoCode))
     {
         return;
@@ -654,6 +654,7 @@ int UI::CreateInitWindow(HINSTANCE hInstance, int nCmdShow, const std::wstring& 
 
     SetHwnd(hWnd);
     SetWindowLongPtr(hWnd, GWLP_USERDATA, (LONG_PTR)this);
+    ShowWindow(hWnd, nCmdShow);
     PreprocessRequest();
     ShowWindow(hWnd, nCmdShow);
     UpdateWindow(hWnd);

--- a/preview/MsixCore/msixmgr/InstallUI.hpp
+++ b/preview/MsixCore/msixmgr/InstallUI.hpp
@@ -71,6 +71,7 @@ private:
     std::wstring m_version = L"";
     std::vector<std::wstring> m_capabilities;
 
+    bool m_loadedPackageInfo = false;
     HRESULT m_loadingPackageInfoCode = 0;
     UIType m_type;
 
@@ -165,6 +166,11 @@ public:
     /// @param parentHWnd - the HWND of the window to be changed
     /// @param windowText - the text to change the window to
     BOOL ChangeText(HWND parentHWnd, std::wstring displayText, std::wstring  messageText, IStream* logoStream = nullptr);
+
+    /// Display the loading package message
+    ///
+    /// @param parentHWnd - the HWND of the window to be changed
+    BOOL DisplayLoadingPackage(HWND parentHWnd);
 
     /// Sends the WM_INSTALLCOMPLETE_MSG message to the main window when app installation is complete
     void SendInstallCompleteMsg();

--- a/preview/MsixCore/msixmgr/WindowsCompatibility.manifest
+++ b/preview/MsixCore/msixmgr/WindowsCompatibility.manifest
@@ -14,4 +14,16 @@
             <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
         </application> 
     </compatibility>
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+					type="win32"
+					name="Microsoft.Windows.Common-Controls"
+					version="6.0.0.0"
+					processorArchitecture="*"
+					publicKeyToken="6595b64144ccf1df"
+					language="*"
+        />
+		</dependentAssembly>
+	</dependency>
 </assembly>

--- a/preview/MsixCore/msixmgr/msixmgr.rc
+++ b/preview/MsixCore/msixmgr/msixmgr.rc
@@ -115,6 +115,7 @@ BEGIN
 	IDS_STRING_CAPABILITIES "Capabilities:"
 	IDS_STRING_INSTALLING_APP "Installing app package"
 	IDS_STRING_ERROR_REASON_TEXT "Reason:"
+    IDS_STRING_LOADING_PACKAGE "Loading Package..."
 
 	END
 

--- a/preview/MsixCore/msixmgr/msixmgr.vcxproj
+++ b/preview/MsixCore/msixmgr/msixmgr.vcxproj
@@ -104,7 +104,7 @@
       <AdditionalLibraryDirectories>..\x86\Debug;..\..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
@@ -134,7 +134,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <AdditionalLibraryDirectories>..\x64\Debug;..\..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
@@ -173,7 +173,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <AdditionalLibraryDirectories>..\x86\Release;..\..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
     </Link>
     <PostBuildEvent>
@@ -208,7 +208,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <AdditionalLibraryDirectories>..\x64\Release;..\..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
     </Link>
     <PostBuildEvent>

--- a/preview/MsixCore/msixmgr/resource.h
+++ b/preview/MsixCore/msixmgr/resource.h
@@ -47,6 +47,7 @@
 #define IDS_STRING_CAPABILITIES         141
 #define IDS_STRING_INSTALLING_APP       142
 #define IDS_STRING_ERROR_REASON_TEXT    143
+#define IDS_STRING_LOADING_PACKAGE      144
 
 // Next default values for new objects
 // 


### PR DESCRIPTION
Before: displayed a cmd prompt for the duration of opening a package
After: displays empty UI with Loading package... text.
Noticeable when double clicking large packages.

Before: showed the same capability Uses all system resources text for each capability in the package.
After: shows it once

Before: progress bars/buttons used ancient window style
After: progress bars/buttons use common controls 6, which is slightly less ancient.
