### PR TITLE
Update schemas to Vibranium 20H1

### DIFF
--- a/cmake/msix_resources.cmake
+++ b/cmake/msix_resources.cmake
@@ -129,6 +129,12 @@ if ((XML_PARSER MATCHES msxml6) OR (XML_PARSER MATCHES xerces))
             "http://schemas.microsoft.com/appx/manifest/uap/windows10/7"                               "uap7"               "AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v7.xsd")
         list(APPEND MANIFEST_UAP8
             "http://schemas.microsoft.com/appx/manifest/uap/windows10/8"                               "uap8"               "AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v8.xsd")
+        list(APPEND MANIFEST_COM3
+            "http://schemas.microsoft.com/appx/manifest/com/windows10/3"                               "com3"               "AppxPackaging/Manifest/Schema/2019/ComManifestSchema_v3.xsd")
+        list(APPEND MANIFEST_PREVIEWAPPCOMPAT
+            "http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"        "previewappcompat"   "AppxPackaging/Manifest/Schema/2019/PreviewManifestSchema_MsixAppCompatSupport.xsd")
+        list(APPEND MANIFEST_UAP10
+            "http://schemas.microsoft.com/appx/manifest/uap/windows10/10"                              "uap10"              "AppxPackaging/Manifest/Schema/2019/UapManifestSchema_v10.xsd" )
         list(APPEND RESOURCES_APPXMANIFEST
             MANIFEST_FOUNDATION
             MANIFEST_UAP
@@ -162,7 +168,10 @@ if ((XML_PARSER MATCHES msxml6) OR (XML_PARSER MATCHES xerces))
             MANIFEST_UAP5
             MANIFEST_UAP6
             MANIFEST_UAP7
-            MANIFEST_UAP8)
+            MANIFEST_UAP8
+            MANIFEST_COM3
+            MANIFEST_PREVIEWAPPCOMPAT
+            MANIFEST_UAP10)
 
         # Bundle manifest
         list(APPEND BUNDLE_2014
@@ -173,11 +182,14 @@ if ((XML_PARSER MATCHES msxml6) OR (XML_PARSER MATCHES xerces))
             "http://schemas.microsoft.com/appx/2017/bundle" "b3" "AppxPackaging/Manifest/Schema/2017/BundleManifestSchema2017.xsd")
         list(APPEND BUNDLE_2018
             "http://schemas.microsoft.com/appx/2018/bundle" "b4" "AppxPackaging/Manifest/Schema/2018/BundleManifestSchema2018.xsd")
+        list(APPEND BUNDLE_2019
+            "http://schemas.microsoft.com/appx/2019/bundle" "b5" "AppxPackaging/Manifest/Schema/2019/BundleManifestSchema2019.xsd")
         list(APPEND RESOURCES_APPXBUNDLEMANIFEST
             BUNDLE_2014
             BUNDLE_2016
             BUNDLE_2017
-            BUNDLE_2018)
+            BUNDLE_2018
+            BUNDLE_2019)
 
         if (XML_PARSER MATCHES xerces)
             file(COPY ${RESOURCES_DIR} DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
@@ -236,6 +248,19 @@ if ((XML_PARSER MATCHES msxml6) OR (XML_PARSER MATCHES xerces))
                 APPTYPES_TEXT "${APPTYPES_TEXT}")
 
             file(WRITE "${RESOURCES_DIR}/${APPX_TYPES_FILE}" "${APPTYPES_TEXT}")
+
+            # DesktopManifestSchema_v6.xsd 
+            list(GET MANIFEST_DESK6 2 DESK6_FILE)
+            file(READ "${RESOURCES_DIR}/${DESK6_FILE}" DESK6_TEXT)
+
+            # ST_ServiceName same as ST_Description above
+            string(REGEX REPLACE 
+                [[\\x01-\\x1f]]
+                [[\\t\\n\\r]]
+                DESK6_TEXT "${DESK6_TEXT}")
+
+            file(WRITE "${RESOURCES_DIR}/${DESK6_FILE}" "${DESK6_TEXT}")
+
         endif()
 
         function(CreateNamespaceManager LIST OUTPUT)

--- a/resources/AppxPackaging/Manifest/Schema/2015/AppxManifestTypes.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/AppxManifestTypes.xsd
@@ -103,6 +103,19 @@
       <xs:maxLength value="64"/>
     </xs:restriction>
   </xs:simpleType>
+
+  <xs:simpleType name="ST_FileNameCharSet_2019">
+    <xs:restriction base="ST_NonEmptyString">
+      <xs:pattern value="[^&lt;&gt;&quot;:%|?\x01-\x1f]+"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_FileType_2019">
+    <xs:restriction base="ST_FileNameCharSet_2019">
+      <xs:pattern value="(\*|.[^.\*]+)"/>
+      <xs:maxLength value="64"/>
+    </xs:restriction>
+  </xs:simpleType>
   
   <xs:simpleType name="ST_FileTypeOrStar">
     <xs:restriction base="ST_NonEmptyString">
@@ -749,10 +762,27 @@
     </xs:restriction>
   </xs:simpleType>
 
+  <xs:simpleType name="ST_ExtensionCategory_Uap10">
+    <xs:restriction base="xs:string">
+      <!-- Application Extensions -->
+      <xs:enumeration value="windows.protocol"/>
+      <!-- Package Extensions -->
+      <xs:enumeration value="windows.hostRuntime"/>
+      <xs:enumeration value="windows.installedLocationVirtualization"/>
+      <xs:enumeration value="windows.mediaContentDecryptionModule"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:simpleType name="ST_ExtensionCategory_Com">
     <xs:restriction base="xs:string">
       <xs:enumeration value="windows.comServer"/>
       <xs:enumeration value="windows.comInterface"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_ExtensionCategory_Preview_Com">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="windows.comServer"/>
     </xs:restriction>
   </xs:simpleType>
 
@@ -1125,6 +1155,13 @@
       <xs:pattern value="[a-z][-a-z0-9\.\+]*"/>
       <xs:minLength value="2"/>
       <xs:maxLength value="39"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_Protocol_2019">
+    <xs:restriction base="ST_NonEmptyString">
+      <xs:minLength value="2"/>
+      <xs:maxLength value="2048"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/BundleManifestSchema2013.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/BundleManifestSchema2013.xsd
@@ -5,10 +5,12 @@
     xmlns="http://schemas.microsoft.com/appx/2013/bundle"
     xmlns:b="http://schemas.microsoft.com/appx/2013/bundle"
     xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
