### PR TITLE
Add configuration files to create Utils NuGet package

### DIFF
--- a/tools/utils/SignConfig.xml
+++ b/tools/utils/SignConfig.xml
@@ -1,0 +1,5 @@
+<SignConfigXML>
+  <job platform="" configuration="" dest="__OUTPATHROOT__" jobname="ISS EngFun" approvers="">
+    <file src="__INPATHROOT__\Microsoft.Msix.Utils*.nupkg" signType="NuGet" />
+  </job>
+</SignConfigXML>

--- a/tools/utils/Utils/Properties/AssemblyInfo.cs
+++ b/tools/utils/Utils/Properties/AssemblyInfo.cs
@@ -12,11 +12,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Packaging.Utils.Properties")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Library for utilities like AppxPackaging, AppxPackagingInterop, CommandLine, IO, Logger, ProcessRunner, and StandardInput.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft.Packaging.Utils.Properties")]
-[assembly: AssemblyCopyright("Microsoft Copyright ©  2018")]
+[assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -34,6 +34,5 @@ using System.Runtime.InteropServices;
 //      Minor Version 1.0.0.0
 //      Build Number 1.0.0.0
 //      Revision 1.0.0.0
-//      This files is needed to test locally any change on BDCTool or PackageEditor.
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/utils/Utils/Utils.nuspec
+++ b/tools/utils/Utils/Utils.nuspec
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>Microsoft.Msix.Utils</id>
+    <version>$version$</version>
+    <description>$description$</description>
+    <authors>$author$</authors>
+    <license type="expression">MIT</license>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+  </metadata>
+</package>

--- a/tools/utils/custom.props
+++ b/tools/utils/custom.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- This file is read by XES, which we use in our Release builds. -->
+  <PropertyGroup Label="Version">
+    <VersionMajor>1</VersionMajor>
+    <VersionMinor>0</VersionMinor>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
All of this is to be consumed by the release pipeline.
* Added configuration for signing.
* Added build properties to control major/minor version with recommended semantic versioning. Patch version is set by the pipeline.
* Added .nuspec file to indicate license and package name. Remaining fields are taken from the .csproj/AssemblyInfo.
* Updated AssemblyInfo with required information.