### PR TITLE
Dont fail on missing registry

### DIFF
--- a/MsixCore/msixmgr/FileTypeAssociation.cpp
+++ b/MsixCore/msixmgr/FileTypeAssociation.cpp
@@ -167,7 +167,10 @@ HRESULT FileTypeAssociation::ProcessFtaForAdd(Fta& fta)
         }
 
         bool registryHasExtension = false;
-        RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->HasFTA(*extensionName, registryHasExtension));
+        if (m_msixRequest->GetRegistryDevirtualizer() != nullptr)
+        {
+            RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->HasFTA(*extensionName, registryHasExtension));
+        }
 
         if (registryHasExtension)
         {
@@ -260,7 +263,10 @@ HRESULT FileTypeAssociation::ProcessFtaForRemove(Fta& fta)
     for (auto extensionName = fta.extensions.begin(); extensionName != fta.extensions.end(); ++extensionName)
     {
         bool registryHasExtension = false;
-        RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->HasFTA(*extensionName, registryHasExtension));
+        if (m_msixRequest->GetRegistryDevirtualizer() != nullptr)
+        {
+            RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->HasFTA(*extensionName, registryHasExtension));
+        }
 
         if (registryHasExtension)
         {

--- a/MsixCore/msixmgr/RegistryDevirtualizer.cpp
+++ b/MsixCore/msixmgr/RegistryDevirtualizer.cpp
@@ -30,7 +30,13 @@ HRESULT RegistryDevirtualizer::Run(_In_ bool remove)
     }
 
     std::wstring rootPath = m_loadedHiveKeyName + L"\\Registry";
-    RETURN_IF_FAILED(m_rootKey.Open(HKEY_USERS, rootPath.c_str(), KEY_READ));
+    HRESULT hrOpenRootKey = m_rootKey.Open(HKEY_USERS, rootPath.c_str(), KEY_READ);
+    if (hrOpenRootKey == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+    {
+        TraceLoggingWrite(g_MsixTraceLoggingProvider,
+            "Skipping registry devirtualization because root Registry hive does not exist.");
+        return S_OK;
+    }
     
     for (auto mapping : mappings)
     {

--- a/MsixCore/msixmgr/RegistryDevirtualizer.cpp
+++ b/MsixCore/msixmgr/RegistryDevirtualizer.cpp
@@ -416,7 +416,6 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
 
     if (registryFileExists)
     {
-        localInstance->m_hiveFileNameExists = true;
         HANDLE userToken = nullptr;
         if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY | TOKEN_ADJUST_PRIVILEGES, &userToken))
         {
@@ -464,6 +463,8 @@ HRESULT RegistryDevirtualizer::Create(std::wstring hiveFileName, MsixRequest* ms
 
         RETURN_IF_FAILED(CreateTempKeyName(localInstance->m_loadedHiveKeyName));
         RETURN_IF_FAILED(HRESULT_FROM_WIN32(RegLoadKey(HKEY_USERS, localInstance->m_loadedHiveKeyName.c_str(), localInstance->m_registryHiveFileName.c_str())));
+        
+        localInstance->m_hiveFileNameExists = true;
     }
 
     *instance = localInstance;

--- a/MsixCore/msixmgr/WriteDevirtualizedRegistry.cpp
+++ b/MsixCore/msixmgr/WriteDevirtualizedRegistry.cpp
@@ -16,7 +16,18 @@ const PCWSTR WriteDevirtualizedRegistry::HandlerName = L"WriteDevirtualizedRegis
 
 HRESULT WriteDevirtualizedRegistry::ExecuteForAddRequest()
 {
-    RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->Run(false));
+    const HRESULT hrWriteRegistry = m_msixRequest->GetRegistryDevirtualizer()->Run(false);
+    if (FAILED(hrWriteRegistry))
+    {
+        const HRESULT hrUnloadMountedHive = m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive();
+        TraceLoggingWrite(g_MsixTraceLoggingProvider,
+            "Unable to write registry",
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+            TraceLoggingValue(hrWriteRegistry, "HR"),
+            TraceLoggingValue(hrUnloadMountedHive, "HR"));
+
+        return hrWriteRegistry;
+    }
     RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive());
     return S_OK;
 }

--- a/MsixCore/msixmgr/WriteDevirtualizedRegistry.cpp
+++ b/MsixCore/msixmgr/WriteDevirtualizedRegistry.cpp
@@ -16,33 +16,39 @@ const PCWSTR WriteDevirtualizedRegistry::HandlerName = L"WriteDevirtualizedRegis
 
 HRESULT WriteDevirtualizedRegistry::ExecuteForAddRequest()
 {
-    const HRESULT hrWriteRegistry = m_msixRequest->GetRegistryDevirtualizer()->Run(false);
-    if (FAILED(hrWriteRegistry))
+    if (m_msixRequest->GetRegistryDevirtualizer() != nullptr)
     {
-        const HRESULT hrUnloadMountedHive = m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive();
-        TraceLoggingWrite(g_MsixTraceLoggingProvider,
-            "Unable to write registry",
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
-            TraceLoggingValue(hrWriteRegistry, "HR"),
-            TraceLoggingValue(hrUnloadMountedHive, "HR"));
+        const HRESULT hrWriteRegistry = m_msixRequest->GetRegistryDevirtualizer()->Run(false);
+        if (FAILED(hrWriteRegistry))
+        {
+            const HRESULT hrUnloadMountedHive = m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive();
+            TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                "Unable to write registry",
+                TraceLoggingLevel(WINEVENT_LEVEL_ERROR),
+                TraceLoggingValue(hrWriteRegistry, "HR"),
+                TraceLoggingValue(hrUnloadMountedHive, "HR"));
 
-        return hrWriteRegistry;
+            return hrWriteRegistry;
+        }
+        RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive());
     }
-    RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive());
     return S_OK;
 }
 
 HRESULT WriteDevirtualizedRegistry::ExecuteForRemoveRequest()
 {
-    const HRESULT hrRemoveRegistry = m_msixRequest->GetRegistryDevirtualizer()->Run(true);
-    if (FAILED(hrRemoveRegistry))
+    if (m_msixRequest->GetRegistryDevirtualizer() != nullptr)
     {
-        TraceLoggingWrite(g_MsixTraceLoggingProvider,
-            "Unable to remove registry",
-            TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
-            TraceLoggingValue(hrRemoveRegistry, "HR"));
+        const HRESULT hrRemoveRegistry = m_msixRequest->GetRegistryDevirtualizer()->Run(true);
+        if (FAILED(hrRemoveRegistry))
+        {
+            TraceLoggingWrite(g_MsixTraceLoggingProvider,
+                "Unable to remove registry",
+                TraceLoggingLevel(WINEVENT_LEVEL_WARNING),
+                TraceLoggingValue(hrRemoveRegistry, "HR"));
+        }
+        RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive());
     }
-    RETURN_IF_FAILED(m_msixRequest->GetRegistryDevirtualizer()->UnloadMountedHive());
     return S_OK;
 }
 


### PR DESCRIPTION
Registry.dat provided can be in unexpected formats: we won't fail when it's in an unexpected format; also, if registrydevirtualizer fails during create, we will crash because we did not set it in msixrequest. Consumers of this should check for null before using. 