### PR TITLE
Use attributes instead of elements on generated .appinstaller files

### DIFF
--- a/tools/pipelines-tasks/AppInstallerFile/appinstallerfile.ts
+++ b/tools/pipelines-tasks/AppInstallerFile/appinstallerfile.ts
@@ -160,7 +160,7 @@ export const createNew = (
     // Update settings
     if (updateOnLaunch)
     {
-        const onLaunchSettings: any = {};
+        const onLaunchSettings: any = { $: {} };
         newFile.AppInstaller.UpdateSettings =
         {
             OnLaunch: onLaunchSettings
@@ -168,17 +168,17 @@ export const createNew = (
 
         if (hoursBetweenUpdateChecks)
         {
-            onLaunchSettings.HoursBetweenUpdateChecks = hoursBetweenUpdateChecks;
+            onLaunchSettings.$.HoursBetweenUpdateChecks = hoursBetweenUpdateChecks;
         }
 
         if (showPromptWhenUpdating)
         {
-            onLaunchSettings.ShowPrompt = showPromptWhenUpdating;
+            onLaunchSettings.$.ShowPrompt = showPromptWhenUpdating;
         }
 
         if (updateBlocksActivation)
         {
-            onLaunchSettings.UpdateBlocksActivation = updateBlocksActivation;
+            onLaunchSettings.$.UpdateBlocksActivation = updateBlocksActivation;
         }
     }
 

--- a/tools/pipelines-tasks/test/appinstallerfile.ts
+++ b/tools/pipelines-tasks/test/appinstallerfile.ts
@@ -1,6 +1,5 @@
 import assert = require('assert');
 import childProcess = require('child_process');
-import fs = require('fs');
 import ttm = require('azure-pipelines-task-lib/mock-test');
 
 import testHelpers = require('./testhelpers');
@@ -17,7 +16,7 @@ const runTestAndVerifyFileIsAsExpected = (testName: string) =>
 
     // Using Compare-Object instead of comparing the files ourselves
     // prevents errors due to mismatched line endings.
-    const diff = childProcess.execSync(`powershell Compare-Object (Get-Content ${createdFilePath}) (Get-Content ${createdFilePath})`).toString();
+    const diff = childProcess.execSync(`powershell Compare-Object (Get-Content ${expectedFilePath}) (Get-Content ${createdFilePath})`).toString();
     assert.strictEqual(diff, '', `There should be no difference between the expected .appinstaller '${expectedFilePath}' and created .appinstaller '${createdFilePath}'.`);
 }
 

--- a/tools/pipelines-tasks/test/assets/expected/appinstallerfile-new-from-package-success.appinstaller
+++ b/tools/pipelines-tasks/test/assets/expected/appinstallerfile-new-from-package-success.appinstaller
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2018" Version="1.0.0.0" Uri="https://example.com/appinstallerfile-new-from-package-success">
-  <MainPackage Name="7fa9aa49-c12e-4977-8a29-14b25a006dc7" Publisher="CN=HelloWorldPublisher" Version="4.0.0.0" ProcessorArchitecture="x86" Uri="existingPackage.msix"/>
+  <MainPackage Name="7fa9aa49-c12e-4977-8a29-14b25a006dc7" Publisher="CN=HelloWorldPublisher" Version="1.0.0.0" ProcessorArchitecture="x86" Uri="existingPackage.msix"/>
   <OptionalPackages>
     <Package Name="Goodbye World App" Publisher="CN=Goodbye World Inc." Version="2.2.3.3" ProcessorArchitecture="x86" Uri="http://goodbyeworld.com/install"/>
   </OptionalPackages>
   <Dependencies>
     <Bundle Name="Visual Studio" Publisher="CN=Microsoft" Version="10.37.96.549" Uri="https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=Community&amp;rel=16"/>
   </Dependencies>
+  <UpdateSettings>
+    <OnLaunch HoursBetweenUpdateChecks="24" ShowPrompt="true" UpdateBlocksActivation="true"/>
+  </UpdateSettings>
 </AppInstaller>

--- a/tools/pipelines-tasks/test/assets/expected/appinstallerfile-update-from-package-success.appinstaller
+++ b/tools/pipelines-tasks/test/assets/expected/appinstallerfile-update-from-package-success.appinstaller
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2018" Version="1.0.0.1" Uri="existingInstaller.appinstaller">
-  <MainPackage Name="7fa9aa49-c12e-4977-8a29-14b25a006dc7" Publisher="CN=HelloWorldPublisher" Version="4.0.0.0" ProcessorArchitecture="x86" Uri="existingPackage.msix"/>
+  <MainPackage Name="7fa9aa49-c12e-4977-8a29-14b25a006dc7" Publisher="CN=HelloWorldPublisher" Version="1.0.0.0" ProcessorArchitecture="x86" Uri="existingPackage.msix"/>
   <UpdateSettings>
     <OnLaunch HoursBetweenUpdateChecks="3" UpdateBlocksActivation="false" ShowPrompt="true"/>
   </UpdateSettings>

--- a/tools/pipelines-tasks/test/mock-tests/appinstallerfile-new-from-package-success.ts
+++ b/tools/pipelines-tasks/test/mock-tests/appinstallerfile-new-from-package-success.ts
@@ -3,6 +3,10 @@ import testHelpers = require('../testhelpers');
 
 const taskMockRunner: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(testHelpers.TaskEntryPoints.AppInstallerTask);
 testHelpers.setUpNewAppInstallerFileArguments(taskMockRunner, __filename, testHelpers.testPackage);
+taskMockRunner.setInput("updateOnLaunch", "true");
+taskMockRunner.setInput("hoursBetweenUpdateChecks", "24");
+taskMockRunner.setInput("showPromptWhenUpdating", "true");
+taskMockRunner.setInput("updateBlocksActivation", "true");
 
 // Don't mock call to makeappx to unpack
 taskMockRunner.run(/* noMockTask */ true);


### PR DESCRIPTION
When generating an App Installer file with the DevOps task, the settings for update on launch should be attributes but they were being generated as elements in the XML. Change to using attributes, update test to check for this and fix error in tests to actually validate the generated file.

This fixes #405 