### PR TITLE
Updated EndsWith API in GeneralUtils.cpp to make case-insensitive comparison

### DIFF
--- a/MsixCore/msixmgrLib/GeneralUtil.cpp
+++ b/MsixCore/msixmgrLib/GeneralUtil.cpp
@@ -236,8 +236,7 @@ namespace MsixCoreLib
         return VerifyVersionInfo(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask);
     }
 
-    bool EndsWith(std::wstring const &fullString, std::wstring const &ending) {
-        
+    bool EndsWith(std::wstring const &fullString, std::wstring const &ending) { 
         if (fullString.length() >= ending.length()) {
             std::wstring fullStringPrefix = fullString.substr(fullString.length() - ending.length(), ending.length());
             return CaseInsensitiveEquals(fullStringPrefix, ending);

--- a/MsixCore/msixmgrLib/GeneralUtil.cpp
+++ b/MsixCore/msixmgrLib/GeneralUtil.cpp
@@ -236,7 +236,7 @@ namespace MsixCoreLib
         return VerifyVersionInfo(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask);
     }
 
-    bool EndsWith(std::wstring const &fullString, std::wstring const &ending) { 
+    bool EndsWith(std::wstring const &fullString, std::wstring const &ending) {
         if (fullString.length() >= ending.length()) {
             std::wstring fullStringPrefix = fullString.substr(fullString.length() - ending.length(), ending.length());
             return CaseInsensitiveEquals(fullStringPrefix, ending);

--- a/MsixCore/msixmgrLib/GeneralUtil.cpp
+++ b/MsixCore/msixmgrLib/GeneralUtil.cpp
@@ -237,8 +237,10 @@ namespace MsixCoreLib
     }
 
     bool EndsWith(std::wstring const &fullString, std::wstring const &ending) {
+        
         if (fullString.length() >= ending.length()) {
-            return (0 == fullString.compare(fullString.length() - ending.length(), ending.length(), ending));
+            std::wstring fullStringPrefix = fullString.substr(fullString.length() - ending.length(), ending.length());
+            return CaseInsensitiveEquals(fullStringPrefix, ending);
         }
         else {
             return false;


### PR DESCRIPTION
**Problem:**

When running the command: 

msixmgr.exe -unpack -packagePath <appx.appxbundle> -destination 

...package paths that did not have a file extension in all lower-case letters (.appxbundle vs. .AppxBundle) would get rejected as invalid package paths. 

**Changes:**

Updated the EndsWith API in GeneralUtils.cpp to make case-insensitive comparisons.

**Validation:**

Successfully unpacked packages and bundles regardless of whether file extension was all lower-case letters.