### PR TITLE
Rename GetLogTextUTF8 to MsixGetLogTextUTF8

### DIFF
--- a/sample/BundleSample/BundleSample.cpp
+++ b/sample/BundleSample/BundleSample.cpp
@@ -201,7 +201,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Error: " << std::hex << hr << " while extracting the appx package" <<std::endl;
         Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {   std::cout << "LOG:" << std::endl << text.content << std::endl;
         }

--- a/sample/ExtractContentsSample/ExtractContentsSample.cpp
+++ b/sample/ExtractContentsSample/ExtractContentsSample.cpp
@@ -478,7 +478,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Error: " << std::hex << result << " while extracting the appx package" <<std::endl;
         Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {   std::cout << "LOG:" << std::endl << text.content << std::endl;
         }

--- a/sample/OverrideLanguageSample/OverrideLanguageSample.cpp
+++ b/sample/OverrideLanguageSample/OverrideLanguageSample.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Error: " << std::hex << hr << " while reading the bundle" << std::endl;
         Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {
             std::cout << "LOG:" << std::endl << text.content << std::endl;

--- a/sample/OverrideStreamSample/OverrideStreamSample.cpp
+++ b/sample/OverrideStreamSample/OverrideStreamSample.cpp
@@ -446,7 +446,7 @@ int main(int argc, char* argv[])
     {
         std::cout << "Error: " << std::hex << hr << " while extracting the appx package" <<std::endl;
         Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {   std::cout << "LOG:" << std::endl << text.content << std::endl;
         }

--- a/sample/PackSample/PackSample.cpp
+++ b/sample/PackSample/PackSample.cpp
@@ -329,7 +329,7 @@ int main(int argc, char* argv[])
         remove(package.c_str());
         std::cout << "Error: " << std::hex << hr << " while extracting the appx package" <<std::endl;
         Text<char> text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {
             std::cout << "LOG:" << std::endl << text.content << std::endl;

--- a/src/inc/public/AppxPackaging.hpp
+++ b/src/inc/public/AppxPackaging.hpp
@@ -1740,8 +1740,14 @@ typedef void STDMETHODCALLTYPE COTASKMEMFREE(LPVOID pv);
 
 MSIX_API HRESULT STDMETHODCALLTYPE MsixGetLogTextUTF8(COTASKMEMALLOC* memalloc, char** logText) noexcept;
 
+#ifndef MSIX_DEFINE_GetLogTextUTF8_BACKCOMPAT
+#define MSIX_DEFINE_GetLogTextUTF8_BACKCOMPAT 1
+#endif
+
+#if MSIX_DEFINE_GetLogTextUTF8_BACKCOMPAT
 #ifndef GetLogTextUTF8
 #define GetLogTextUTF8(memalloc, logText) MsixGetLogTextUTF8(memalloc, logText)
+#endif
 #endif
 
 // Call specific for Windows. Default to call CoTaskMemAlloc and CoTaskMemFree

--- a/src/inc/public/AppxPackaging.hpp
+++ b/src/inc/public/AppxPackaging.hpp
@@ -1738,7 +1738,11 @@ MSIX_API HRESULT STDMETHODCALLTYPE PackPackage(
 typedef LPVOID STDMETHODCALLTYPE COTASKMEMALLOC(SIZE_T cb);
 typedef void STDMETHODCALLTYPE COTASKMEMFREE(LPVOID pv);
 
-MSIX_API HRESULT STDMETHODCALLTYPE GetLogTextUTF8(COTASKMEMALLOC* memalloc, char** logText) noexcept;
+MSIX_API HRESULT STDMETHODCALLTYPE MsixGetLogTextUTF8(COTASKMEMALLOC* memalloc, char** logText) noexcept;
+
+#ifndef GetLogTextUTF8
+#define GetLogTextUTF8(memalloc, logText) MsixGetLogTextUTF8(memalloc, logText)
+#endif
 
 // Call specific for Windows. Default to call CoTaskMemAlloc and CoTaskMemFree
 MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxFactory(

--- a/src/makemsix/main.cpp
+++ b/src/makemsix/main.cpp
@@ -603,7 +603,7 @@ int main(int argc, char* argv[])
         }
 
         Text text;
-        auto logResult = GetLogTextUTF8(MyAllocate, &text);
+        auto logResult = MsixGetLogTextUTF8(MyAllocate, &text);
         if (0 == logResult)
         {
             std::cout << "LOG:" << std::endl << text.content << std::endl;

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -27,7 +27,8 @@ list(APPEND MSIX_EXPORTS
     "CoCreateAppxFactoryWithHeap"
     "CreateStreamOnFile"
     "CreateStreamOnFileUTF16"
-    "GetLogTextUTF8"
+    "MsixGetLogTextUTF8"
+    "GetLogTextUTF8=MsixGetLogTextUTF8"
     "CoCreateAppxBundleFactory"
     "CoCreateAppxBundleFactoryWithHeap"
     ${MSIX_UNPACK_EXPORTS}

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -28,7 +28,6 @@ list(APPEND MSIX_EXPORTS
     "CreateStreamOnFile"
     "CreateStreamOnFileUTF16"
     "MsixGetLogTextUTF8"
-    "GetLogTextUTF8=MsixGetLogTextUTF8"
     "CoCreateAppxBundleFactory"
     "CoCreateAppxBundleFactoryWithHeap"
     ${MSIX_UNPACK_EXPORTS}

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -41,7 +41,7 @@ static void finalizer(void) {
 LPVOID STDMETHODCALLTYPE InternalAllocate(SIZE_T cb)  { return std::malloc(cb); }
 void STDMETHODCALLTYPE InternalFree(LPVOID pv)        { std::free(pv); }
 
-MSIX_API HRESULT STDMETHODCALLTYPE GetLogTextUTF8(COTASKMEMALLOC* memalloc, char** logText) noexcept try
+MSIX_API HRESULT STDMETHODCALLTYPE MsixGetLogTextUTF8(COTASKMEMALLOC* memalloc, char** logText) noexcept try
 {
     ThrowErrorIf(MSIX::Error::InvalidParameter, (logText == nullptr || *logText != nullptr), "bad pointer" );
     std::size_t countBytes = sizeof(char)*(MSIX::Global::Log::Text().size()+1);


### PR DESCRIPTION
Caller can now use MsixGetLogTextUTF8. To avoid compat issues, if GetLogTextUTF8 is not defined we define it.

Address #210. 