### PR TITLE
Enable build for Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ We also produce msix-jni.jar which acts as a helper to get the languages from th
 The default level for the SDK level is 24 because we use the [Configuration class](https://developer.android.com/reference/android/content/res/Configuration) and, depending on the version of the device, we either use the locale attribute (deprecated as of API level 24) or getLocales.
 We recommend using the [makeaosp](makeaosp) script to build for Android on non-Windows devices.
 
+## Apple Silicon
+To enable building the MSIX SDK to run on Apple Silicon do the following:
+1. Install Xcode beta 12 build 12A8161k (https://developer.apple.com/download/)
+2. Change active developer directory `sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer`
+3. Build using makemac.sh `./makemac.sh -arch arm64 --skip-tests`
+
 ## Testing
 msixtest uses Catch2 as testing framework. msixtest is either an executable or a shared library, depending on the platform. It has a single entrypoint msixtest_main that takes argc and argv, as main, plus the path were the test packages are located. The shared library is used for our mobile test apps, while non-mobile just forwards the arguments to msixtest_main. It requires msix.dll to be build with "Release" or "RelWithDebInfo" CMake switch. 
 

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -1,4 +1,4 @@
-# This is a check to fail arm64 build if the Xcode version is not adecuate.
+# This is a check to fail arm64 build if the Xcode version is not adequate.
 
 # Get xcode version and build.
 execute_process(COMMAND xcodebuild -version OUTPUT_VARIABLE XCODE_OUTPUT ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -14,13 +14,13 @@ if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
     if (XCODE_VERSION LESS 12.0)
         # If you see this and you have Xcode-beta 12 do:
         # sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer
-        message(FATAL_ERROR "arm64 is not supported for Xcode version ${XCODE_VERSION}")
+        message(FATAL_ERROR "arm64 is only supported on Xcode 12 12A8161k at this time. Found version ${XCODE_VERSION}. To enable arm64 builds please download Xcode beta 12 build 12A8161k and run `sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer`")
     endif()
 
     # WARNING, this will be false once Xcode 12 is release. Currently there are two
     # Xcode-beta 12, build 12A8161k and build 12A6163b. The latter does NOT support arm64
     if (NOT XCODE_BUILD MATCHES "12A8161k")
-        message(FATAL_ERROR "arm64 is not supported for Xcode build ${XCODE_BUILD}")
+        message(FATAL_ERROR "arm64 is only supported on Xcode 12 12A8161k at this time. Found build ${XCODE_BUILD}")
     endif()
 
 endif()

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -1,4 +1,4 @@
-# This is a workaround while Xcode 12 is still in beta.
+# This is a check to fail arm64 build if the Xcode version is not adecuate.
 
 # Get xcode version and build.
 execute_process(COMMAND xcodebuild -version OUTPUT_VARIABLE XCODE_OUTPUT ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -18,7 +18,7 @@ if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
     endif()
 
     # WARNING, this will be false once Xcode 12 is release. Currently there are two
-    # Xcode-beta 12, build 12A8161k and build 12A6163b. The later does NOT support arm64
+    # Xcode-beta 12, build 12A8161k and build 12A6163b. The latter does NOT support arm64
     if (NOT XCODE_BUILD MATCHES "12A8161k")
         message(FATAL_ERROR "arm64 is not supported for Xcode build ${XCODE_BUILD}")
     endif()

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -1,0 +1,26 @@
+# This is a workaround while Xcode 12 is still in beta.
+
+# Get xcode version and build.
+execute_process(COMMAND xcodebuild -version OUTPUT_VARIABLE XCODE_OUTPUT ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(REGEX MATCH "Xcode [0-9\\.]+" XCODE_VERSION "${XCODE_OUTPUT}")
+string(REGEX REPLACE "Xcode ([0-9\\.]+)" "\\1" XCODE_VERSION "${XCODE_VERSION}")
+string(REGEX MATCH "Build version [a-zA-Z0-9]+" XCODE_BUILD "${XCODE_OUTPUT}")
+string(REGEX REPLACE "Build version ([a-zA-Z0-9]+)" "\\1" XCODE_BUILD "${XCODE_BUILD}")
+message(STATUS "Using Xcode version: ${XCODE_VERSION}")
+message(STATUS "Using Xcode build: ${XCODE_BUILD}")
+
+if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+    # arm64 is only supported for version xcode 12 and higher
+    if (XCODE_VERSION LESS 12.0)
+        # If you see this and you have Xcode-beta 12 do:
+        # sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer
+        message(FATAL_ERROR "arm64 is not supported for Xcode version ${XCODE_VERSION}")
+    endif()
+
+    # WARNING, this will be false once Xcode 12 is release. Currently there are two
+    # Xcode-beta 12, build 12A8161k and build 12A6163b. The later does NOT support arm64
+    if (NOT XCODE_BUILD MATCHES "12A8161k")
+        message(FATAL_ERROR "arm64 is not supported for Xcode build ${XCODE_BUILD}")
+    endif()
+
+endif()

--- a/makemac.sh
+++ b/makemac.sh
@@ -9,6 +9,7 @@ validationParser=off
 pack=off
 samples=on
 tests=on
+arch=x86_64
 
 usage()
 {
@@ -22,6 +23,7 @@ usage()
     echo $'\t' "--pack                  Include packaging features. Uses MSIX SDK Zlib and Xerces with validation parser on."
     echo $'\t' "--skip-samples          Skip building samples."
     echo $'\t' "--skip-tests            Skip building tests."
+    echo $'\t' "-arch arch              Architecture. Default x86_64"
 }
 
 printsetup()
@@ -68,6 +70,9 @@ while [ "$1" != "" ]; do
         -h )    usage
                 exit
                 ;;
+        -arch ) shift
+                arch=$1
+                ;;
         * )     usage
                 exit 1
     esac
@@ -83,7 +88,7 @@ find . -name *msix* -d | xargs rm -r
 
 echo "cmake -DCMAKE_BUILD_TYPE="$build $zlib "-DSKIP_BUNDLES="$bundle 
 echo "-DXML_PARSER="$xmlparser "-DASAN="$addressSanitizer "-DUSE_VALIDATION_PARSER="$validationParser 
-echo "-DMSIX_PACK="$pack "-DMSIX_SAMPLES="$samples "-DMSIX_TESTS="$tests "-DMACOS=on .."
+echo "-DMSIX_PACK="$pack "-DMSIX_SAMPLES="$samples "-DMSIX_TESTS="$tests "-DCMAKE_OSX_ARCHITECTURES="$arch "-DMACOS=on .."
 cmake -DCMAKE_BUILD_TYPE=$build \
       -DXML_PARSER=$xmlparser \
       -DSKIP_BUNDLES=$bundle \
@@ -92,5 +97,7 @@ cmake -DCMAKE_BUILD_TYPE=$build \
       -DMSIX_PACK=$pack \
       -DMSIX_SAMPLES=$samples \
       -DMSIX_TESTS=$tests \
+      -DCMAKE_OSX_ARCHITECTURES=$arch \
+      -DCMAKE_TOOLCHAIN_FILE=../cmake/macos.cmake \
       $zlib -DMACOS=on ..
 make


### PR DESCRIPTION
This changes enables building the MSIX SDK to run on Apple Silicon Macs.

Prerequisites:

- Xcode 12 beta Build 12A8161k

Notes: Currently there are two Xcode 12 beta builds: 12A6163b and 12A8161k. 12A6163b does NOT include support for building macOS Universal apps. Also, this is the version that ADO's macOS agents have preinstalled it is not added to our automated builds. When ADO updates their images or when Xcode 12 releases a new change include the build. 