### PR TITLE
macOS universal binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The following native platforms are in development now:
 **Release x32 Xerces With Pack**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20Windows%20CI?branchName=master&jobName=Windows&configuration=Windows%20release_32_xerces)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=64&branchName=master)|
 **Release x64 Xerces With Pack**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20Windows%20CI?branchName=master&jobName=Windows&configuration=Windows%20release_64_xerces)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=64&branchName=master)|
 
-Built in the Azure Pipelines Hosted VS2017 pool. See specifications [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2017-Server2016-Readme.md)
+Built in the Azure Pipelines windows-latest pool. See specifications [here](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md)
 
 ### macOS
 ||master|
@@ -158,8 +158,16 @@ Built in the Azure Pipelines Hosted VS2017 pool. See specifications [here](https
 **Release Without Bundle support**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20release_nobundle)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
 **Debug With Pack**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20debug_pack)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
 **Release With Pack**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20release_pack)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Debug arm64**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20debug_nopack_arm64)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release arm64**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20release_nopack_arm64)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release Without Bundle support arm64**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20release_nobundle_arm64)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Debug With Pack arm64**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20debug_pack_arm64)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release With Pack arm64**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS%20release_pack_arm64)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release Universal**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS_universal_nopack)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release Without Bundle support Universal**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macOS_universal_nobundle)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
