### PR TITLE
execution bypass and better psf error checking

### DIFF
--- a/preview/MsixCore/msixmgr/PSFScriptExecuter.cpp
+++ b/preview/MsixCore/msixmgr/PSFScriptExecuter.cpp
@@ -29,7 +29,7 @@ HRESULT PSFScriptExecuter::ExecuteForAddRequest()
     std::wstring workingDirectory = m_msixRequest->GetPackageInfo()->GetExecutionInfo()->workingDirectory;
 
     std::wstring scriptPath = workingDirectory + L"\\" + scriptName;
-    std::wstring psArguments = L"-file \"" + scriptPath + L"\"";
+    std::wstring psArguments = L"-executionpolicy bypass -file \"" + scriptPath + L"\"";
 
     TraceLoggingWrite(g_MsixTraceLoggingProvider,
         "Executing PSF script",


### PR DESCRIPTION
Shore up the error handling of PSF scripts: i.e. handle cases where config.json is missing expected elements and error out instead of just crashing. 

Also, add execution bypass to the command line, so that user do not have to have set script execution to unrestricted in order to run the PSF scripts.