-    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle">
+    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle"
+    xmlns:b5="http://schemas.microsoft.com/appx/2019/bundle">
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
   <xs:import namespace="http://schemas.microsoft.com/appx/2018/bundle" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2019/bundle" />
 
   <!-- Root bundle element -->
   <xs:element name="Bundle">
@@ -23,8 +25,8 @@
         </xs:element>
         <xs:element name="Packages">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element name="Package" maxOccurs="10000">
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element name="Package">
                 <xs:complexType>
                   <xs:all>
                     <xs:element name="Resources" type="CT_Resources" />
@@ -51,7 +53,8 @@
                   <xs:field xpath="@DXFeatureLevel"/>
                 </xs:unique>
               </xs:element>
-            </xs:sequence>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/resources/AppxPackaging/Manifest/Schema/2015/BundleManifestSchema2014.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/BundleManifestSchema2014.xsd
@@ -5,10 +5,12 @@
     xmlns="http://schemas.microsoft.com/appx/2013/bundle"
     xmlns:b="http://schemas.microsoft.com/appx/2013/bundle"
     xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
-    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle">
+    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle"
+    xmlns:b5="http://schemas.microsoft.com/appx/2019/bundle">
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
   <xs:import namespace="http://schemas.microsoft.com/appx/2018/bundle" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2019/bundle" />
 
   <!-- Root bundle element -->
   <xs:element name="Bundle">
@@ -23,8 +25,8 @@
         </xs:element>
         <xs:element name="Packages">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element name="Package" maxOccurs="10000">
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element name="Package">
                 <xs:complexType>
                   <xs:all>
                     <xs:element name="Resources" type="CT_Resources" />
@@ -51,7 +53,8 @@
                   <xs:field xpath="@DXFeatureLevel"/>
                 </xs:unique>
               </xs:element>
-            </xs:sequence>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
       </xs:all>

--- a/resources/AppxPackaging/Manifest/Schema/2015/ComManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/ComManifestSchema.xsd
@@ -21,11 +21,15 @@
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
            xmlns:com2="http://schemas.microsoft.com/appx/manifest/com/windows10/2"
+           xmlns:com3="http://schemas.microsoft.com/appx/manifest/com/windows10/3"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/com/windows10/2"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/com/windows10/3"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extensions" substitutionGroup="f:ComExtensions" type="CT_ComPackageExtensions"/>
 
@@ -48,7 +52,7 @@
         <xs:element name="ComServer" type="CT_ComServer" maxOccurs="1">
           <!-- Class/@AutoConvertTo, ProgId/@Clsid and TreatAsClass/@TreatAs refers to ExeServer/Class/@Id | SurrogateServer/Class/@Id | TreatAsClass/@Id-->
           <xs:key name="Class_Or_TreatAsClass_IdKey">
-            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com:TreatAsClass"/>
+            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com:TreatAsClass | com3:ServiceServer/com3:Class"/>
             <xs:field xpath="@Id"/>
           </xs:key>
           <xs:keyref name="ProgId_ClsidRef" refer="Class_Or_TreatAsClass_IdKey">
@@ -60,7 +64,7 @@
             <xs:field xpath="@TreatAs"/>
           </xs:keyref>
           <xs:keyref name="AutoConvertToRef" refer="Class_Or_TreatAsClass_IdKey">
-            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com:TreatAsClass"/>
+            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com:TreatAsClass | com3:ServiceServer/com3:Class"/>
             <xs:field xpath="@AutoConvertTo"/>
           </xs:keyref>
           <!-- Class/@ProgId , Class/@VersionIndependentProgId and ProgId/@CurrentVersion refer to ProgId/@Id-->
@@ -69,15 +73,49 @@
             <xs:field xpath="@Id"/>
           </xs:key>
           <xs:keyref name="Class_ProgIdRef" refer="ProgId_IdKey">
-            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class"/>
+            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
             <xs:field xpath="@ProgId"/>
           </xs:keyref>
           <xs:keyref name="Class_VerIndProgIdRef" refer="ProgId_IdKey">
-            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class"/>
+            <xs:selector xpath="com:ExeServer/com:Class | com:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
             <xs:field xpath="@VersionIndependentProgId"/>
           </xs:keyref>
           <xs:keyref name="ProgId_CurrentVersionRef" refer="ProgId_IdKey">
             <xs:selector xpath="com:ProgId"/>
+            <xs:field xpath="@CurrentVersion"/>
+          </xs:keyref>
+          <!--Com3: Class/@AutoConvertTo, ProgId/@Clsid and TreatAsClass/@TreatAs refers to ExeServer/Class/@Id | SurrogateServer/Class/@Id | TreatAsClass/@Id | com3:ServiceServer/com3:Class/@id-->
+          <xs:key name="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:TreatAsClass | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@Id"/>
+          </xs:key>
+          <xs:keyref name="Com3_ProgId_ClsidRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
+            <xs:field xpath="@Clsid"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_TreatAsRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:TreatAsClass"/>
+            <xs:field xpath="@TreatAs"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_AutoConvertToRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:TreatAsClass | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@AutoConvertTo"/>
+          </xs:keyref>
+          <!-- Com3: Class/@ProgId , Class/@VersionIndependentProgId and ProgId/@CurrentVersion refer to ProgId/@Id-->
+          <xs:key name="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
+            <xs:field xpath="@Id"/>
+          </xs:key>
+          <xs:keyref name="Com3_Class_ProgIdRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@ProgId"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_Class_VerIndProgIdRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@VersionIndependentProgId"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_ProgId_CurrentVersionRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
             <xs:field xpath="@CurrentVersion"/>
           </xs:keyref>
         </xs:element>
@@ -116,6 +154,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Com" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 
@@ -125,6 +164,11 @@
       <xs:element ref="SurrogateServer" minOccurs="0" maxOccurs="1000"/>
       <xs:element ref="TreatAsClass" minOccurs="0" maxOccurs="10000"/>
       <xs:element ref="ProgId" minOccurs="0" maxOccurs="10000"/>
