### PR TITLE
Fix output path in localization pipeline for ADO tasks

### DIFF
--- a/tools/pipelines-tasks/azure-pipelines/localization.yml
+++ b/tools/pipelines-tasks/azure-pipelines/localization.yml
@@ -30,7 +30,6 @@ steps:
     relativePathRoot: '$(tasksRoot)'
     resourceFilePath: '*\Strings\resources.resjson\en-US\resources.resjson'
     appendRelativeDir: true
-    outputDirectoryRoot: '$(tasksRoot)'
 
 # TouchdownBuildTask will place the localized files under
 # Strings\resources.resjson\en-US\

--- a/tools/pipelines-tasks/azure-pipelines/localization.yml
+++ b/tools/pipelines-tasks/azure-pipelines/localization.yml
@@ -26,10 +26,11 @@ steps:
     teamId: 15687
     authId: 2796a411-f030-46c1-ae3e-ab56f60ea523
     authKey: $(LocServiceKey)
-    isPreview: false
+    isPreview: true
     relativePathRoot: '$(tasksRoot)'
     resourceFilePath: '*\Strings\resources.resjson\en-US\resources.resjson'
     appendRelativeDir: true
+    outputDirectoryRoot: '$(tasksRoot)'
 
 # TouchdownBuildTask will place the localized files under
 # Strings\resources.resjson\en-US\

--- a/tools/pipelines-tasks/azure-pipelines/localization.yml
+++ b/tools/pipelines-tasks/azure-pipelines/localization.yml
@@ -26,7 +26,7 @@ steps:
     teamId: 15687
     authId: 2796a411-f030-46c1-ae3e-ab56f60ea523
     authKey: $(LocServiceKey)
-    isPreview: true
+    isPreview: false
     relativePathRoot: '$(tasksRoot)'
     resourceFilePath: '*\Strings\resources.resjson\en-US\resources.resjson'
     appendRelativeDir: true

--- a/tools/pipelines-tasks/azure-pipelines/localization.yml
+++ b/tools/pipelines-tasks/azure-pipelines/localization.yml
@@ -30,6 +30,7 @@ steps:
     relativePathRoot: '$(tasksRoot)'
     resourceFilePath: '*\Strings\resources.resjson\en-US\resources.resjson'
     appendRelativeDir: true
+    outputDirectoryRoot: '$(tasksRoot)'
 
 # TouchdownBuildTask will place the localized files under
 # Strings\resources.resjson\en-US\


### PR DESCRIPTION
The loc pipeline for the ADO tasks was missing a parameter for where to place the localized strings. By default it is the repo root which made sense in the internal repo but not here.