### PR TITLE
Change Utils namespace to match NuGet package name

### DIFF
--- a/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
@@ -4,13 +4,13 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.InteropServices.ComTypes;
-    using Microsoft.Packaging.Utils.AppxPackagingInterop;
+    using Microsoft.Msix.Utils.AppxPackagingInterop;
 
     /// <summary>
     /// Class that represents msix bundle information.

--- a/tools/utils/Utils/AppxPackaging/AppxMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/AppxMetadata.cs
@@ -4,14 +4,14 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices.ComTypes;
-    using Microsoft.Packaging.Utils.AppxPackagingInterop;
+    using Microsoft.Msix.Utils.AppxPackagingInterop;
 
     /// <summary>
     /// Class that represents msix package information.

--- a/tools/utils/Utils/AppxPackaging/Block.cs
+++ b/tools/utils/Utils/AppxPackaging/Block.cs
@@ -4,11 +4,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System;
     using System.Runtime.InteropServices;
-    using Microsoft.Packaging.Utils.AppxPackagingInterop;
+    using Microsoft.Msix.Utils.AppxPackagingInterop;
 
     /// <summary>
     /// Stores information about a block.

--- a/tools/utils/Utils/AppxPackaging/ExternalPackageReference.cs
+++ b/tools/utils/Utils/AppxPackaging/ExternalPackageReference.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System;
     using System.IO;