+      <xs:element ref="com3:ServiceServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:ExeServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:SurrogateServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:TreatAsClass" minOccurs="0" maxOccurs="10000"/>
+      <xs:element ref="com3:ProgId" minOccurs="0" maxOccurs="10000"/>
     </xs:sequence>
   </xs:complexType>
   

--- a/resources/AppxPackaging/Manifest/Schema/2015/DesktopManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/DesktopManifestSchema.xsd
@@ -24,6 +24,7 @@
            xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
            xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:rescap5="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/5"
            >
 
@@ -31,6 +32,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/5"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
@@ -43,6 +45,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Desktop" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
     <xs:unique name="FullTrustProcessParameterGroup_GroupId">
       <xs:selector xpath="desktop:FullTrustProcess/desktop:ParameterGroup"/>

--- a/resources/AppxPackaging/Manifest/Schema/2015/FoundationManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/FoundationManifestSchema.xsd
@@ -28,6 +28,7 @@
            xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
            xmlns:uap7="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:wincap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities"
            xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
            xmlns:rescap6="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/6"
@@ -50,6 +51,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/iot/windows10/2"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"/>
@@ -103,7 +105,7 @@
       <xs:field xpath="@Name"/>
     </xs:unique>
     <xs:unique name="Extension_FileType">
-      <xs:selector xpath="f:Applications/f:Application/f:Extensions/uap:Extension/uap:FileTypeAssociation/uap:SupportedFileTypes/uap:FileType"/>
+      <xs:selector xpath="f:Applications/f:Application/f:Extensions/uap:Extension/uap:FileTypeAssociation/uap:SupportedFileTypes/uap:FileType | f:Applications/f:Application/f:Extensions/uap:Extension/uap:FileTypeAssociation/uap:SupportedFileTypes/uap10:FileType"/>
       <xs:field xpath="."/>
     </xs:unique>
     <xs:unique name="Extension_Protocol">
@@ -172,6 +174,8 @@
       <xs:element ref="desktop6:RegistryWriteVirtualization" minOccurs="0"/>
       <xs:element ref="desktop6:FileSystemWriteVirtualization" minOccurs="0"/>
       <xs:element ref="rescap6:ModificationPackage" minOccurs="0"/>
+      <xs:element ref="uap10:AllowExternalContent" minOccurs="0"/>
+      <xs:element ref="uap10:PackageIntegrity" minOccurs="0"/>
     </xs:all>
   </xs:complexType>
 
@@ -209,6 +213,7 @@
       <xs:element ref="MainPackageDependencyChoice2" minOccurs="0" maxOccurs="1000"/>
       <xs:element ref="uap5:DriverDependency" minOccurs="0" maxOccurs="1000"/>
       <xs:element ref="uap7:OSPackageDependency" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="uap10:HostRuntimeDependency" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 
@@ -267,6 +272,7 @@
             <xs:element name="PublisherCacheFolders" type="CT_PublisherCacheFolders"/>
           </xs:choice>
           <xs:attribute name="Category" type="t:ST_PackageExtensionCategory_Foundation" use="required"/>
+          <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
         </xs:complexType>
       </xs:element>
       <xs:element ref="ExtensionChoice"/>
@@ -349,8 +355,11 @@
           <xs:attribute name="ResourceGroup" type="t:ST_AsciiWindowsId" use="optional"/>
           <xs:attribute ref="desktop4:Subsystem" use="optional"/>
           <xs:attribute ref="iot2:Subsystem" use="optional"/>
+          <xs:attribute ref="uap10:Subsystem" use="optional"/>
           <xs:attribute ref="desktop4:SupportsMultipleInstances" use="optional"/>
           <xs:attribute ref="iot2:SupportsMultipleInstances" use="optional"/>
+          <xs:attribute ref="uap10:SupportsMultipleInstances" use="optional"/>
+          <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
         </xs:complexType>
         <xs:unique name="ApplicationContentUrisRule_Match">
           <xs:selector xpath="uap:ApplicationContentUriRules/uap:Rule"/>
@@ -430,6 +439,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Foundation" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
     <xs:unique name="BackgroundTasks_Type">
       <xs:selector xpath="f:BackgroundTasks/f:Task | f:BackgroundTasks/uap:Task"/>

--- a/resources/AppxPackaging/Manifest/Schema/2015/MobileManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/MobileManifestSchema.xsd
@@ -22,10 +22,12 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:mobile="http://schemas.microsoft.com/appx/manifest/mobile/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
            
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Capability" substitutionGroup="f:CapabilityChoice">
     <xs:complexType>
@@ -41,6 +43,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Mobile" use="required" />
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/RestrictedCapabilitiesManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/RestrictedCapabilitiesManifestSchema.xsd
@@ -21,10 +21,12 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   
   <xs:element name="Capability" substitutionGroup="f:CapabilityChoice">
     <xs:complexType>
@@ -39,6 +41,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Restricted" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/RestrictedCapabilitiesManifestSchema_v2.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/RestrictedCapabilitiesManifestSchema_v2.xsd
@@ -21,15 +21,18 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/2"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
     <xs:complexType>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Restricted2" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/ServerManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/ServerManifestSchema.xsd
@@ -22,10 +22,12 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:serverpreview="http://schemas.microsoft.com/appx/manifest/serverpreview/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <!-- Application extensions in the Server Preview namespace    -->
 
@@ -50,6 +52,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="ST_ApplicationExtensionCategory_Server" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
     <xs:unique name="ModuleName">
       <xs:selector xpath="serverpreview:IisModules/serverpreview:IisModule" />

--- a/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema.xsd
@@ -25,10 +25,12 @@
            xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
            xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:rescap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"
            xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
            xmlns:desktop3="http://schemas.microsoft.com/appx/manifest/desktop/windows10/3"
            xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+           xmlns:previewappcompat="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
@@ -36,10 +38,12 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/3"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"/>
 
   <xs:attribute name="Scale" type="t:ST_Scale_All"/>
   <xs:attribute name="DXFeatureLevel" type="t:ST_DXFeatureLevel"/>
@@ -151,6 +155,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Uap" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
     <xs:unique name="AppointmentsProvider_Verb">
       <xs:selector xpath="uap:AppointmentsProvider/uap:AppointmentsProviderLaunchActions/uap:LaunchAction"/>
