### PR TITLE
Fix [Content Types].xml creation for files without an extension

### DIFF
--- a/src/msix/pack/ContentTypeWriter.cpp
+++ b/src/msix/pack/ContentTypeWriter.cpp
@@ -44,11 +44,11 @@ namespace MSIX {
     {
         auto percentageEncodedName = Encoding::EncodeFileName(name);
 
-        auto lastDir = percentageEncodedName;
-        auto lastSlash = lastDir.find_last_of("/");
+        auto filename = percentageEncodedName;
+        auto lastSlash = filename.find_last_of("/");
         if (lastSlash != std::string::npos)
         {
-            lastDir = lastDir.substr(lastSlash + 1);
+            filename = filename.substr(lastSlash + 1);
         }
 
         if (forceOverride)
@@ -57,11 +57,11 @@ namespace MSIX {
             return;
         }
 
-        auto findLastPeriod = lastDir.find_last_of(".");
+        auto findLastPeriod = filename.find_last_of(".");
         if (findLastPeriod != std::string::npos)
         {
             // See if already exist
-            std::string ext = lastDir.substr(findLastPeriod + 1);
+            std::string ext = filename.substr(findLastPeriod + 1);
             std::string normalizedExt = ext;
             std::transform(normalizedExt.begin(), normalizedExt.end(), normalizedExt.begin(), ::tolower);
             auto find = m_defaultExtensions.find(normalizedExt);

--- a/src/msix/pack/ContentTypeWriter.cpp
+++ b/src/msix/pack/ContentTypeWriter.cpp
@@ -44,17 +44,24 @@ namespace MSIX {
     {
         auto percentageEncodedName = Encoding::EncodeFileName(name);
 
+        auto lastDir = percentageEncodedName;
+        auto lastSlash = lastDir.find_last_of("/");
+        if (lastSlash != std::string::npos)
+        {
+            lastDir = lastDir.substr(lastSlash + 1);
+        }
+
         if (forceOverride)
         {
             AddOverride(percentageEncodedName, contentType);
             return;
         }
 
-        auto findLastPeriod = percentageEncodedName.find_last_of(".");
+        auto findLastPeriod = lastDir.find_last_of(".");
         if (findLastPeriod != std::string::npos)
         {
             // See if already exist
-            std::string ext = percentageEncodedName.substr(percentageEncodedName.find_last_of(".") + 1);
+            std::string ext = lastDir.substr(findLastPeriod + 1);
             std::string normalizedExt = ext;
             std::transform(normalizedExt.begin(), normalizedExt.end(), normalizedExt.begin(), ::tolower);
             auto find = m_defaultExtensions.find(normalizedExt);


### PR DESCRIPTION
At package time, adding files to the [Content Types].xml where a parent directory contains a "." and the actual file doesn't have an extension incorrectly took that "." from a parent directory as a file extension. For example for ".git/description" produces an Extension element `<Default ContentType="application/octet-stream" Extension="git/description"/>` instead of the correctly Override element `<Override ContentType="application/octet-stream" PartName="/.git/config"/>`

#355 uncovered this issue but incorrectly states that the .git folder was not in the package.