--- a/tools/utils/Utils/AppxPackaging/FileExtensionHelper.cs
+++ b/tools/utils/Utils/AppxPackaging/FileExtensionHelper.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     public static class FileExtensionHelper
     {

--- a/tools/utils/Utils/AppxPackaging/PackageMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/PackageMetadata.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System.Runtime.InteropServices.ComTypes;
 

--- a/tools/utils/Utils/AppxPackaging/PackagingConstants.cs
+++ b/tools/utils/Utils/AppxPackaging/PackagingConstants.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System.Collections.Generic;
 

--- a/tools/utils/Utils/AppxPackaging/PackagingUtils.cs
+++ b/tools/utils/Utils/AppxPackaging/PackagingUtils.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System.Text.RegularExpressions;
     using AppxPackagingInterop;

--- a/tools/utils/Utils/AppxPackaging/VersionInfo.cs
+++ b/tools/utils/Utils/AppxPackaging/VersionInfo.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackaging
+namespace Microsoft.Msix.Utils.AppxPackaging
 {
     using System;
 

--- a/tools/utils/Utils/AppxPackagingInterop/AppxBundleFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/AppxBundleFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
 

--- a/tools/utils/Utils/AppxPackagingInterop/AppxEncryptionFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/AppxEncryptionFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
 

--- a/tools/utils/Utils/AppxPackagingInterop/AppxFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/AppxFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;

--- a/tools/utils/Utils/AppxPackagingInterop/AppxPackageEditor.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/AppxPackageEditor.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;

--- a/tools/utils/Utils/AppxPackagingInterop/AppxPackagingDiagnosticEventSinkManager.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/AppxPackagingDiagnosticEventSinkManager.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapBlock.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapBlock.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapBlocksEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapBlocksEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapFile.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapFile.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapFilesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapFilesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapReader.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBlockMapReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestOptionalBundleInfo.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestOptionalBundleInfo.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestOptionalBundleInfoEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestOptionalBundleInfoEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestPackageInfo.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestPackageInfo.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestPackageInfoEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestPackageInfoEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestReader.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestReader2.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleManifestReader2.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleReader.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxBundleWriter.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxBundleWriter.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
 

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxEncryptedBlockMapFile.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxEncryptedBlockMapFile.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxEncryptionFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxEncryptionFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxFactory.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxFactory.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxFile.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxFile.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxFilesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxFilesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestApplication.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestApplication.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestApplicationsEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestApplicationsEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestCapabilitiesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestCapabilitiesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestDeviceCapabilitiesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestDeviceCapabilitiesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
 

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestOptionalPackageInfo.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestOptionalPackageInfo.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependenciesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependenciesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependency.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependency.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependency2.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependency2.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependencyInternal.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageDependencyInternal.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageId.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageId.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageId2.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestPackageId2.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestProperties.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestProperties.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestQualifiedResource.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestQualifiedResource.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestQualifiedResourcesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestQualifiedResourcesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader2.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader2.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader3.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader3.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader4.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestReader4.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestResourcesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestResourcesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestTargetDeviceFamiliesEnumerator.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestTargetDeviceFamiliesEnumerator.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxManifestTargetDeviceFamily.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxManifestTargetDeviceFamily.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxPackageEditor.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxPackageEditor.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxPackageReader.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxPackageReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxPackageWriter.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxPackageWriter.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System.Diagnostics.CodeAnalysis;
     using System.Runtime.InteropServices;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxPackagingDiagnosticEventSink.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxPackagingDiagnosticEventSink.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IAppxPackagingDiagnosticEventSinkManager.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IAppxPackagingDiagnosticEventSinkManager.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/AppxPackagingInterop/IUri.cs
+++ b/tools/utils/Utils/AppxPackagingInterop/IUri.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.AppxPackagingInterop
+namespace Microsoft.Msix.Utils.AppxPackagingInterop
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/CommandLine/ArgumentConfiguration.cs
+++ b/tools/utils/Utils/CommandLine/ArgumentConfiguration.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/CommandLine/CLIApplication.cs
+++ b/tools/utils/Utils/CommandLine/CLIApplication.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/CommandLine/CommandBase.cs
+++ b/tools/utils/Utils/CommandLine/CommandBase.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using Microsoft.Extensions.CommandLineUtils;

--- a/tools/utils/Utils/CommandLine/CommandLineException.cs
+++ b/tools/utils/Utils/CommandLine/CommandLineException.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
 

--- a/tools/utils/Utils/CommandLine/ConfiguredInputs.cs
+++ b/tools/utils/Utils/CommandLine/ConfiguredInputs.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/CommandLine/InputConfigurationBase.cs
+++ b/tools/utils/Utils/CommandLine/InputConfigurationBase.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/CommandLine/OptionConfiguration.cs
+++ b/tools/utils/Utils/CommandLine/OptionConfiguration.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.CommandLine
+namespace Microsoft.Msix.Utils.CommandLine
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/IO/EmbeddedResourcesUtils.cs
+++ b/tools/utils/Utils/IO/EmbeddedResourcesUtils.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.IO
+namespace Microsoft.Msix.Utils.IO
 {
     using System;
     using System.IO;

--- a/tools/utils/Utils/IO/FileSystemUtils.cs
+++ b/tools/utils/Utils/IO/FileSystemUtils.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils
+namespace Microsoft.Msix.Utils
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/IO/IncompatibleFileTypesException.cs
+++ b/tools/utils/Utils/IO/IncompatibleFileTypesException.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils
+namespace Microsoft.Msix.Utils
 {
     using System;
 

--- a/tools/utils/Utils/IO/InvalidFileTypeException.cs
+++ b/tools/utils/Utils/IO/InvalidFileTypeException.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils
+namespace Microsoft.Msix.Utils
 {
     using System;
 

--- a/tools/utils/Utils/IO/StandardInputReader.cs
+++ b/tools/utils/Utils/IO/StandardInputReader.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.IO
+namespace Microsoft.Msix.Utils.IO
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/IO/StreamUtils.cs
+++ b/tools/utils/Utils/IO/StreamUtils.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils
+namespace Microsoft.Msix.Utils
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/Utils/Logger/AppxPackagingEventSinkToLogger.cs
+++ b/tools/utils/Utils/Logger/AppxPackagingEventSinkToLogger.cs
@@ -4,7 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System.Collections.Generic;
     using System.Runtime.InteropServices;

--- a/tools/utils/Utils/Logger/ConsoleLog.cs
+++ b/tools/utils/Utils/Logger/ConsoleLog.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Reflection;

--- a/tools/utils/Utils/Logger/ExpMessageArg.cs
+++ b/tools/utils/Utils/Logger/ExpMessageArg.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
 

--- a/tools/utils/Utils/Logger/FileLog.cs
+++ b/tools/utils/Utils/Logger/FileLog.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.IO;

--- a/tools/utils/Utils/Logger/ILogMessage.cs
+++ b/tools/utils/Utils/Logger/ILogMessage.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     /// <summary>
     /// Log message

--- a/tools/utils/Utils/Logger/ILogMessageFormatter.cs
+++ b/tools/utils/Utils/Logger/ILogMessageFormatter.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
 

--- a/tools/utils/Utils/Logger/ILogProvider.cs
+++ b/tools/utils/Utils/Logger/ILogProvider.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     /// <summary>
     /// Log provider interface. Must be implemented by each logger

--- a/tools/utils/Utils/Logger/IMessageArg.cs
+++ b/tools/utils/Utils/Logger/IMessageArg.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     /// <summary>
     /// Message argument interface

--- a/tools/utils/Utils/Logger/LogMessage.cs
+++ b/tools/utils/Utils/Logger/LogMessage.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/Logger/LogMessageFormatter.cs
+++ b/tools/utils/Utils/Logger/LogMessageFormatter.cs
@@ -4,7 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Diagnostics;

--- a/tools/utils/Utils/Logger/LogProvider.cs
+++ b/tools/utils/Utils/Logger/LogProvider.cs
@@ -4,7 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     /// <summary>
     /// Log provider class (providers can be: Trace output, file, debug output, event viewer etc.)

--- a/tools/utils/Utils/Logger/LogUtils.cs
+++ b/tools/utils/Utils/Logger/LogUtils.cs
@@ -4,7 +4,7 @@
 //  </copyright>
 // -----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.IO;

--- a/tools/utils/Utils/Logger/Logger.cs
+++ b/tools/utils/Utils/Logger/Logger.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/Logger/TraceLog.cs
+++ b/tools/utils/Utils/Logger/TraceLog.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Diagnostics;

--- a/tools/utils/Utils/ProcessRunner/ComparePackageRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/ComparePackageRunner.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Globalization;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     ///  The class to run Compare package tool.

--- a/tools/utils/Utils/ProcessRunner/DesktopProcessRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/DesktopProcessRunner.cs
@@ -4,14 +4,14 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     /// Implements a process runner which runs on Desktop

--- a/tools/utils/Utils/ProcessRunner/IProcessRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/IProcessRunner.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Collections.Generic;
     using System.Text;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     public interface IProcessRunner : IDisposable
     {

--- a/tools/utils/Utils/ProcessRunner/MakeAppxRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/MakeAppxRunner.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Globalization;

--- a/tools/utils/Utils/ProcessRunner/PackageEditorRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/PackageEditorRunner.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Globalization;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     ///  The base class for Package Editor tool.

--- a/tools/utils/Utils/ProcessRunner/ProcessRunnerBase.cs
+++ b/tools/utils/Utils/ProcessRunner/ProcessRunnerBase.cs
@@ -4,13 +4,13 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     /// Provides a base from which all process runner implementations derive from.

--- a/tools/utils/Utils/ProcessRunner/ProcessRunnerException.cs
+++ b/tools/utils/Utils/ProcessRunner/ProcessRunnerException.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.IO;

--- a/tools/utils/Utils/ProcessRunner/SDKDetector.cs
+++ b/tools/utils/Utils/ProcessRunner/SDKDetector.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using Microsoft.Win32;
 
     /// <summary>

--- a/tools/utils/Utils/ProcessRunner/SDKToolProcessRunner.cs
+++ b/tools/utils/Utils/ProcessRunner/SDKToolProcessRunner.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.IO;
     using System.Text;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     ///  The class to inherit from for all SDK related process runner tools.

--- a/tools/utils/Utils/ProcessRunner/SDKToolProcessRunnerBase.cs
+++ b/tools/utils/Utils/ProcessRunner/SDKToolProcessRunnerBase.cs
@@ -4,13 +4,13 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Reflection;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     ///  The class to inherit from for all SDK related process runner tools.

--- a/tools/utils/Utils/Properties/AssemblyInfo.cs
+++ b/tools/utils/Utils/Properties/AssemblyInfo.cs
@@ -11,11 +11,11 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Packaging.Utils.Properties")]
+[assembly: AssemblyTitle("Microsoft.Msix.Utils.Properties")]
 [assembly: AssemblyDescription("Library for utilities like AppxPackaging, AppxPackagingInterop, CommandLine, IO, Logger, ProcessRunner, and StandardInput.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
-[assembly: AssemblyProduct("Microsoft.Packaging.Utils.Properties")]
+[assembly: AssemblyProduct("Microsoft.Msix.Utils.Properties")]
 [assembly: AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]

--- a/tools/utils/Utils/Properties/AssemblyInfo.cs
+++ b/tools/utils/Utils/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Msix.Utils.Properties")]
-[assembly: AssemblyDescription("Library for utilities like AppxPackaging, AppxPackagingInterop, CommandLine, IO, Logger, ProcessRunner, and StandardInput.")]
+[assembly: AssemblyDescription("Library containing utility types for MSIX, and interop for the Packaging API")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft.Msix.Utils.Properties")]

--- a/tools/utils/Utils/Telemetry/Telemetry.cs
+++ b/tools/utils/Utils/Telemetry/Telemetry.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Telemetry
+namespace Microsoft.Msix.Utils.Telemetry
 {
     using System;
     using System.Collections.Generic;

--- a/tools/utils/Utils/Telemetry/TelemetryEventData.cs
+++ b/tools/utils/Utils/Telemetry/TelemetryEventData.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.Telemetry
+namespace Microsoft.Msix.Utils.Telemetry
 {
     using System;
     using Microsoft.Diagnostics.Tracing;

--- a/tools/utils/Utils/Utils.csproj
+++ b/tools/utils/Utils/Utils.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{94F4F0AD-548E-4FF2-AF95-9D5E7AA24C6F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <NoStandardLibraries>false</NoStandardLibraries>
-    <RootNamespace>Microsoft.Packaging.Utils</RootNamespace>
-    <AssemblyName>Microsoft.Packaging.Utils</AssemblyName>
+    <RootNamespace>Microsoft.Msix.Utils</RootNamespace>
+    <AssemblyName>Microsoft.Msix.Utils</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <StyleCopTreatErrorsAsWarnings>false</StyleCopTreatErrorsAsWarnings>

--- a/tools/utils/UtilsNetCore/Logger/ConsoleLog.cs
+++ b/tools/utils/UtilsNetCore/Logger/ConsoleLog.cs
@@ -3,7 +3,7 @@
 //      Copyright (c) Microsoft Corporation.  All rights reserved.
 //  </copyright>
 // -----------------------------------------------------------------------
-namespace Microsoft.Packaging.Utils.Logger
+namespace Microsoft.Msix.Utils.Logger
 {
     using System;
     using System.Reflection;

--- a/tools/utils/UtilsNetCore/ProcessRunner/NetCoreProcessRunner.cs
+++ b/tools/utils/UtilsNetCore/ProcessRunner/NetCoreProcessRunner.cs
@@ -4,12 +4,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.IO;
     using System.Runtime.InteropServices;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     /// Implements a ProcessRunnerBase which runs on NetCore.

--- a/tools/utils/UtilsNetCore/ProcessRunner/SDKToolProcessRunner.cs
+++ b/tools/utils/UtilsNetCore/ProcessRunner/SDKToolProcessRunner.cs
@@ -4,11 +4,11 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
 
     /// <summary>
     ///  The class to inherit from for all SDK related process runner tools.

--- a/tools/utils/UtilsNetCore/ProcessRunner/Win32InteropException.cs
+++ b/tools/utils/UtilsNetCore/ProcessRunner/Win32InteropException.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Globalization;

--- a/tools/utils/UtilsNetCore/ProcessRunner/Win32NativeMethods.cs
+++ b/tools/utils/UtilsNetCore/ProcessRunner/Win32NativeMethods.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-namespace Microsoft.Packaging.Utils.ProcessRunner
+namespace Microsoft.Msix.Utils.ProcessRunner
 {
     using System;
     using System.Diagnostics.CodeAnalysis;

--- a/tools/utils/UtilsNetCoreTests/LoggerTests.cs
+++ b/tools/utils/UtilsNetCoreTests/LoggerTests.cs
@@ -6,7 +6,7 @@
 
 namespace UtilsNetCoreTests
 {
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System;
     using System.IO;

--- a/tools/utils/UtilsNetCoreTests/ProcessRunnerTests.cs
+++ b/tools/utils/UtilsNetCoreTests/ProcessRunnerTests.cs
@@ -7,7 +7,7 @@
 namespace UtilsNetCoreTests
 {
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.Packaging.Utils.ProcessRunner;
+    using Microsoft.Msix.Utils.ProcessRunner;
     using System;
 
     [TestClass]

--- a/tools/utils/UtilsNetCoreTests/TestBase.cs
+++ b/tools/utils/UtilsNetCoreTests/TestBase.cs
@@ -6,7 +6,7 @@
 
 namespace UtilsNetCoreTests
 {
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/tools/utils/UtilsTests/CommandLineTests/CleanupCommand.cs
+++ b/tools/utils/UtilsTests/CommandLineTests/CleanupCommand.cs
@@ -7,7 +7,7 @@
 namespace UtilsTests
 {
     using Microsoft.Extensions.CommandLineUtils;
-    using Microsoft.Packaging.Utils.CommandLine;
+    using Microsoft.Msix.Utils.CommandLine;
     using WEX.Logging.Interop;
 
     /// <summary>

--- a/tools/utils/UtilsTests/CommandLineTests/CommandLineTests.cs
+++ b/tools/utils/UtilsTests/CommandLineTests/CommandLineTests.cs
@@ -10,7 +10,7 @@ namespace UtilsTests
     using System.Collections.Generic;
     using System.IO;
     using Microsoft.Extensions.CommandLineUtils;
-    using Microsoft.Packaging.Utils.CommandLine;
+    using Microsoft.Msix.Utils.CommandLine;
     using WEX.Logging.Interop;
     using WEX.TestExecution;
     using WEX.TestExecution.Markup;

--- a/tools/utils/UtilsTests/CommandLineTests/SecondCommand.cs
+++ b/tools/utils/UtilsTests/CommandLineTests/SecondCommand.cs
@@ -9,7 +9,7 @@ namespace UtilsTests
     using System;
     using System.Collections.Generic;
     using Microsoft.Extensions.CommandLineUtils;
-    using Microsoft.Packaging.Utils.CommandLine;
+    using Microsoft.Msix.Utils.CommandLine;
     using WEX.Logging.Interop;
 
     /// <summary>

--- a/tools/utils/UtilsTests/CommandLineTests/ThirdCommand.cs
+++ b/tools/utils/UtilsTests/CommandLineTests/ThirdCommand.cs
@@ -9,7 +9,7 @@ namespace UtilsTests
     using System;
     using System.IO;
     using Microsoft.Extensions.CommandLineUtils;
-    using Microsoft.Packaging.Utils.CommandLine;
+    using Microsoft.Msix.Utils.CommandLine;
     using WEX.Logging.Interop;
 
     /// <summary>

--- a/tools/utils/UtilsTests/LoggerTests/LoggerCustomProviderTests.cs
+++ b/tools/utils/UtilsTests/LoggerTests/LoggerCustomProviderTests.cs
@@ -7,7 +7,7 @@
 namespace UtilsTests
 {
     using System;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using WEX.Logging.Interop;
     using WEX.TestExecution;
     using WEX.TestExecution.Markup;

--- a/tools/utils/UtilsTests/LoggerTests/LoggerTests.cs
+++ b/tools/utils/UtilsTests/LoggerTests/LoggerTests.cs
@@ -8,7 +8,7 @@ namespace UtilsTests
 {
     using System;
     using System.IO;
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using WEX.Logging.Interop;
     using WEX.TestExecution;
     using WEX.TestExecution.Markup;

--- a/tools/utils/UtilsTests/ProcessRunnerTests/ProcessRunnerTests.cs
+++ b/tools/utils/UtilsTests/ProcessRunnerTests/ProcessRunnerTests.cs
@@ -9,7 +9,7 @@ namespace UtilsTests
     using System;
     using System.IO;
     using System.Threading;
-    using Microsoft.Packaging.Utils.ProcessRunner;
+    using Microsoft.Msix.Utils.ProcessRunner;
     using WEX.Logging.Interop;
     using WEX.TestExecution;
     using WEX.TestExecution.Markup;

--- a/tools/utils/UtilsTests/TestBase.cs
+++ b/tools/utils/UtilsTests/TestBase.cs
@@ -6,7 +6,7 @@
 
 namespace UtilsTests
 {
-    using Microsoft.Packaging.Utils.Logger;
+    using Microsoft.Msix.Utils.Logger;
     using WEX.Logging.Interop;
     using WEX.TestExecution.Markup;
 


### PR DESCRIPTION
Changing the namespace for the Utils library from Microsoft.Packaging.Utils to Microsoft.Msix.Utils to match what will be the published NuGet package name.