@@ -187,6 +192,7 @@
       <xs:element ref="desktop2:DesktopPropertyHandler" minOccurs="0"/>
       <xs:element ref="desktop2:OleClass" minOccurs="0"/>
       <xs:element ref="desktop3:PropertyLists" minOccurs="0"/>
+      <xs:element ref="previewappcompat:ProgId" minOccurs="0" maxOccurs="1"/>
     </xs:all>
     <xs:attribute name="Name" type="t:ST_FTAName" use="required"/>
     <xs:attribute name="DesiredView" type="t:ST_DesiredView" use="optional"/>
@@ -199,18 +205,20 @@
   <xs:element name="FileTypeAssociationSupportedVerbsChoice" abstract="true"/>
 
   <xs:complexType name="CT_FTASupportedFileTypes">
-    <xs:sequence>
-      <xs:element name="FileType" maxOccurs="1000" >
+    <xs:choice minOccurs="1" maxOccurs="1000">
+      <xs:element name="FileType">
         <xs:complexType>
           <xs:simpleContent>
             <xs:extension base="t:ST_FileType">
               <xs:attribute name="ContentType" type="t:ST_ContentType" use="optional"/>
               <xs:attributeGroup ref="uap4:ShellNewAttributes"/>
+              <xs:attributeGroup ref="uap10:FileTypeAttributes_2019"/>
             </xs:extension>
           </xs:simpleContent>
         </xs:complexType>
       </xs:element>
-    </xs:sequence>
+      <xs:element ref="uap10:FileType"/>
+    </xs:choice>
   </xs:complexType>
 
   <xs:complexType name="CT_Protocol">
@@ -218,6 +226,7 @@
       <xs:element name="Logo" type="t:ST_ImageFile" minOccurs="0"/>
       <xs:element name="DisplayName" type="t:ST_DisplayName" minOccurs="0"/>
       <xs:element ref="rescap3:MigrationProgIds" minOccurs="0"/>
+      <xs:element ref="previewappcompat:ProgId" minOccurs="0" maxOccurs="1"/>
     </xs:all>
     <xs:attribute name="Name" type="t:ST_Protocol_2010_v2" use="required"/>
     <xs:attribute name="DesiredView" type="t:ST_DesiredView" use="optional"/>
@@ -258,6 +267,7 @@
       <xs:element name="DataFormat" type="t:ST_DataFormat" minOccurs="0" maxOccurs="10000"/>
     </xs:sequence>
     <xs:attribute name="Description" type="t:ST_ShareTargetDescription" use="optional"/>
+    <xs:attribute ref="uap10:DisplayName" use="optional"/>
   </xs:complexType>
 
   <xs:complexType name="CT_FilePicker">

--- a/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema_v2.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema_v2.xsd
@@ -23,6 +23,7 @@
            xmlns:uap2="http://schemas.microsoft.com/appx/manifest/uap/windows10/2"
            xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
            xmlns:uap7="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:rescap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"
            >
 
@@ -30,6 +31,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"/>
 
   <xs:element name="Capability" substitutionGroup="f:CapabilityChoice">
@@ -71,6 +73,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Uap2" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema_v3.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/UapManifestSchema_v3.xsd
@@ -24,6 +24,7 @@
            xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
            xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
            xmlns:uap7="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
            >
 
@@ -34,6 +35,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/7"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Capability" substitutionGroup="f:CapabilityChoice">
     <xs:complexType>
@@ -57,6 +59,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Uap3" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
   
@@ -70,7 +73,7 @@
   
   <xs:complexType name="CT_AppExtensionHost">
     <xs:sequence>
-      <xs:element name="Name" type="t:ST_AppServiceName" minOccurs="1" maxOccurs="unbounded"/>
+      <xs:element name="Name" type="t:ST_AppServiceNameLonger" minOccurs="1" maxOccurs="unbounded"/>
     </xs:sequence>
   </xs:complexType>
 

--- a/resources/AppxPackaging/Manifest/Schema/2015/WindowsCapabilitiesManifestSchema_v2.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2015/WindowsCapabilitiesManifestSchema_v2.xsd
@@ -20,15 +20,18 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/2"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
     <xs:complexType>
         <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Windows_Restricted_Party2" use="required"/>
         <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+        <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/resources/AppxPackaging/Manifest/Schema/2016/BundleManifestSchema2016.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2016/BundleManifestSchema2016.xsd
@@ -5,10 +5,12 @@
     xmlns="http://schemas.microsoft.com/appx/2016/bundle"
     xmlns:b="http://schemas.microsoft.com/appx/2016/bundle"
     xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
-    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle">
+    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle"
+    xmlns:b5="http://schemas.microsoft.com/appx/2019/bundle">
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
   <xs:import namespace="http://schemas.microsoft.com/appx/2018/bundle" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2019/bundle" />
 
   <xs:element name="Bundle">
     <xs:complexType>
@@ -22,16 +24,18 @@
         </xs:element>
         <xs:element name="Packages" minOccurs="1" maxOccurs="1">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
         <xs:element name="OptionalBundle" minOccurs="0" maxOccurs="10000">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
             <xs:attribute name="Name" type="t:ST_PackageName" use="required" />
             <xs:attribute name="Publisher" type="t:ST_Publisher_2010_v2" use="required" />
             <xs:attribute name="Version" type="t:ST_VersionQuad" use="optional" />

--- a/resources/AppxPackaging/Manifest/Schema/2016/DesktopManifestSchema_v2.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2016/DesktopManifestSchema_v2.xsd
@@ -22,10 +22,12 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:desktop2="http://schemas.microsoft.com/appx/manifest/desktop/windows10/2"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
     <xs:complexType>
@@ -38,6 +40,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Desktop2" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2016/RestrictedCapabilitiesManifestSchema_v3.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2016/RestrictedCapabilitiesManifestSchema_v3.xsd
@@ -22,10 +22,12 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:rescap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
     <xs:complexType>
@@ -34,6 +36,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Restricted3" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2016/UapManifestSchema_v4.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2016/UapManifestSchema_v4.xsd
@@ -25,6 +25,7 @@
            xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
            xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
@@ -34,6 +35,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="MainPackageDependency" substitutionGroup="f:MainPackageDependencyChoice2">
     <xs:complexType>
@@ -100,6 +102,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Uap4" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
     <xs:unique name="SharedFonts_File">
       <xs:selector xpath="uap4:SharedFonts/uap4:Font"/>

