### PR TITLE
Installation fails if certificate contains extended ascii or non alpha-numeric character

### DIFF
--- a/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
+++ b/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
@@ -428,7 +428,6 @@ namespace MSIX
 
     static bool GetPublisherDisplayName(/*in*/byte* signatureBuffer, /*in*/ ULONG cbSignatureBuffer, /*inout*/ std::string& publisher)
     {
-        //DebugBreak();
         unique_cert_context certificateContext(GetCertContext(signatureBuffer, cbSignatureBuffer, true));
 		if (certificateContext.get() == NULL)
 		{
@@ -451,12 +450,9 @@ namespace MSIX
             publisherT.data(),
             requiredLength) > 0)
         {
-            std::wstring pub = publisherT.data();
-            auto converted = std::wstring_convert<std::codecvt_utf8<wchar_t>>{}.to_bytes(pub.data());
+            auto converted = std::wstring_convert<std::codecvt_utf8<wchar_t>>{}.to_bytes(publisherT.data());
             std::string result(converted.begin(), converted.end());
             publisher = result;
-            //std::string strString(pub.begin(), pub.end());
-            //publisher = std::string(publisherT.data());
             return true;
         }
         return false;

--- a/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
+++ b/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
@@ -428,29 +428,35 @@ namespace MSIX
 
     static bool GetPublisherDisplayName(/*in*/byte* signatureBuffer, /*in*/ ULONG cbSignatureBuffer, /*inout*/ std::string& publisher)
     {
+        //DebugBreak();
         unique_cert_context certificateContext(GetCertContext(signatureBuffer, cbSignatureBuffer, true));
 		if (certificateContext.get() == NULL)
 		{
 			return false;
 		}
-        int requiredLength = CertNameToStrA(
+        int requiredLength = CertNameToStrW(
             X509_ASN_ENCODING,
             &certificateContext.get()->pCertInfo->Subject,
             CERT_X500_NAME_STR | CERT_NAME_STR_REVERSE_FLAG,
             nullptr,
             0);
 
-        std::vector<char> publisherT;
+        std::vector<wchar_t> publisherT;
         publisherT.reserve(requiredLength + 1);
         
-        if (CertNameToStrA(
+        if (CertNameToStrW(
             X509_ASN_ENCODING,
             &certificateContext.get()->pCertInfo->Subject,
             CERT_X500_NAME_STR | CERT_NAME_STR_REVERSE_FLAG,
             publisherT.data(),
             requiredLength) > 0)
         {
-            publisher = std::string(publisherT.data());
+            std::wstring pub = publisherT.data();
+            auto converted = std::wstring_convert<std::codecvt_utf8<wchar_t>>{}.to_bytes(pub.data());
+            std::string result(converted.begin(), converted.end());
+            publisher = result;
+            //std::string strString(pub.begin(), pub.end());
+            //publisher = std::string(publisherT.data());
             return true;
         }
         return false;

--- a/src/msix/common/UnicodeConversion.cpp
+++ b/src/msix/common/UnicodeConversion.cpp
@@ -25,10 +25,10 @@ namespace MSIX {
     {
         if (utf8string.empty()) { return {}; }
         #ifdef WIN32
-        int size = MultiByteToWideChar(CP_ACP, 0, utf8string.data(), static_cast<int>(utf8string.size()), nullptr, 0);
+        int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8string.data(), static_cast<int>(utf8string.size()), nullptr, 0);
         ThrowLastErrorIf(size == 0, "Error converting to wstring");
         std::wstring result(size, 0);
-        MultiByteToWideChar(CP_ACP, 0, utf8string.data(), static_cast<int>(utf8string.size()), &result[0], size);
+        MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8string.data(), static_cast<int>(utf8string.size()), &result[0], size);
         #else
         auto converted = utf8_to_utf16(utf8string);
         std::wstring result(converted.begin(), converted.end());

--- a/src/msix/common/UnicodeConversion.cpp
+++ b/src/msix/common/UnicodeConversion.cpp
@@ -25,10 +25,10 @@ namespace MSIX {
     {
         if (utf8string.empty()) { return {}; }
         #ifdef WIN32
-        int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8string.data(), static_cast<int>(utf8string.size()), nullptr, 0);
+        int size = MultiByteToWideChar(CP_ACP, 0, utf8string.data(), static_cast<int>(utf8string.size()), nullptr, 0);
         ThrowLastErrorIf(size == 0, "Error converting to wstring");
         std::wstring result(size, 0);
-        MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, utf8string.data(), static_cast<int>(utf8string.size()), &result[0], size);
+        MultiByteToWideChar(CP_ACP, 0, utf8string.data(), static_cast<int>(utf8string.size()), &result[0], size);
         #else
         auto converted = utf8_to_utf16(utf8string);
         std::wstring result(converted.begin(), converted.end());


### PR DESCRIPTION
**Issue:** The installation was failing if the app had an accent in the subject name of the certificate or the publisher in the manifest.
**Reason**: 
The equals comparison check between the publisher name derived from the certificate and the publisher name from the appx manifest file was failing. It appears that the value of the 'publisher' being read from the signature file(certificate) was being read and derived using CertNameToStrA which was returning the ANSI string. I changed it to CertNameToStrW which now returns the correct UTF8 string.

**Verified**: by running an app which is signed with a certificate which has the following special characters content in it subject name and manifest publisher name - Île-de-France. It installs and runs successfully.