### PR TITLE
Set ExecutionPolicy when calling powershell in pipeline tasks

### DIFF
--- a/tools/pipelines-tasks/.gitignore
+++ b/tools/pipelines-tasks/.gitignore
@@ -25,3 +25,6 @@ pat.txt
 
 # Powershell modules
 ps_modules/
+
+# Don't exclude VS Code configuration for this project as it contains debug configuration
+!.vscode/

--- a/tools/pipelines-tasks/.vscode/launch.json
+++ b/tools/pipelines-tasks/.vscode/launch.json
@@ -1,0 +1,65 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch AppInstallerFile",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "program": "${workspaceFolder}/AppInstallerFile/index.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "envFile": "${workspaceFolder}/AppInstallerFile/debug_inputs.env"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch MsixAppAttach",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "program": "${workspaceFolder}/MsixAppAttach/index.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "envFile": "${workspaceFolder}/MsixAppAttach/debug_inputs.env"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch MsixSigning",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "program": "${workspaceFolder}/MsixSigning/index.js",
+            "args": ["--mockSecureFileDownload"],
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "envFile": "${workspaceFolder}/MsixSigning/debug_inputs.env"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch MsixPackaging",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "preLaunchTask": "tsc: build - tsconfig.json",
+            "program": "${workspaceFolder}/MsixPackaging/index.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ],
+            "envFile": "${workspaceFolder}/MsixPackaging/debug_inputs.env"
+        }
+    ]
+}

--- a/tools/pipelines-tasks/MsixAppAttach/index.ts
+++ b/tools/pipelines-tasks/MsixAppAttach/index.ts
@@ -24,6 +24,10 @@ const run = async () =>
     const fullVhdxPath: string = path.resolve(vhdxPath);
 
     const powershellRunner: ToolRunner = tl.tool('powershell');
+    powershellRunner.arg('-NoLogo');
+    powershellRunner.arg('-NoProfile');
+    powershellRunner.arg('-NonInteractive');
+    powershellRunner.arg(['-ExecutionPolicy', 'Unrestricted']);
     powershellRunner.arg(GENERATE_VHDX_SCRIPT_PATH);
     powershellRunner.arg(['-vhdxPath', fullVhdxPath]);
     powershellRunner.arg(['-vhdxSize', vhdxSize]);

--- a/tools/pipelines-tasks/MsixPackaging/msbuild.ts
+++ b/tools/pipelines-tasks/MsixPackaging/msbuild.ts
@@ -70,6 +70,10 @@ const getMSBuildPathFromVersion = async (msbuildVersion: string, msbuildArchitec
         // it looks in the Global Assembly Cache to find the right version.
         // We use a wrapper script to call the right function from the helper.
         const powershellRunner = tl.tool('powershell');
+        powershellRunner.arg('-NoLogo');
+        powershellRunner.arg('-NoProfile');
+        powershellRunner.arg('-NonInteractive');
+        powershellRunner.arg(['-ExecutionPolicy', 'Unrestricted']);
         powershellRunner.arg(MSBUILD_PATH_HELPER_SCRIPT);
         powershellRunner.arg(['-PreferredVersion', msbuildVersion]);
         powershellRunner.arg(['-Architecture', msbuildArchitecture]);

--- a/tools/pipelines-tasks/SignConfig.xml
+++ b/tools/pipelines-tasks/SignConfig.xml
@@ -1,5 +1,0 @@
-<SignConfigXML>
-  <job platform="" configuration="" dest="__OUTPATHROOT__" jobname="ISS EngFun" approvers="" certSubject="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US">
-    <file src="__INPATHROOT__\MsixPackagingExtension.vsix" signType="Opc" />
-  </job>
-</SignConfigXML>

--- a/tools/utils/SignConfig.xml
+++ b/tools/utils/SignConfig.xml
@@ -1,5 +1,0 @@
-<SignConfigXML>
-  <job platform="" configuration="" dest="__OUTPATHROOT__" jobname="ISS EngFun" approvers="">
-    <file src="__INPATHROOT__\Microsoft.Msix.Utils*.nupkg" signType="NuGet" />
-  </job>
-</SignConfigXML>


### PR DESCRIPTION
The pipeline tasks for packaging and for creating a VHDX for app attach call a helper PS script, which may be blocked in certain environments due to the ExecutionPolicy. To allow the scripts to run, set the execution policy when calling powershell.exe.

Also removed files regarding release signing configuration that are no longer needed with the new signing method, and added debug configuration for the pipelines tasks that was missing after the move from the private repo.