--- a/resources/AppxPackaging/Manifest/Schema/2016/WindowsCapabilitiesManifestSchema_v3.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2016/WindowsCapabilitiesManifestSchema_v3.xsd
@@ -20,10 +20,12 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <!-- Starting RS2, wincap extensions will skip manifest validation -->
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
@@ -33,6 +35,7 @@
       </xs:sequence>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Windows_Restricted_Party3" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2017/BundleManifestSchema2017.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/BundleManifestSchema2017.xsd
@@ -5,10 +5,12 @@
     xmlns="http://schemas.microsoft.com/appx/2017/bundle"
     xmlns:b="http://schemas.microsoft.com/appx/2017/bundle"
     xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
-    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle">
+    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle"
+    xmlns:b5="http://schemas.microsoft.com/appx/2019/bundle">
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
   <xs:import namespace="http://schemas.microsoft.com/appx/2018/bundle" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2019/bundle" />
 
   <xs:element name="Bundle">
     <xs:complexType>
@@ -22,16 +24,18 @@
         </xs:element>
         <xs:element name="Packages" minOccurs="1" maxOccurs="1">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
         <xs:element name="OptionalBundle" minOccurs="0" maxOccurs="10000">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
             <xs:attribute name="Name" type="t:ST_PackageName" use="required" />
             <xs:attribute name="Publisher" type="t:ST_Publisher_2010_v2" use="required" />
             <xs:attribute name="Version" type="t:ST_VersionQuad" use="optional" />

--- a/resources/AppxPackaging/Manifest/Schema/2017/ComManifestSchema_v2.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/ComManifestSchema_v2.xsd
@@ -20,11 +20,15 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+           xmlns:com3="http://schemas.microsoft.com/appx/manifest/com/windows10/3"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/com/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/com/windows10/3"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="ProxyStubDll" type="CT_ProxyStubDll"/>
 
@@ -71,6 +75,40 @@
             <xs:selector xpath="com:ProgId"/>
             <xs:field xpath="@CurrentVersion"/>
           </xs:keyref>
+          <!--Com3: Class/@AutoConvertTo, ProgId/@Clsid and TreatAsClass/@TreatAs refers to ExeServer/Class/@Id | SurrogateServer/Class/@Id | TreatAsClass/@Id | com3:ServiceServer/com3:Class/@id-->
+          <xs:key name="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:TreatAsClass | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@Id"/>
+          </xs:key>
+          <xs:keyref name="Com3_ProgId_ClsidRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
+            <xs:field xpath="@Clsid"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_TreatAsRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:TreatAsClass"/>
+            <xs:field xpath="@TreatAs"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_AutoConvertToRef" refer="Com3_Class_Or_TreatAsClass_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:TreatAsClass | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@AutoConvertTo"/>
+          </xs:keyref>
+          <!-- Com3: Class/@ProgId , Class/@VersionIndependentProgId and ProgId/@CurrentVersion refer to ProgId/@Id-->
+          <xs:key name="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
+            <xs:field xpath="@Id"/>
+          </xs:key>
+          <xs:keyref name="Com3_Class_ProgIdRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@ProgId"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_Class_VerIndProgIdRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ExeServer/com:Class | com3:SurrogateServer/com:Class | com3:ServiceServer/com3:Class"/>
+            <xs:field xpath="@VersionIndependentProgId"/>
+          </xs:keyref>
+          <xs:keyref name="Com3_ProgId_CurrentVersionRef" refer="Com3_ProgId_IdKey">
+            <xs:selector xpath="com3:ProgId"/>
+            <xs:field xpath="@CurrentVersion"/>
+          </xs:keyref>
         </xs:element>
         <xs:element name="ComInterface" type="CT_ComInterface" maxOccurs="1">
           <xs:key name="Interface_IdKey">
@@ -107,6 +145,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Com" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 
@@ -116,6 +155,11 @@
       <xs:element ref="com:SurrogateServer"/>
       <xs:element ref="com:TreatAsClass"/>
       <xs:element ref="com:ProgId"/>
+      <xs:element ref="com3:ServiceServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:ExeServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:SurrogateServer" minOccurs="0" maxOccurs="1000"/>
+      <xs:element ref="com3:TreatAsClass" minOccurs="0" maxOccurs="10000"/>
+      <xs:element ref="com3:ProgId" minOccurs="0" maxOccurs="10000"/>
     </xs:choice>
   </xs:complexType>
 

--- a/resources/AppxPackaging/Manifest/Schema/2017/DesktopManifestSchema_v3.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/DesktopManifestSchema_v3.xsd
@@ -23,11 +23,13 @@
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:desktop3="http://schemas.microsoft.com/appx/manifest/desktop/windows10/3"
            xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
     <xs:complexType>
@@ -37,6 +39,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Desktop3" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2017/DesktopManifestSchema_v4.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/DesktopManifestSchema_v4.xsd
@@ -23,11 +23,13 @@
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
            xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ApplicationExtensionChoice">
     <xs:complexType>
@@ -36,6 +38,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Desktop4" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2017/RestrictedCapabilitiesManifestSchema_v4.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/RestrictedCapabilitiesManifestSchema_v4.xsd
@@ -21,10 +21,12 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/4"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
     <xs:complexType>
@@ -34,6 +36,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_PackageExtensionCategory_Restricted4" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2017/UapManifestSchema_v5.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/UapManifestSchema_v5.xsd
@@ -23,6 +23,7 @@
            xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
            xmlns:uap6="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            xmlns:wincap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"
            xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
            xmlns:iot2="http://schemas.microsoft.com/appx/manifest/iot/windows10/2"
@@ -33,6 +34,7 @@
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/iot/windows10/2"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"/>
@@ -49,6 +51,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ApplicationExtensionCategory_Uap5" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 
@@ -186,6 +189,7 @@
     </xs:sequence>
     <xs:attribute ref="desktop4:Subsystem" use="optional"/>
     <xs:attribute ref="iot2:Subsystem" use="optional"/>
+    <xs:attribute ref="uap10:Subsystem" use="optional"/>
   </xs:complexType>
 
   <xs:element name="DriverDependency">

--- a/resources/AppxPackaging/Manifest/Schema/2017/UapManifestSchema_v6.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2017/UapManifestSchema_v6.xsd
@@ -19,10 +19,12 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/uap/windows10/6"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="AllowExecution" type="xs:boolean"/>
 
