### PR TITLE
Remove task input groups

### DIFF
--- a/tools/pipelines-tasks/AppInstallerFile/Strings/resources.resjson/en-US/resources.resjson
+++ b/tools/pipelines-tasks/AppInstallerFile/Strings/resources.resjson/en-US/resources.resjson
@@ -3,8 +3,6 @@
   "loc.helpMarkDown": "",
   "loc.description": "Create or update an App Installer file for MSIX apps",
   "loc.instanceNameFormat": "Create App Installer file",
-  "loc.group.displayName.optionalItems": "Optional Items",
-  "loc.group.displayName.dependencies": "Dependencies",
   "loc.input.label.package": "Package",
   "loc.input.help.package": "Path to the package or bundle.",
   "loc.input.label.outputPath": "Output File Path",

--- a/tools/pipelines-tasks/AppInstallerFile/index.ts
+++ b/tools/pipelines-tasks/AppInstallerFile/index.ts
@@ -58,6 +58,10 @@ const readInputsForCreate = (): appInstallerFile.CreateParameters =>
         {
             optionalItems.push(readInputsForItem(optionalItemInputPrefix, /* isBundle */ true));
         }
+        else
+        {
+            break;
+        }
     }
 
     const dependencies: appInstallerFile.PackageOrBundle[] = [];

