### PR TITLE
Add missing files to Linux artifacts

### DIFF
--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -86,6 +86,8 @@ jobs:
         src/msix/AppxPackaging.hpp
         src/msix/MSIXWindows.hpp
         src/msix/MsixErrors.hpp
+        Package.nuspec
+        build/**
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
     condition: succeededOrFailed()
 


### PR DESCRIPTION
Missing package.nuspec and files under the build directory.