@@ -35,6 +37,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Uap6" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2018/BundleManifestSchema2018.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2018/BundleManifestSchema2018.xsd
@@ -4,9 +4,11 @@
     targetNamespace="http://schemas.microsoft.com/appx/2018/bundle"
     xmlns="http://schemas.microsoft.com/appx/2018/bundle"
     xmlns:b="http://schemas.microsoft.com/appx/2018/bundle"
-    xmlns:t="http://schemas.microsoft.com/appx/manifest/types">
+    xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
+    xmlns:b5="http://schemas.microsoft.com/appx/2019/bundle">
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2019/bundle" />
 
   <xs:element name="Bundle">
     <xs:complexType>
@@ -20,16 +22,18 @@
         </xs:element>
         <xs:element name="Packages" minOccurs="1" maxOccurs="1">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
           </xs:complexType>
         </xs:element>
         <xs:element name="OptionalBundle" minOccurs="0" maxOccurs="10000">
           <xs:complexType>
-            <xs:sequence>
-              <xs:element ref="Package" minOccurs="1" maxOccurs="10000" />
-            </xs:sequence>
+            <xs:choice minOccurs="1" maxOccurs="10000">
+              <xs:element ref="Package"/>
+              <xs:element ref="b5:Package"/>
+            </xs:choice>
             <xs:attribute name="Name" type="t:ST_PackageName" use="required" />
             <xs:attribute name="Publisher" type="t:ST_Publisher_2010_v2" use="required" />
             <xs:attribute name="Version" type="t:ST_VersionQuad" use="optional" />
@@ -46,7 +50,7 @@
     <xs:complexType>
       <xs:all>
         <xs:element name="Resources" type="CT_Resources" minOccurs="0" />
-        <xs:element ref="Dependencies" minOccurs="1" maxOccurs="1" />
+        <xs:element ref="Dependencies" minOccurs="0" maxOccurs="1" />
       </xs:all>
       <xs:attribute name="Type" type="t:ST_PackageType" use="optional" default="resource" />
       <xs:attribute name="Version" type="t:ST_VersionQuad" use="required" />

--- a/resources/AppxPackaging/Manifest/Schema/2018/DesktopManifestSchema_v6.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2018/DesktopManifestSchema_v6.xsd
@@ -21,10 +21,12 @@
            xmlns="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6"
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
     <xs:complexType>
@@ -35,6 +37,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Desktop6" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 
@@ -43,20 +46,27 @@
       <xs:element name="Dependencies" type="CT_Dependencies" minOccurs="0"/>
       <xs:element name="TriggerEvents" type="CT_TriggerEvents" minOccurs="0"/>
     </xs:all>
-    <xs:attribute name="Name" type="t:ST_NonEmptyString" use="required"/>
+    <xs:attribute name="Name" type="ST_ServiceName" use="required"/>
     <xs:attribute name="StartupType" type="ST_StartupType" use="required"/>
     <xs:attribute name="StartAccount" type="ST_StartAccount" use="required"/>
     <xs:attribute name="Arguments" type="t:ST_NonEmptyString"/>
   </xs:complexType>
 
+  <xs:simpleType name="ST_ServiceName">
+    <xs:restriction base="t:ST_NonEmptyString">
+      <xs:pattern value="[^/\\\x01-\x1f]+"/>
+      <xs:maxLength value="256"/>
+    </xs:restriction>
+  </xs:simpleType>
+
   <xs:complexType name="CT_Dependencies">
-    <xs:sequence minOccurs="0" maxOccurs="10000">
+    <xs:sequence minOccurs="1" maxOccurs="10000">
       <xs:element name="DependentService" type="CT_DependentService"/>
     </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="CT_DependentService">
-    <xs:attribute name="Name" type="t:ST_NonEmptyString" use="required"/>
+    <xs:attribute name="Name" type="ST_ServiceName" use="required"/>
   </xs:complexType>
 
   <xs:simpleType name="ST_StartAccount">

--- a/resources/AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v7.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v7.xsd
@@ -21,12 +21,14 @@
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
            xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
     <xs:complexType>
@@ -36,6 +38,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Uap7" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 
@@ -64,6 +67,7 @@
       <xs:all>
         <xs:element name="ImportRedirectionTable" type="t:ST_DllFile" minOccurs="0"/>
         <xs:element ref="uap8:ActiveCodePage" minOccurs="0"/>
+        <xs:element ref="uap10:LanguagePreference" minOccurs="0"/>
       </xs:all>
     </xs:complexType>
   </xs:element>

--- a/resources/AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v8.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2018/UapManifestSchema_v8.xsd
@@ -20,11 +20,13 @@
            xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
            xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
            xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
            >
 
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
   <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/3"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"/>
 
   <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
     <xs:complexType>
@@ -34,6 +36,7 @@
       </xs:choice>
       <xs:attribute name="Category" type="t:ST_ExtensionCategory_Uap8" use="required"/>
       <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="uap10:TrustLevelGroup"/>
     </xs:complexType>
   </xs:element>
 