--- a/tools/pipelines-tasks/AppInstallerFile/task.json
+++ b/tools/pipelines-tasks/AppInstallerFile/task.json
@@ -19,18 +19,6 @@
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
-  "groups": [
-    {
-      "name": "optionalItems",
-      "displayName": "Optional Items",
-      "isExpanded": false
-    },
-    {
-      "name": "dependencies",
-      "displayName": "Dependencies",
-      "isExpanded": false
-    }
-  ],
   "inputs": [
     {
       "name": "package",
@@ -150,7 +138,6 @@
       "label": "Add an Optional Package/Bundle",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "Add an optional package or bundle",
       "visibleRule": "method = create",
       "options": {
@@ -164,45 +151,40 @@
       "type": "string",
       "label": "Optional Item 1: Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The package or bundle name of your first optional item to include.",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1Publisher",
       "type": "string",
       "label": "Optional Item 1: Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The publisher name of the first optional item to include.",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1Version",
       "type": "string",
       "label": "Optional Item 1: Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The version number of the first optional item to include.",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1ProcessorArchitecture",
       "type": "string",
       "label": "Optional Item 1: Processor Architecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The processor architecture of the first optional item to include.",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1URI",
       "type": "string",
       "label": "Optional Item 1: URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The URI of the first optional item to include.",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "addOptionalItem2",
@@ -210,9 +192,8 @@
       "label": "Add a Second Optional Package/Bundle",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "Add a second optional package or bundle",
-      "visibleRule": "method = create && addOptionalItem1 != none",
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle",
       "options": {
         "none": "No Optional Package/Bundle",
         "package": "Add Optional Package",
@@ -224,45 +205,40 @@
       "type": "string",
       "label": "Optional Item 2: Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The package or bundle name of your second optional item to include.",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2Publisher",
       "type": "string",
       "label": "Optional Item 2: Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The publisher name of the second optional item to include.",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2Version",
       "type": "string",
       "label": "Optional Item 2: Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The version number of the second optional item to include.",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2ProcessorArchitecture",
       "type": "string",
       "label": "Optional Item 2: Processor Architecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The processor architecture of the second optional item to include.",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2URI",
       "type": "string",
       "label": "Optional Item 2: URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The URI of the second optional item to include.",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "addOptionalItem3",
@@ -270,9 +246,8 @@
       "label": "Add a Third Optional Package/Bundle",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "Add a third optional package or bundle",
-      "visibleRule": "method = create && addOptionalItem2 != none",
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle",
       "options": {
         "none": "No Optional Package/Bundle",
         "package": "Add Optional Package",
@@ -284,45 +259,40 @@
       "type": "string",
       "label": "Optional Item 3: Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The package or bundle name of your third optional item to include.",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3Publisher",
       "type": "string",
       "label": "Optional Item 3: Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The publisher name of the third optional item to include.",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3Version",
       "type": "string",
       "label": "Optional Item 3: Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The version number of the third optional item to include.",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3ProcessorArchitecture",
       "type": "string",
       "label": "Optional Item 3: Processor Architecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The processor architecture of the third optional item to include.",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3URI",
       "type": "string",
       "label": "Optional Item 3: URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "The URI of the third optional item to include.",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "addDependency1",
@@ -330,7 +300,6 @@
       "label": "Add a Dependency",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "Add a dependency.",
       "visibleRule": "method = create",
       "options": {
@@ -344,45 +313,40 @@
       "type": "string",
       "label": "Dependency 1: Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The name of the first dependency to include.",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1Publisher",
       "type": "string",
       "label": "Dependency 1: Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The publisher name of the first dependency to include.",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1Version",
       "type": "string",
       "label": "Dependency 1: Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The version number of the first dependency to include.",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1ProcessorArchitecture",
       "type": "string",
       "label": "Dependency 1: Processor Architecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The processor architecture of the first dependency to include.",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1URI",
       "type": "string",
       "label": "Dependency 1: URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The URI of the first dependency to include.",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "addDependency2",
@@ -390,9 +354,8 @@
       "label": "Add a Second Dependency",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "Add a second dependency.",
-      "visibleRule": "method = create && addDependency1 != none",
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle",
       "options": {
         "none": "No Dependency",
         "package": "Add Package Dependency",
@@ -404,45 +367,40 @@
       "type": "string",
       "label": "Dependency 2: Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The name of the second dependency to include.",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2Publisher",
       "type": "string",
       "label": "Dependency 2: Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The publisher name of the second dependency to include.",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2Version",
       "type": "string",
       "label": "Dependency 2: Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The version number of the second dependency to include.",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2ProcessorArchitecture",
       "type": "string",
       "label": "Dependency 2: Processor Architecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The processor architecture of the second dependency to include.",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2URI",
       "type": "string",
       "label": "Dependency 2: URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The URI of the second dependency to include.",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "addDependency3",
@@ -450,9 +408,8 @@
       "label": "Add a Third Dependency",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "Add a third dependency.",
-      "visibleRule": "method = create && addDependency2 != none",
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle",
       "options": {
         "none": "No Dependency",
         "package": "Add Package Dependency",
@@ -464,45 +421,40 @@
       "type": "string",
       "label": "Dependency 3: Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The name of the third dependency to include.",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3Publisher",
       "type": "string",
       "label": "Dependency 3: Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The publisher name of the third dependency to include.",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3Version",
       "type": "string",
       "label": "Dependency 3: Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The version number of the third dependency to include.",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3ProcessorArchitecture",
       "type": "string",
       "label": "Dependency 3: Processor Architecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The processor architecture of the third dependency to include.",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3URI",
       "type": "string",
       "label": "Dependency 3: URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "The URI of the third dependency to include.",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     }
   ]
 }

--- a/tools/pipelines-tasks/AppInstallerFile/task.loc.json
+++ b/tools/pipelines-tasks/AppInstallerFile/task.loc.json
@@ -19,18 +19,6 @@
     "Patch": 0
   },
   "minimumAgentVersion": "1.95.0",
-  "groups": [
-    {
-      "name": "optionalItems",
-      "displayName": "ms-resource:loc.group.displayName.optionalItems",
-      "isExpanded": false
-    },
-    {
-      "name": "dependencies",
-      "displayName": "ms-resource:loc.group.displayName.dependencies",
-      "isExpanded": false
-    }
-  ],
   "inputs": [
     {
       "name": "package",
@@ -150,7 +138,6 @@
       "label": "ms-resource:loc.input.label.addOptionalItem1",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.addOptionalItem1",
       "visibleRule": "method = create",
       "options": {
@@ -164,45 +151,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem1Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem1Name",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem1Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem1Publisher",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem1Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem1Version",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem1ProcessorArchitecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem1ProcessorArchitecture",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "optionalItem1URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem1URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem1URI",
-      "visibleRule": "method = create && addOptionalItem1 != none"
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle"
     },
     {
       "name": "addOptionalItem2",
@@ -210,9 +192,8 @@
       "label": "ms-resource:loc.input.label.addOptionalItem2",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.addOptionalItem2",
-      "visibleRule": "method = create && addOptionalItem1 != none",
+      "visibleRule": "addOptionalItem1 == package || addOptionalItem1 == bundle",
       "options": {
         "none": "No Optional Package/Bundle",
         "package": "Add Optional Package",
@@ -224,45 +205,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem2Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem2Name",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem2Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem2Publisher",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem2Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem2Version",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem2ProcessorArchitecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem2ProcessorArchitecture",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "optionalItem2URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem2URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem2URI",
-      "visibleRule": "method = create && addOptionalItem2 != none"
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle"
     },
     {
       "name": "addOptionalItem3",
@@ -270,9 +246,8 @@
       "label": "ms-resource:loc.input.label.addOptionalItem3",
       "defaultValue": "none",
       "required": false,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.addOptionalItem3",
-      "visibleRule": "method = create && addOptionalItem2 != none",
+      "visibleRule": "addOptionalItem2 == package || addOptionalItem2 == bundle",
       "options": {
         "none": "No Optional Package/Bundle",
         "package": "Add Optional Package",
@@ -284,45 +259,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem3Name",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem3Name",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem3Publisher",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem3Publisher",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem3Version",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem3Version",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem3ProcessorArchitecture",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem3ProcessorArchitecture",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "optionalItem3URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.optionalItem3URI",
       "required": true,
-      "groupName": "optionalItems",
       "helpMarkDown": "ms-resource:loc.input.help.optionalItem3URI",
-      "visibleRule": "method = create && addOptionalItem3 != none"
+      "visibleRule": "addOptionalItem3 == package || addOptionalItem3 == bundle"
     },
     {
       "name": "addDependency1",
@@ -330,7 +300,6 @@
       "label": "ms-resource:loc.input.label.addDependency1",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.addDependency1",
       "visibleRule": "method = create",
       "options": {
@@ -344,45 +313,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency1Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency1Name",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency1Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency1Publisher",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency1Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency1Version",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency1ProcessorArchitecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency1ProcessorArchitecture",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "dependency1URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency1URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency1URI",
-      "visibleRule": "method = create && addDependency1 != none"
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle"
     },
     {
       "name": "addDependency2",
@@ -390,9 +354,8 @@
       "label": "ms-resource:loc.input.label.addDependency2",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.addDependency2",
-      "visibleRule": "method = create && addDependency1 != none",
+      "visibleRule": "addDependency1 == package || addDependency1 == bundle",
       "options": {
         "none": "No Dependency",
         "package": "Add Package Dependency",
@@ -404,45 +367,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency2Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency2Name",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency2Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency2Publisher",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency2Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency2Version",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency2ProcessorArchitecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency2ProcessorArchitecture",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "dependency2URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency2URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency2URI",
-      "visibleRule": "method = create && addDependency2 != none"
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle"
     },
     {
       "name": "addDependency3",
@@ -450,9 +408,8 @@
       "label": "ms-resource:loc.input.label.addDependency3",
       "defaultValue": "none",
       "required": false,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.addDependency3",
-      "visibleRule": "method = create && addDependency2 != none",
+      "visibleRule": "addDependency2 == package || addDependency2 == bundle",
       "options": {
         "none": "No Dependency",
         "package": "Add Package Dependency",
@@ -464,45 +421,40 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency3Name",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency3Name",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3Publisher",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency3Publisher",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency3Publisher",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3Version",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency3Version",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency3Version",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3ProcessorArchitecture",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency3ProcessorArchitecture",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency3ProcessorArchitecture",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     },
     {
       "name": "dependency3URI",
       "type": "string",
       "label": "ms-resource:loc.input.label.dependency3URI",
       "required": true,
-      "groupName": "dependencies",
       "helpMarkDown": "ms-resource:loc.input.help.dependency3URI",
-      "visibleRule": "method = create && addDependency3 != none"
+      "visibleRule": "addDependency3 == package || addDependency3 == bundle"
     }
   ]
 }

--- a/tools/pipelines-tasks/MsixPackaging/Strings/resources.resjson/en-US/resources.resjson
+++ b/tools/pipelines-tasks/MsixPackaging/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,6 @@
   "loc.helpMarkDown": "",
   "loc.description": "Build and package Windows apps using the MSIX package format",
   "loc.instanceNameFormat": "MSIX build and package",
-  "loc.group.displayName.msbuild": "Advanced Options for MSBuild",
   "loc.input.label.outputPath": "Output Path",
   "loc.input.help.outputPath": "Path of the generated package or bundle.",
   "loc.input.label.buildSolution": "Build Solution with MSBuild",

--- a/tools/pipelines-tasks/MsixPackaging/task.json
+++ b/tools/pipelines-tasks/MsixPackaging/task.json
@@ -22,13 +22,6 @@
     "msbuild"
   ],
   "minimumAgentVersion": "1.95.0",
-  "groups": [
-    {
-      "name": "msbuild",
-      "displayName": "Advanced Options for MSBuild",
-      "isExpanded": false
-    }
-  ],
   "inputs": [
     {
       "name": "outputPath",
@@ -179,7 +172,6 @@
       "label": "MSBuild",
       "required": true,
       "defaultValue": "version",
-      "groupName": "msbuild",
       "options": {
         "version": "Version",
         "location": "Specify Location"
@@ -192,7 +184,6 @@
       "label": "MSBuild Version",
       "required": true,
       "defaultValue": "latest",
-      "groupName": "msbuild",
       "helpMarkDown": "If the preferred version cannot be found, the latest version found will be used instead.",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = version",
       "options": {
@@ -210,7 +201,6 @@
       "label": "MSBuild Architecture",
       "defaultValue": "x86",
       "required": true,
-      "groupName": "msbuild",
       "helpMarkDown": "Optionally supply the architecture (x86, x64) of MSBuild to run.",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = version",
       "options": {
@@ -223,7 +213,6 @@
       "type": "string",
       "label": "Path to MSBuild",
       "defaultValue": "",
-      "groupName": "msbuild",
       "required": true,
       "helpMarkDown": "Optionally supply the path to MSBuild.",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = location"

--- a/tools/pipelines-tasks/MsixPackaging/task.loc.json
+++ b/tools/pipelines-tasks/MsixPackaging/task.loc.json
@@ -22,13 +22,6 @@
     "msbuild"
   ],
   "minimumAgentVersion": "1.95.0",
-  "groups": [
-    {
-      "name": "msbuild",
-      "displayName": "ms-resource:loc.group.displayName.msbuild",
-      "isExpanded": false
-    }
-  ],
   "inputs": [
     {
       "name": "outputPath",
@@ -179,7 +172,6 @@
       "label": "ms-resource:loc.input.label.msbuildLocationMethod",
       "required": true,
       "defaultValue": "version",
-      "groupName": "msbuild",
       "options": {
         "version": "Version",
         "location": "Specify Location"
@@ -192,7 +184,6 @@
       "label": "ms-resource:loc.input.label.msbuildVersion",
       "required": true,
       "defaultValue": "latest",
-      "groupName": "msbuild",
       "helpMarkDown": "ms-resource:loc.input.help.msbuildVersion",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = version",
       "options": {
@@ -210,7 +201,6 @@
       "label": "ms-resource:loc.input.label.msbuildArchitecture",
       "defaultValue": "x86",
       "required": true,
-      "groupName": "msbuild",
       "helpMarkDown": "ms-resource:loc.input.help.msbuildArchitecture",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = version",
       "options": {
@@ -223,7 +213,6 @@
       "type": "string",
       "label": "ms-resource:loc.input.label.msbuildLocation",
       "defaultValue": "",
-      "groupName": "msbuild",
       "required": true,
       "helpMarkDown": "ms-resource:loc.input.help.msbuildLocation",
       "visibleRule": "buildSolution = true && msbuildLocationMethod = location"

--- a/tools/pipelines-tasks/azure-pipelines/ci-build.yml
+++ b/tools/pipelines-tasks/azure-pipelines/ci-build.yml
@@ -13,7 +13,7 @@ pr:
     - release_v*
   paths:
     include:
-    - tools/pipelines-tasks/*
+    - tools/pipelines-tasks
 
 pool:
   vmImage: 'windows-latest'

--- a/tools/pipelines-tasks/build.ps1
+++ b/tools/pipelines-tasks/build.ps1
@@ -57,12 +57,12 @@ function OnEachTask([string]$message, [scriptblock]$script)
 
 # Builds the common helpers and installs it to each task.
 # This needs to run after any changes to the common helpers.
-function BuildCommonHelpers([switch]$cleanBuild)
+function BuildCommonHelpers([switch]$installDependencies)
 {
-    OnDirectory "$PSScriptRoot\common" -arguments $cleanBuild {
-        param($cleanBuild)
+    OnDirectory "$PSScriptRoot\common" -arguments $installDependencies {
+        param($installDependencies)
 
-        if ($cleanBuild)
+        if ($installDependencies)
         {
             Write-Host "Installing dependencies"
             npm ci
@@ -108,14 +108,8 @@ function BuildCommonHelpers([switch]$cleanBuild)
         # The helpers need to be installed to each task because each task is
         # installed independently to the agent, so only files on the task's
         # directory can be used.
-        # If we are doing a clean build, the package will be installed in a
-        # later step with `npm ci`.  Avoid `npm` install in that case as it
-        # may also update other packages.
-        if (-not $cleanBuild)
-        {
-            OnEachTask "Installing common helpers" {
-                npm install common
-            }
+        OnEachTask "Installing common helpers" {
+            npm install common
         }
     }
 }
@@ -142,7 +136,7 @@ function InstallAllDepenencies()
     # from package-lock.json and get the same results on any machine.
 
     # First build the common helpers as they are a dependency of everything else.
-    BuildCommonHelpers -cleanBuild
+    BuildCommonHelpers -installDependencies
 
     # Install dependencies for top level scripts.
     OnDirectory $PSScriptRoot {

--- a/tools/utils/azure-pipelines.yml
+++ b/tools/utils/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
     - release_v*
   paths:
     include:
-    - tools/utils/*
+    - tools/utils
 
 pool:
   vmImage: 'windows-latest'


### PR DESCRIPTION
Issue: The packaging extension fails to install on Azure DevOps Server due to how we used input groups in the tasks. The visibility of some inputs in one group depended on inputs from another group, but that is not allowed there.

Fix: Removed the input groups altogether. The UI is a little more cluttered, but this allows to install.

Validated install works in a local server.

Also updated the build script to prevent updating packages depended on while building.

See #400