### PR TITLE
Adding macOS Sillicon to pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ We recommend using the [makeaosp](makeaosp) script to build for Android on non-W
 
 ## Apple Silicon
 To enable building the MSIX SDK to run on Apple Silicon do the following:
-1. Install Xcode beta 12 build 12A8161k (https://developer.apple.com/download/)
+1. Install Xcode beta 12 (https://developer.apple.com/download/)
 2. Change active developer directory `sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer`
 3. Build using makemac.sh `./makemac.sh -arch arm64 --skip-tests`
 

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -14,13 +14,6 @@ if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
     if (XCODE_VERSION LESS 12.0)
         # If you see this and you have Xcode-beta 12 do:
         # sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer
-        message(FATAL_ERROR "arm64 is only supported on Xcode 12 12A8161k at this time. Found version ${XCODE_VERSION}. To enable arm64 builds please download Xcode beta 12 build 12A8161k and run `sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer`")
+        message(FATAL_ERROR "arm64 is only supported on Xcode 12 at this time. Found version ${XCODE_VERSION}. To enable arm64 builds please download Xcode beta 12 and run `sudo xcode-select -switch /Applications/Xcode-beta.app/Contents/Developer`")
     endif()
-
-    # WARNING, this will be false once Xcode 12 is release. Currently there are two
-    # Xcode-beta 12, build 12A8161k and build 12A6163b. The latter does NOT support arm64
-    if (NOT XCODE_BUILD MATCHES "12A8161k")
-        message(FATAL_ERROR "arm64 is only supported on Xcode 12 12A8161k at this time. Found build ${XCODE_BUILD}")
-    endif()
-
 endif()

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -29,7 +29,7 @@ pr:
 jobs:
 - job: macOS
   pool:
-    name: Hosted macOS
+    name: Azure Pipelines
     vmImage: macOS-latest
   strategy:
     # TODO: add builds using xerces if needed.
@@ -68,12 +68,7 @@ jobs:
   steps:
 
   # Az Pipelines has Xcode 11.6 as default. For arm64, change to supported Xcode. 
-  - script: |
-      ls /Applications
-      sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
-      xcodebuild -version
-      sudo xcode-select -switch /Applications/Xcode_12.app/Contents/Developer
-      xcodebuild -version
+  - script: sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
     displayName: 'Set up'
     condition: and(succeeded(), contains(variables['Agent.JobName'], 'arm64'))
 

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -30,6 +30,7 @@ jobs:
 - job: macOS
   pool:
     name: Hosted macOS
+    vmImage: macOS-latest
   strategy:
     # TODO: add builds using xerces if needed.
     matrix:

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -48,7 +48,29 @@ jobs:
       debug_pack:
         _arguments: -b Debug --pack
         _artifact: MACOSchk-pack
+      # arm64
+      debug_nopack_arm64:
+        _arguments: -b Debug -arch arm64 --skip-tests
+        _artifact: MACOSarm64chk
+      release_nopack_arm64:
+        _arguments: -b MinSizeRel -arch arm64 --skip-tests
+        _artifact: MACOSarm64
+      release_nobundle_arm64:
+        _arguments: -b MinSizeRel -sb -arch arm64 --skip-tests
+        _artifact: MACOSarm64-nobundle
+      release_pack_arm64:
+        _arguments: -b MinSizeRel --pack -arch arm64 --skip-tests
+        _artifact: MACOSarm64chk-pack
+      debug_pack_arm64:
+        _arguments: -b Debug --pack -arch arm64 --skip-tests
+        _artifact: MACOSarm64chk-pack
   steps:
+
+  # Az Pipelines has Xcode 11.6 as default. For arm64, change to supported Xcode. 
+  - script: sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
+    displayName: 'Set up'
+    condition: and(succeeded(), contains(variables['Agent.JobName'], 'arm64'))
+
   - task: Bash@3
     displayName: Build
     inputs:
@@ -64,14 +86,14 @@ jobs:
   - script: 'msixtest/msixtest -s -r junit -o TEST-MsixSDK-$(_artifact).xml'
     workingDirectory: .vs
     displayName: 'macOS BVTs'
-    condition: and(succeeded(), contains(variables['Agent.JobName'], 'release'))
+    condition: and(succeeded(), contains(variables['Agent.JobName'], 'release'), not(contains(variables['Agent.JobName'], 'arm64')))
   
   - task: PublishTestResults@2
     displayName: 'Publish $(_artifact) Test Results'
     inputs:
       failTaskOnFailedTests: true
       testRunTitle: $(_artifact)
-    condition: and(succeededOrFailed(), contains(variables['Agent.JobName'], 'release'))
+    condition: and(succeededOrFailed(), contains(variables['Agent.JobName'], 'release'), not(contains(variables['Agent.JobName'], 'arm64')))
 
   - task: CopyFiles@2
     displayName: 'Copy Files to: $(Build.ArtifactStagingDirectory)'

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -68,7 +68,12 @@ jobs:
   steps:
 
   # Az Pipelines has Xcode 11.6 as default. For arm64, change to supported Xcode. 
-  - script: sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
+  - script: |
+      ls /Applications
+      sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
+      xcodebuild -version
+      sudo xcode-select -switch /Applications/Xcode_12.app/Contents/Developer
+      xcodebuild -version
     displayName: 'Set up'
     condition: and(succeeded(), contains(variables['Agent.JobName'], 'arm64'))
 


### PR DESCRIPTION
Azure DevOps's Mac Microsoft-hosted agents now include a version of Xcode that can build targeting macOS. Adding it to pipelines.