### PR TITLE
Remove manifested-UAC prompt. Manually re-launch in the scenarios whe…

### DIFF
--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -6,6 +6,7 @@
 #include <CommCtrl.h>
 
 #include <string>
+#include <sstream>
 #include <iostream>
 #include <vector>
 #include <TraceLoggingProvider.h>
@@ -50,11 +51,80 @@ HRESULT LogFileInfo()
     return S_OK;
 }
 
+bool IsAdmin()
+{
+    HANDLE token = nullptr;
+    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+    {
+        TOKEN_ELEVATION_TYPE type;
+        DWORD length = sizeof(TOKEN_ELEVATION_TYPE);
+        if (GetTokenInformation(token, TokenElevationType, &type, sizeof(TOKEN_ELEVATION_TYPE), &length))
+        {
+            PWSTR elevationTypeString = nullptr;
+            switch (type)
+            {
+            case TokenElevationTypeDefault:
+                elevationTypeString = L"DefaultType";
+                break;
+            case TokenElevationTypeFull:
+                elevationTypeString = L"Full";
+                break;
+            case TokenElevationTypeLimited:
+                elevationTypeString = L"Limited";
+                break;
+            default:
+                elevationTypeString = L"unknown";
+                break;
+            }
+
+            TraceLoggingWrite(g_MsixUITraceLoggingProvider, "ElevationType",
+                TraceLoggingValue(elevationTypeString, "ElevationTypeString"),
+                TraceLoggingValue((DWORD)type, "elevationTypeEnum"));
+            if (type == TokenElevationTypeFull)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+void RelaunchAsAdmin(int argc, char * argv[])
+{
+    // free the console window so it's not showing when UAC prompt shows.
+    FreeConsole();
+
+    SHELLEXECUTEINFOW shellExecuteInfo = {};
+    shellExecuteInfo.cbSize = sizeof(SHELLEXECUTEINFOW);
+    shellExecuteInfo.fMask = SEE_MASK_DEFAULT;
+    shellExecuteInfo.lpVerb = L"runas";
+    shellExecuteInfo.lpFile = L"msixmgr.exe";
+    shellExecuteInfo.nShow = SW_SHOW;
+
+    std::wstringstream argumentstream;
+    for (int i = 1; i < argc; i++)
+    {
+        argumentstream << argv[i] << L" ";
+    }
+    std::wstring args = argumentstream.str();
+
+    shellExecuteInfo.lpParameters = args.c_str();
+
+    TraceLoggingWrite(g_MsixUITraceLoggingProvider, "Relaunching as admin",
+        TraceLoggingValue(args.c_str(), "args"));
+
+    ShellExecuteExW(&shellExecuteInfo);
+}
+
 int main(int argc, char * argv[])
 {
     // Register the providers
     TraceLoggingRegister(g_MsixUITraceLoggingProvider);
     TraceLoggingRegister(g_MsixTraceLoggingProvider);
+
+    // Determine if running as admin up front to log the result in all codepaths
+    bool isAdmin = IsAdmin();
 
     HRESULT hrCoInitialize = CoInitializeEx(NULL, COINIT_MULTITHREADED);
     if (FAILED(hrCoInitialize))
@@ -79,6 +149,11 @@ int main(int argc, char * argv[])
 
             if (cli.IsQuietMode())
             {
+                if (!isAdmin)
+                {
+                    RelaunchAsAdmin(argc, argv);
+                    return 0;
+                }
                 HRESULT hrAddPackage = packageManager->AddPackage(cli.GetPackageFilePathToInstall(), DeploymentOptions::None);
                 if (FAILED(hrAddPackage))
                 {
@@ -115,6 +190,11 @@ int main(int argc, char * argv[])
                 }
                 else
                 {
+                    if (!isAdmin)
+                    {
+                        RelaunchAsAdmin(argc, argv);
+                        return 0;
+                    }
                     auto ui = new UI(packageManager, cli.GetPackageFilePathToInstall(), UIType::InstallUIAdd);
                     ui->ShowUI();
                 }
@@ -123,6 +203,11 @@ int main(int argc, char * argv[])
         }
         case OperationType::Remove:
         {
+            if (!isAdmin)
+            {
+                RelaunchAsAdmin(argc, argv);
+                return 0;
+            }
             FreeConsole();
             AutoPtr<IPackageManager> packageManager;
             RETURN_IF_FAILED(MsixCoreLib_CreatePackageManager(&packageManager));

--- a/MsixCore/msixmgr/msixmgr.vcxproj
+++ b/MsixCore/msixmgr/msixmgr.vcxproj
@@ -102,7 +102,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\x86\Debug;..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
@@ -132,7 +132,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\x64\Debug;..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
@@ -171,7 +171,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\x86\Release;..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>
@@ -206,7 +206,7 @@ del "$(OutDir)msixmgr_LN.exe"
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\x64\Release;..\..\.vs\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
+      <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <AdditionalOptions>comctl32.lib %(AdditionalOptions)</AdditionalOptions>
       <AdditionalDependencies>msixmgrlib.lib;msix.lib;msi.lib;comctl32.lib;uxtheme.lib;gdiplus.lib;version.lib;taskschd.lib;windowsapp_downlevel.lib;windowsapp.lib;urlmon.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>api-ms-win-core-winrt-string-l1-1-0.dll;api-ms-win-core-winrt-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-0.dll;api-ms-win-core-winrt-error-l1-1-1.dll</DelayLoadDLLs>


### PR DESCRIPTION
…re we require admin.

Before: running as non-elevated user would prompt for UAC, and then display the results for cmdlines like -findpackage and help text in a window that flashes and closes.

After: we don't require a UAC prompt for -findpackage or showing help text; the UAC only prompts on -addpackage and -removepackage calls.