--- a/resources/AppxPackaging/Manifest/Schema/2019/BundleManifestSchema2019.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2019/BundleManifestSchema2019.xsd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://schemas.microsoft.com/appx/2019/bundle"
+    xmlns="http://schemas.microsoft.com/appx/2019/bundle"
+    xmlns:b="http://schemas.microsoft.com/appx/2019/bundle"
+    xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
+    xmlns:b4="http://schemas.microsoft.com/appx/2018/bundle">
+
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types" />
+  <xs:import namespace="http://schemas.microsoft.com/appx/2018/bundle" />
+
+  <xs:element name="Package">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="Resources" type="CT_Resources" minOccurs="0" />
+        <xs:element ref="b4:Dependencies" minOccurs="0" maxOccurs="1" />
+      </xs:all>
+      <xs:attribute name="Type" type="t:ST_PackageType" use="optional" default="resource" />
+      <xs:attribute name="Version" type="t:ST_VersionQuad" use="required" />
+      <xs:attribute name="Architecture" type="t:ST_ArchitectureUnrestricted" use="optional" default="neutral" />
+      <xs:attribute name="ResourceId" type="t:ST_ResourceId" use="optional" />
+      <xs:attribute name="FileName" type="t:ST_FileName" use="required" />
+      <xs:attribute name="Offset" type="xs:unsignedLong" use="optional" />
+      <xs:attribute name="Size" type="xs:unsignedLong" use="optional" />
+      <xs:attribute name="IsStub" type="xs:boolean" use="optional" default="false" />
+    </xs:complexType>
+    <xs:unique name="Unique_Language">
+      <xs:selector xpath="b:Resources/b:Resource"/>
+      <xs:field xpath="@Language"/>
+    </xs:unique>
+    <xs:unique name="Unique_Scale">
+      <xs:selector xpath="b:Resources/b:Resource"/>
+      <xs:field xpath="@Scale"/>
+    </xs:unique>
+    <xs:unique name="Unique_DXFeatureLevel">
+      <xs:selector xpath="b:Resources/b:Resource"/>
+      <xs:field xpath="@DXFeatureLevel"/>
+    </xs:unique>
+    <xs:unique name="Unique_TDF_Name">
+      <xs:selector xpath="b4:Dependencies/b4:TargetDeviceFamily"/>
+      <xs:field xpath="@Name"/>
+    </xs:unique>
+  </xs:element>
+
+  <xs:complexType name="CT_Resources">
+    <xs:sequence>
+      <xs:element name="Resource" minOccurs="0" maxOccurs="200">
+        <xs:complexType>
+          <xs:attribute name="Language" type="xs:language" use="optional"/>
+          <xs:attribute name="Scale" type="t:ST_Scale_All" use="optional"/>
+          <xs:attribute name="DXFeatureLevel" type="t:ST_DXFeatureLevel" use="optional"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="Default" type="xs:boolean" use="optional" default="false"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/resources/AppxPackaging/Manifest/Schema/2019/ComManifestSchema_v3.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2019/ComManifestSchema_v3.xsd
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- @@BEGIN_SDKSPLIT
+
+  Vibranium COM MANIFEST SCHEMA
+
+  This schema extends the elements that are available in the Vibranium COM schema.
+
+  !!!WARNING!!!
+
+  Don't make any changes to this schema.  Changes will affect a wide range of
+  partners and can potentially break product and test code, as well as existing
+  .appx packages and manifests. Please follow https://microsoft.sharepoint.com/teams/appxmanifest/SitePages/Home.aspx
+  if you need to request any addition or modification.
+
+@@END_SDKSPLIT -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://schemas.microsoft.com/appx/manifest/com/windows10/3"
+           xmlns="http://schemas.microsoft.com/appx/manifest/com/windows10/3"
+           xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
+           xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
+           >
+
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/com/windows10"/>
+
+  <xs:element name="ServiceServer" type="CT_ServiceServer" />
+  <xs:element name="ExeServer" type="com:CT_ExeServer" />
+  <xs:element name="SurrogateServer" type="com:CT_SurrogateServer" />
+  <xs:element name="TreatAsClass" type="com:CT_TreatAsClass" />
+  <xs:element name="ProgId" type="com:CT_ProgId" />
+
+  <xs:complexType name="CT_ServiceServer">
+    <xs:sequence>
+      <xs:element name="Class" type="com:CT_ExeServerClass" minOccurs="1" maxOccurs="10000"/>
+    </xs:sequence>
+    <xs:attribute name="ServiceName" type="t:ST_NonEmptyString" use="required"/>
+    <xs:attribute name="Arguments" type="t:ST_NonEmptyString"/>
+    <xs:attribute name="DisplayName" type="t:ST_DisplayName"/>
+    <xs:attribute name="LaunchAndActivationPermission" type="com:ST_Permissions" />
+  </xs:complexType>
+
+</xs:schema>

--- a/resources/AppxPackaging/Manifest/Schema/2019/PreviewManifestSchema_MsixAppCompatSupport.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2019/PreviewManifestSchema_MsixAppCompatSupport.xsd
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- @@BEGIN_SDKSPLIT
+
+  Vibranium Preview MANIFEST SCHEMA for Msix App Compat Support feature.
+
+  !!!WARNING!!!
+
+  Don't make any changes to this schema.  Changes will affect a wide range of
+  partners and can potentially break product and test code, as well as existing
+  .appx packages and manifests. Please follow https://microsoft.sharepoint.com/teams/appxmanifest/SitePages/Home.aspx
+  if you need to request any addition or modification.
+
+@@END_SDKSPLIT -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"
+           xmlns="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"
+           xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
+           xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    >
+
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+
+  <xs:attributeGroup name="PreviewEntryPointAttributesGroup">
+    <xs:attribute name="CompatMode" type="ST_CompatMode" use="optional" form="qualified"/>
+    <xs:attribute name="Scope" type="ST_Scope" use="optional" form="qualified"/>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="ST_CompatMode">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="classic"/>
+      <xs:enumeration value="modern"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_Scope">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="machine"/>
+      <xs:enumeration value="user"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="ProgId" type="t:ST_ProgId"/>
+
+</xs:schema>