+**Release With Pack Universal**|[![Build Status](https://dev.azure.com/ms/msix-packaging/_apis/build/status/msix-packaging%20macOS%20CI?branchName=master&jobName=macOS&configuration=macO_universal_pack)](https://dev.azure.com/ms/msix-packaging/_build/latest?definitionId=69&branchName=master)|
 
-Built in the Azure Pipelines macOS pool. See specification [here](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/macos/macos-10.14-Readme.md)
+Built in the Azure Pipelines macOS pool. See specification [here](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md)
 
 ### iOS
 ||master|

--- a/pipelines/azure-pipelines-ios.yml
+++ b/pipelines/azure-pipelines-ios.yml
@@ -45,6 +45,9 @@ jobs:
       release_arm64:
         _arguments: -b MinSizeRel -arch arm64
         _artifact: iOS-arm64
+      release_arm64_nobundle:
+        _arguments: -b MinSizeRel -arch arm64 -sb
+        _artifact: iOS-arm64-nobundle
   steps:
   - task: Bash@3
     displayName: Build

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -119,7 +119,7 @@ jobs:
       ArtifactName: $(_artifact)
     condition: succeededOrFailed()
 
--job:
+- job: macOS_universal_nopack
   dependsOn:
     - 'macOS release_nopack'
     - 'macOS release_nopack_arm64'
@@ -133,7 +133,7 @@ jobs:
         artifact_x86: MACOS
         artifact_arm64: MACOSarm64
 
--job:
+- job: macOS_universal_nobundle
   dependsOn:
     - 'macOS release_nobundle'
     - 'macOS release_nobundle_arm64'
@@ -147,7 +147,7 @@ jobs:
         artifact_x86: MACOS-nobundle
         artifact_arm64: MACOSarm64-nobundle
 
--job:
+- job: macOS_universal_pack
   dependsOn:
     - 'macOS release_pack'
     - 'macOS release_pack_arm64'
@@ -160,4 +160,3 @@ jobs:
         artifact_output: MACOS-pack-Universal
         artifact_x86: MACOS-pack
         artifact_arm64: MACOSarm64-pack
-

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -121,8 +121,7 @@ jobs:
 
 - job: macOS_universal_nopack
   dependsOn:
-    - 'macOS release_nopack'
-    - 'macOS release_nopack_arm64'
+    - 'macOS'
   pool:
     name: Azure Pipelines
     vmImage: macOS-latest
@@ -135,8 +134,7 @@ jobs:
 
 - job: macOS_universal_nobundle
   dependsOn:
-    - 'macOS release_nobundle'
-    - 'macOS release_nobundle_arm64'
+    - 'macOS'
   pool:
     name: Azure Pipelines
     vmImage: macOS-latest
@@ -149,8 +147,7 @@ jobs:
 
 - job: macOS_universal_pack
   dependsOn:
-    - 'macOS release_pack'
-    - 'macOS release_pack_arm64'
+    - 'macOS'
   pool:
     name: Azure Pipelines
     vmImage: macOS-latest

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -45,7 +45,7 @@ jobs:
         _artifact: MACOS-nobundle
       release_pack:
         _arguments: -b MinSizeRel --pack
-        _artifact: MACOSchk-pack
+        _artifact: MACOS-pack
       debug_pack:
         _arguments: -b Debug --pack
         _artifact: MACOSchk-pack
@@ -61,7 +61,7 @@ jobs:
         _artifact: MACOSarm64-nobundle
       release_pack_arm64:
         _arguments: -b MinSizeRel --pack -arch arm64 --skip-tests
-        _artifact: MACOSarm64chk-pack
+        _artifact: MACOSarm64-pack
       debug_pack_arm64:
         _arguments: -b Debug --pack -arch arm64 --skip-tests
         _artifact: MACOSarm64chk-pack
@@ -118,3 +118,46 @@ jobs:
     inputs:
       ArtifactName: $(_artifact)
     condition: succeededOrFailed()
+
+-job:
+  dependsOn:
+    - 'macOS release_nopack'
+    - 'macOS release_nopack_arm64'
+  pool:
+    name: Azure Pipelines
+    vmImage: macOS-latest
+  steps:
+    - template: templates/macos-universal.yml
+      parameters:
+        artifact_output: MACOS-Universal
+        artifact_x86: MACOS
+        artifact_arm64: MACOSarm64
+
+-job:
+  dependsOn:
+    - 'macOS release_nobundle'
+    - 'macOS release_nobundle_arm64'
+  pool:
+    name: Azure Pipelines
+    vmImage: macOS-latest
+  steps:
+    - template: templates/macos-universal.yml
+      parameters:
+        artifact_output: MACOS-nobundle-Universal
+        artifact_x86: MACOS-nobundle
+        artifact_arm64: MACOSarm64-nobundle
+
+-job:
+  dependsOn:
+    - 'macOS release_pack'
+    - 'macOS release_pack_arm64'
+  pool:
+    name: Azure Pipelines
+    vmImage: macOS-latest
+  steps:
+    - template: templates/macos-universal.yml
+      parameters:
+        artifact_output: MACOS-pack-Universal
+        artifact_x86: MACOS-pack
+        artifact_arm64: MACOSarm64-pack
+

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -68,7 +68,7 @@ jobs:
         _artifact: WIN32-pack
       release_64_pack:
         _arguments: x64 --pack
-        _artifact: WIN32-pack
+        _artifact: WIN32-x64-pack
       debug_32_pack:
         _arguments: x86 -d --pack
         _artifact: WIN32chk-pack

--- a/pipelines/templates/macos-universal.yml
+++ b/pipelines/templates/macos-universal.yml
@@ -1,0 +1,35 @@
+# Template helper to package projects (using DotNetCoreCLI Publish Command) and publish them as an artifact
+parameters:
+  artifact_output: ''
+  artifact_x86: ''
+  artifact_arm64: ''
+
+steps:
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download ${{ parameters.artifact_x86 }}'
+  inputs:
+    artifactName: ${{ parameters.artifact_x86 }}
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download ${{ parameters.artifact_arm64 }}'
+  inputs:
+    artifactName: ${{ parameters.artifact_arm64 }}
+
+- script: |
+    sudo xcode-select -switch /Applications/Xcode_12_beta.app/Contents/Developer
+  
+    cp -R $(System.ArtifactsDirectory)/${{ parameters.artifact_x86 }} $(System.ArtifactsDirectory)/Universal
+    rm $(System.ArtifactsDirectory)/Universal/lib/libmsix.dylib
+    rm $(System.ArtifactsDirectory)/Universal/bin/makemsix
+  
+    lipo -create -output $(System.ArtifactsDirectory)/Universal/lib/libmsix.dylib $(System.ArtifactsDirectory)/${{ parameters.artifact_x86 }}/lib/libmsix.dylib $(System.ArtifactsDirectory)/${{ parameters.artifact_arm64 }}/lib/libmsix.dylib
+  
+    lipo -create -output $(System.ArtifactsDirectory)/Universal/bin/makemsix $(System.ArtifactsDirectory)/${{ parameters.artifact_x86 }}/bin/makemsix $(System.ArtifactsDirectory)/${{ parameters.artifact_arm64 }}/bin/makemsix
+
+  displayName: 'Command Line Script'
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Universal'
+  inputs:
+    PathtoPublish: '$(System.ArtifactsDirectory)/Universal'
+    ArtifactName: ${{ parameters.artifact_output }}


### PR DESCRIPTION
macOS universal binaries are executables that run natively on both Apple silicon and Intel-based Mac computers. These are created by providing the architecture specific binaries to the `lipo` tool for it to merge. The new jobs will wait for the binaries to be built and combine them.

Also, adding new build badges to the README.md, update the link for the az devops images used and fix some typos in the artifacts names. 