### PR TITLE
Resize ux elements

### DIFF
--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -560,7 +560,7 @@ BOOL UI::CreateDisplayPercentageText(HWND parentHWnd, RECT parentRect)
         GetStringResource(IDS_STRING_INSTALLING_APP).c_str(),
         WS_CHILD ,
         parentRect.left + 50,
-        parentRect.bottom - scrollHeight - 143,
+        parentRect.bottom - scrollHeight - 145,
         175,
         20,
         parentHWnd,
@@ -573,9 +573,9 @@ BOOL UI::CreateDisplayPercentageText(HWND parentHWnd, RECT parentRect)
         L"Static",
         L"0%...",
         WS_CHILD,
-        parentRect.left + 200,
-        parentRect.bottom - scrollHeight - 143,
-        175,
+        parentRect.left + 225,
+        parentRect.bottom - scrollHeight - 145,
+        80,
         20,
         parentHWnd,
         (HMENU)IDC_STATICPERCENTCONTROL,
@@ -663,9 +663,14 @@ BOOL UI::ChangeText(HWND parentHWnd, std::wstring displayName, std::wstring mess
     {
         // We shouldn't fail if the image can't be loaded, just don't show it.
         auto image = Gdiplus::Image::FromStream(logoStream, FALSE);
+
+        UINT width = image->GetWidth();
+        UINT height = image->GetHeight();
+        width = (width > 180) ? 180 : width;
+        height = (height > 180) ? 180 : height;
         if (image != nullptr)
         {
-            Gdiplus::Status status = graphics.DrawImage(image, g_width - 200, 25);
+            Gdiplus::Status status = graphics.DrawImage(image, g_width - 200, 25, width, height);
             delete image;
         }
     }

--- a/preview/MsixCore/msixmgr/InstallUI.cpp
+++ b/preview/MsixCore/msixmgr/InstallUI.cpp
@@ -160,7 +160,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             ShowWindow(g_progressHWnd, SW_HIDE); //hide progress bar
             ShowWindow(g_checkboxHWnd, SW_HIDE); //hide launch check box
             ShowWindow(g_percentageTextHWnd, SW_HIDE);
-            ShowWindow(g_staticPercentText, SW_HIDE);
             ShowWindow(g_LaunchbuttonHWnd, SW_SHOW);
         }
     }
@@ -561,26 +560,13 @@ BOOL UI::CreateDisplayPercentageText(HWND parentHWnd, RECT parentRect)
         WS_CHILD ,
         parentRect.left + 50,
         parentRect.bottom - scrollHeight - 145,
-        175,
+        300,
         20,
         parentHWnd,
         (HMENU)IDC_STATICPERCENTCONTROL,
         reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
         0);
 
-    g_staticPercentText = CreateWindowEx(
-        WS_EX_LEFT,
-        L"Static",
-        L"0%...",
-        WS_CHILD,
-        parentRect.left + 225,
-        parentRect.bottom - scrollHeight - 145,
-        80,
-        20,
-        parentHWnd,
-        (HMENU)IDC_STATICPERCENTCONTROL,
-        reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parentHWnd, GWLP_HINSTANCE)),
-        0);
     return TRUE;
 }
 
@@ -774,7 +760,6 @@ void UI::ButtonClicked()
                 {
                     g_installing = false;
                     ShowWindow(g_percentageTextHWnd, SW_HIDE);
-                    ShowWindow(g_staticPercentText, SW_HIDE);
                     ShowWindow(g_progressHWnd, SW_HIDE);
                     ShowWindow(g_checkboxHWnd, SW_HIDE);
                     ShowWindow(g_CancelbuttonHWnd, SW_HIDE);
@@ -818,10 +803,10 @@ void UI::SendInstallCompleteMsg()
 void UI::UpdateDisplayPercent(float displayPercent)
 {
     std::wstringstream ss;
-    ss << (int)displayPercent << "%...";
-    SetWindowText(g_staticPercentText, ss.str().c_str());
-    ShowWindow(g_staticPercentText, SW_HIDE);
-    ShowWindow(g_staticPercentText, SW_SHOW);
+    ss << GetStringResource(IDS_STRING_INSTALLING_APP) << " " << (int)displayPercent << "%...";
+    SetWindowText(g_percentageTextHWnd, ss.str().c_str());
+    ShowWindow(g_percentageTextHWnd, SW_HIDE);
+    ShowWindow(g_percentageTextHWnd, SW_SHOW);
 }
 
 void UI::DisplayError(HRESULT hr)

--- a/preview/MsixCore/msixmgr/InstallUI.hpp
+++ b/preview/MsixCore/msixmgr/InstallUI.hpp
@@ -26,7 +26,6 @@ static HWND g_progressHWnd = NULL;
 static HWND g_CancelbuttonHWnd = NULL;
 static HWND g_LaunchbuttonHWnd = NULL;
 static HWND g_percentageTextHWnd = NULL;
-static HWND g_staticPercentText = NULL;
 static HWND g_staticErrorTextHWnd = NULL;
 static HWND g_staticErrorDescHWnd = NULL;
 static bool g_launchCheckBoxState = true; /// launch checkbox is checked by default


### PR DESCRIPTION
+Resize the logo so that logos larger than the size allotted are shrunk down to fit.
+Combine the two % text controls into one, so that they do not overlap, and so the spacing is not weird in other languages. y is also adjusted slightly so text does not overlap with progress bar, which was causing some flickering.