--- a/resources/AppxPackaging/Manifest/Schema/2019/UapManifestSchema_v10.xsd
+++ b/resources/AppxPackaging/Manifest/Schema/2019/UapManifestSchema_v10.xsd
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- @@BEGIN_SDKSPLIT
+
+  Vibranium UAP V10 MANIFEST SCHEMA
+
+  This schema extends the elements that are available in the Vibranium UAP schema.
+
+  !!!WARNING!!!
+
+  Don't make any changes to this schema.  Changes will affect a wide range of
+  partners and can potentially break product and test code, as well as existing
+  .appx packages and manifests. Please follow https://microsoft.sharepoint.com/teams/appxmanifest/SitePages/Home.aspx
+  if you need to request any addition or modification.
+
+@@END_SDKSPLIT -->
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+           xmlns="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+           xmlns:t="http://schemas.microsoft.com/appx/manifest/types"
+           xmlns:f="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+           xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
+           xmlns:uap4="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"
+           xmlns:wincap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"
+           xmlns:rescap3="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"
+           xmlns:previewappcompat="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"
+           >
+
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/types"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/windowscapabilities/3"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities/3"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/preview/windows10/msixappcompatsupport"/>
+  <xs:import namespace="http://schemas.microsoft.com/appx/manifest/uap/windows10/4"/>
+
+  <xs:attributeGroup name="TrustLevelGroup">
+    <xs:attribute name="TrustLevel" type="ST_TrustLevel" use="optional" form="qualified"/>
+    <xs:attribute name="RuntimeBehavior" type="ST_RuntimeBehavior" use="optional" form="qualified"/>
+    <xs:attribute name="HostId" type="ST_HostRuntimeId" use="optional" form="qualified"/>
+    <xs:attribute name="Parameters" type="t:ST_NonEmptyString" use="optional" form="qualified"/>
+    <xs:attributeGroup ref="previewappcompat:PreviewEntryPointAttributesGroup"/>
+  </xs:attributeGroup>
+
+  <xs:simpleType name="ST_TrustLevel">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="appContainer"/>
+      <xs:enumeration value="mediumIL"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="ST_RuntimeBehavior">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="windowsApp"/>
+      <xs:enumeration value="packagedClassicApp"/>
+      <xs:enumeration value="win32App"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="AllowExternalContent" type="xs:boolean" />
+
+  <xs:element name="Extension" substitutionGroup="f:ExtensionChoice">
+    <xs:complexType>
+      <xs:choice minOccurs="0">
+        <xs:element name="HostRuntime" type="CT_HostRuntime"/>
+        <xs:element name="InstalledLocationVirtualization" type="CT_InstalledLocationVirtualization"/>
+        <xs:element name="MediaContentDecryptionModule" type="CT_MediaContentDecryptionModule"/>
+        <xs:element name="Protocol" type="CT_Protocol"/>
+      </xs:choice>
+      <xs:attribute name="Category" type="t:ST_ExtensionCategory_Uap10" use="required"/>
+      <xs:attributeGroup ref="t:ExtensionBaseAttributes"/>
+      <xs:attributeGroup ref="TrustLevelGroup"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="CT_HostRuntime">
+    <xs:attribute name="Id" type="ST_HostRuntimeId" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ST_HostRuntimeId">
+    <xs:restriction base="t:ST_NonEmptyString">
+      <xs:maxLength value="256"/>
+      <xs:pattern value="([A-Za-z][A-Za-z0-9]*)(\.[A-Za-z][A-Za-z0-9]*)*"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:element name="HostRuntimeDependency">
+    <xs:complexType>
+      <xs:attribute name="Name" type="t:ST_AsciiIdentifier" use="required"/>
+      <xs:attribute name="Publisher" type="t:ST_Publisher_2010_v2" use="required"/>
+      <xs:attribute name="MinVersion" type="t:ST_VersionQuad" use="required"/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:attributeGroup name="FileTypeAttributes_2019">
+    <xs:attribute name="PerceivedType" type="t:ST_EntryPoint" use="optional" form="qualified"/>
+    <xs:attribute name="ShellNewCommandParameters" type="t:ST_Parameters" use="optional" form="qualified"/>
+  </xs:attributeGroup>
+
+  <xs:element name="LanguagePreference" type="ST_LanguagePreference" />
+
+  <xs:simpleType name="ST_LanguagePreference">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="windowsDisplayLanguage"/>
+      <xs:enumeration value="userPreferredLanguages"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attribute name="Subsystem" type="t:ST_Subsystem"/>
+  <xs:attribute name="SupportsMultipleInstances" type="xs:boolean"/>
+
+  <xs:complexType name="CT_InstalledLocationVirtualization">
+    <xs:sequence>
+      <xs:element name="UpdateActions"  minOccurs="1" maxOccurs="1">
+        <xs:complexType>
+          <xs:attribute name="ModifiedItems" type="ST_UpdateActions" use="required"/>
+          <xs:attribute name="DeletedItems" type="ST_UpdateActions" use="required"/>
+          <xs:attribute name="AddedItems" type="ST_UpdateActions" use="required"/>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:simpleType name="ST_UpdateActions">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="keep"/>
+      <xs:enumeration value="reset"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:attribute name="DisplayName" type="t:ST_DisplayName"/>
+
+  <xs:complexType name="CT_MediaContentDecryptionModule">
+    <xs:attribute name="DisplayName" type="t:ST_DisplayName" use="required"/>
+    <xs:attribute name="Description" type="t:ST_Description" use="required"/>
+    <xs:attribute name="SupportedKeySystem" type="t:ST_ActivatableClassId" use="required"/>
+    <xs:attributeGroup ref="wincap3:InprocMediaCodecAttributes"/>
+  </xs:complexType>
+
+  <xs:complexType name="CT_Protocol">
+    <xs:all>
+        <xs:element name="Logo" type="t:ST_ImageFile" minOccurs="0"/>
+        <xs:element name="DisplayName" type="t:ST_DisplayName" minOccurs="0"/>
+        <xs:element ref="rescap3:MigrationProgIds" minOccurs="0"/>
+        <xs:element ref="previewappcompat:ProgId" minOccurs="0" maxOccurs="1"/>
+    </xs:all>
+    <xs:attribute name="Name" type="t:ST_Protocol_2019" use="required"/>
+    <xs:attribute name="DesiredView" type="t:ST_DesiredView" use="optional"/>
+    <xs:attribute name="ReturnResults" type="t:ST_ProtocolReturnResults" use="optional"/>
+    <xs:attribute name="Parameters" type="t:ST_Parameters" use="optional"/>
+  </xs:complexType>
+
+  <xs:element name="FileType">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="t:ST_FileType_2019">
+          <xs:attribute name="ContentType" type="t:ST_ContentType" use="optional"/>
+          <xs:attributeGroup ref="uap4:ShellNewAttributes"/>
+          <xs:attributeGroup ref="uap10:FileTypeAttributes_2019"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="PackageIntegrity">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="Content" type="CT_Enforcement" minOccurs="0"/>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:complexType name="CT_Enforcement">
+    <xs:attribute name="Enforcement" type="ST_Enforcement" use="required"/>
+  </xs:complexType>
+
+  <xs:simpleType name="ST_Enforcement">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="default"/>
+      <xs:enumeration value="on"/>
+      <xs:enumeration value="off"/>
+    </xs:restriction>
+  </xs:simpleType>
+
+</xs:schema>


### PR DESCRIPTION
#334 

Updating Appx/MSIX schemas up to May 2020 Update (Vibranium 20H1). DesktopManifestSchema_v6.xsd required some modifications to be able to work with Xerces.