### PR TITLE
Add yaml pipeline for building the VSIX for MSIX Packaging Extension

### DIFF
--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -42,7 +42,6 @@ steps:
   displayName: 'Restore NuGet packages for test project'
   inputs:
     restoreSolution: '$(tasksRoot)/test/assets/HelloWorldUWPApp/HelloWorldApp.sln'
-  enabled: false
 
 - powershell: |
     npx mocha
@@ -50,9 +49,9 @@ steps:
   workingDirectory: '$(tasksRoot)'
   env:
     SYSTEM_CULTURE: 'en-US'
-  enabled: false
 
-#  Set the version for each task as the Package step does not update the task.loc.json
+# Set the version for each task as the Package step does not update the task.loc.json
+# See https://github.com/microsoft/azure-devops-extension-tasks/issues/184
 - powershell: |
    foreach ($path in $(Get-ChildItem -Depth 1 -Recurse -Include 'task.json','task.loc.json')) {
       $taskJson = Get-Content $path.FullName -Raw | ConvertFrom-Json
@@ -61,21 +60,20 @@ steps:
       $taskJson.version.Patch = $(patch)
       $taskJson | ConvertTo-Json -Depth 10 | Set-Content $path.FullName
    }
-  workingDirectory: 'tools/pipelines-tasks'
+  workingDirectory: '$(tasksRoot)'
   displayName: 'Update tasks'' version'
-  enabled: false
 
 # Package and sign the VSIX
 - task: PackageAzureDevOpsExtension@3
-  displayName: 'Package Extension: tools/pipelines-tasks'
+  displayName: 'Package Extension: $(tasksRoot)'
   inputs:
     rootFolder: '$(tasksRoot)'
+    patternManifest: 'vss-extension.json'
     outputPath: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'
     extensionVisibility: public
-    localizationRoot:
-    updateTasksVersion: true
+    updateTasksVersion: false
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
@@ -106,26 +104,47 @@ steps:
           "ToolVersion" : "1.0"
       }
      ]
-  # disabled for testing
-  enabled: false
 
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: VSIX'
+- task: PublishPipelineArtifact@1
+  displayName: 'Publish VSIX artifact'
   inputs:
-    ArtifactName: VSIX
+    targetPath: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
+    artifact: 'VSIX'
+    publishLocation: 'pipeline'
 
 # Publish privately
-# Use different task IDs from public extension
+# Use different task IDs from public extension to prevent clashing.
+# We need to update the IDs manually because the task doesn't do it.
+# See https://github.com/microsoft/azure-devops-extension-tasks/issues/184
+- powershell: |
+    $newIds = (
+      @{ Id = "10d89817-fdc8-572b-9e70-5a3300a49491"; Name = "AppInstallerFile" },
+      @{ Id = "8d76d007-40aa-5704-abcd-fccba288ec3f"; Name = "MsixAppAttach" },
+      @{ Id = "e1431997-aad9-5eeb-a649-a945fa6fd7d7"; Name = "MsixPackaging" },
+      @{ Id = "bc2a3a10-c739-5277-acb1-32f8ffb6a382"; Name = "MsixSigning" }
+    )
+    foreach ($task in $newIds) {
+      foreach ($jsonName in ('task.json', 'task.loc.json')) {
+        $path = Join-Path $task.Name $jsonName
+        $taskJson = Get-Content $path -Raw | ConvertFrom-Json
+        $taskJson.id = $task.Id
+        $taskJson | ConvertTo-Json -Depth 10 | Set-Content $path
+      }
+    }
+  workingDirectory: $(tasksRoot)
+  displayName: 'Update tasks'' IDs for private'
+
 - task: PublishAzureDevOpsExtension@3
   displayName: 'Publish Extension'
   inputs:
     connectedServiceName: 'Visual Studio Marketplace - MSIX'
-    fileType: vsix
-    vsixFile: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
+    fileType: 'manifest'
+    rootFolder: '$(tasksRoot)'
+    patternManifest: 'vss-extension.json'
+    publisherId: 'MSIX'
     extensionId: 'msix-ci-automation-task-dev'
     extensionName: 'MSIX Packaging (Preview)'
+    extensionVersion: '$(major).$(minor).$(patch)'
     updateTasksVersion: false
-    updateTasksId: true
+    # updateTasksId: true
     extensionVisibility: 'privatepreview'
-  # disabled for testing
-  enabled: false

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -109,5 +109,6 @@ steps:
     vsixFile: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
     extensionId: 'msix-ci-automation-task-dev'
     extensionName: 'MSIX Packaging (Preview)'
+    extensionVersion: '$(major).$(minor).$(patch)'
     updateTasksId: true
     extensionVisibility: 'privatepreview'

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -102,6 +102,8 @@ steps:
           "ToolVersion" : "1.0"
       }
      ]
+  # disabled for testing
+  enabled: false
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: VSIX'
@@ -121,3 +123,5 @@ steps:
     updateTasksVersion: false
     updateTasksId: true
     extensionVisibility: 'privatepreview'
+  # disabled for testing
+  enabled: false

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -16,7 +16,7 @@ variables:
   major: '1'
   minor: '0'
   # Set to 0 on next change to minor. This grew while using a classic pipeline.
-  patch: '$[counter(variables['minor'], 7)]'
+  patch: $[counter(variables['minor'], 7)]
 
 steps:
 # Install the tools needed

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -1,0 +1,125 @@
+# Pipeline to create extension VSIX
+
+trigger:
+  branches:
+    include:
+    - master
+  paths:
+    include:
+    - tools/pipelines-tasks
+
+pool:
+  vmImage: 'windows-latest'
+
+variables:
+  # Version number
+  major: '1'
+  minor: '0'
+  # Set to 0 on next change to minor. This grew while using a classic pipeline.
+  patch: '$[counter(variables['minor'], 7)]'
+
+steps:
+# Install the tools needed
+- task: NodeTool@0
+  displayName: 'Use Node 10.x'
+  inputs:
+    versionSpec: 10.x
+
+- task: TfxInstaller@3
+  displayName: 'Use Node CLI for Azure DevOps (tfx-cli): v0.7.x'
+
+# Build the project
+- task: PowerShell@2
+  displayName: 'Build the project'
+  inputs:
+    targetType: filePath
+    filePath: './tools/pipelines-tasks/build.ps1'
+    arguments: BuildForProduction
+
+# Run the tests
+- task: NuGetCommand@2
+  displayName: 'Restore NuGet packages for test project'
+  inputs:
+    restoreSolution: '$(tasksRoot)/test/assets/HelloWorldUWPApp/HelloWorldApp.sln'
+
+- powershell: |
+    npx mocha
+  displayName: 'Run the tests'
+  workingDirectory: '$(tasksRoot)'
+  env:
+    SYSTEM_CULTURE: 'en-US'
+
+#  Set the version for each task as the Package step does not update the task.loc.json
+- powershell: |
+   foreach ($path in $(Get-ChildItem -Depth 1 -Recurse -Include 'task.json','task.loc.json')) {
+      $taskJson = Get-Content $path.FullName -Raw | ConvertFrom-Json
+      $taskJson.version.Major = $(major)
+      $taskJson.version.Minor = $(minor)
+      $taskJson.version.Patch = $(patch)
+      $taskJson | ConvertTo-Json -Depth 10 | Set-Content $path.FullName
+   }
+  workingDirectory: 'tools/pipelines-tasks'
+  displayName: 'Update tasks'' version'
+  enabled: false # May not actually be needed?
+
+# Build and sign the package
+- task: PackageAzureDevOpsExtension@3
+  displayName: 'Package Extension: tools/pipelines-tasks'
+  inputs:
+    rootFolder: '$(Build.SourcesDirectory)\tools\pipelines-tasks'
+    outputPath: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
+    publisherId: 'MSIX'
+    extensionVersion: '$(major).$(minor).$(patch)'
+    extensionVisibility: public
+    updateTasksVersion: true
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component Detection'
+
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+  displayName: 'ESRP CodeSigning'
+  inputs:
+    ConnectedServiceName: 'ESRP CodeSigning'
+    FolderPath: '$(Build.ArtifactStagingDirectory)'
+    Pattern: MsixPackagingExtension.vsix
+    signConfigType: inlineSignParams
+    inlineOperation: |
+     [
+      {
+          "KeyCode" : "CP-233016",
+          "OperationCode" : "OpcSign",
+          "Parameters" : {
+              "FileDigest" : "/fd SHA256"
+          },
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+      },
+      {
+          "KeyCode" : "CP-233016",
+          "OperationCode" : "OpcVerify",
+          "Parameters" : {},
+          "ToolName" : "sign",
+          "ToolVersion" : "1.0"
+      }
+     ]
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: VSIX'
+  inputs:
+    ArtifactName: VSIX
+
+# Publish privately
+# Use different task IDs from public extension
+- task: PublishAzureDevOpsExtension@3
+  displayName: 'Publish Extension'
+  inputs:
+    connectedServiceName: 'Visual Studio Marketplace - MSIX'
+    fileType: vsix
+    vsixFile: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
+    extensionId: 'msix-ci-automation-task-dev'
+    extensionName: 'MSIX Packaging (Preview)'
+    updateTasksVersion: false
+    updateTasksId: true
+    extensionVisibility: 'privatepreview'
+  enabled: false
+

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -65,7 +65,7 @@ steps:
   displayName: 'Update tasks'' version'
   enabled: false
 
-# Build and sign the package
+# Package and sign the VSIX
 - task: PackageAzureDevOpsExtension@3
   displayName: 'Package Extension: tools/pipelines-tasks'
   inputs:
@@ -74,6 +74,7 @@ steps:
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'
     extensionVisibility: public
+    localizationRoot:
     updateTasksVersion: true
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -61,7 +61,6 @@ steps:
    }
   workingDirectory: 'tools/pipelines-tasks'
   displayName: 'Update tasks'' version'
-  enabled: false # May not actually be needed?
 
 # Build and sign the package
 - task: PackageAzureDevOpsExtension@3
@@ -72,7 +71,7 @@ steps:
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'
     extensionVisibility: public
-    updateTasksVersion: true
+    updateTasksVersion: false
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
@@ -122,5 +121,3 @@ steps:
     updateTasksVersion: false
     updateTasksId: true
     extensionVisibility: 'privatepreview'
-  enabled: false
-

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -42,6 +42,7 @@ steps:
   displayName: 'Restore NuGet packages for test project'
   inputs:
     restoreSolution: '$(tasksRoot)/test/assets/HelloWorldUWPApp/HelloWorldApp.sln'
+  enabled: false
 
 - powershell: |
     npx mocha
@@ -49,6 +50,7 @@ steps:
   workingDirectory: '$(tasksRoot)'
   env:
     SYSTEM_CULTURE: 'en-US'
+  enabled: false
 
 #  Set the version for each task as the Package step does not update the task.loc.json
 - powershell: |
@@ -61,6 +63,7 @@ steps:
    }
   workingDirectory: 'tools/pipelines-tasks'
   displayName: 'Update tasks'' version'
+  enabled: false
 
 # Build and sign the package
 - task: PackageAzureDevOpsExtension@3
@@ -71,7 +74,7 @@ steps:
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'
     extensionVisibility: public
-    updateTasksVersion: false
+    updateTasksVersion: true
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -12,6 +12,7 @@ pool:
   vmImage: 'windows-latest'
 
 variables:
+  tasksRoot: 'tools/pipelines-tasks'
   # Version number
   major: '1'
   minor: '0'
@@ -33,7 +34,7 @@ steps:
   displayName: 'Build the project'
   inputs:
     targetType: filePath
-    filePath: './tools/pipelines-tasks/build.ps1'
+    filePath: '$(tasksRoot)/build.ps1'
     arguments: BuildForProduction
 
 # Run the tests
@@ -66,7 +67,7 @@ steps:
 - task: PackageAzureDevOpsExtension@3
   displayName: 'Package Extension: tools/pipelines-tasks'
   inputs:
-    rootFolder: '$(Build.SourcesDirectory)\tools\pipelines-tasks'
+    rootFolder: '$(tasksRoot)'
     outputPath: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'

--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -50,19 +50,6 @@ steps:
   env:
     SYSTEM_CULTURE: 'en-US'
 
-# Set the version for each task as the Package step does not update the task.loc.json
-# See https://github.com/microsoft/azure-devops-extension-tasks/issues/184
-- powershell: |
-   foreach ($path in $(Get-ChildItem -Depth 1 -Recurse -Include 'task.json','task.loc.json')) {
-      $taskJson = Get-Content $path.FullName -Raw | ConvertFrom-Json
-      $taskJson.version.Major = $(major)
-      $taskJson.version.Minor = $(minor)
-      $taskJson.version.Patch = $(patch)
-      $taskJson | ConvertTo-Json -Depth 10 | Set-Content $path.FullName
-   }
-  workingDirectory: '$(tasksRoot)'
-  displayName: 'Update tasks'' version'
-
 # Package and sign the VSIX
 - task: PackageAzureDevOpsExtension@3
   displayName: 'Package Extension: $(tasksRoot)'
@@ -73,7 +60,7 @@ steps:
     publisherId: 'MSIX'
     extensionVersion: '$(major).$(minor).$(patch)'
     extensionVisibility: public
-    updateTasksVersion: false
+    updateTasksVersion: true
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
   displayName: 'Component Detection'
@@ -114,37 +101,13 @@ steps:
 
 # Publish privately
 # Use different task IDs from public extension to prevent clashing.
-# We need to update the IDs manually because the task doesn't do it.
-# See https://github.com/microsoft/azure-devops-extension-tasks/issues/184
-- powershell: |
-    $newIds = (
-      @{ Id = "10d89817-fdc8-572b-9e70-5a3300a49491"; Name = "AppInstallerFile" },
-      @{ Id = "8d76d007-40aa-5704-abcd-fccba288ec3f"; Name = "MsixAppAttach" },
-      @{ Id = "e1431997-aad9-5eeb-a649-a945fa6fd7d7"; Name = "MsixPackaging" },
-      @{ Id = "bc2a3a10-c739-5277-acb1-32f8ffb6a382"; Name = "MsixSigning" }
-    )
-    foreach ($task in $newIds) {
-      foreach ($jsonName in ('task.json', 'task.loc.json')) {
-        $path = Join-Path $task.Name $jsonName
-        $taskJson = Get-Content $path -Raw | ConvertFrom-Json
-        $taskJson.id = $task.Id
-        $taskJson | ConvertTo-Json -Depth 10 | Set-Content $path
-      }
-    }
-  workingDirectory: $(tasksRoot)
-  displayName: 'Update tasks'' IDs for private'
-
 - task: PublishAzureDevOpsExtension@3
   displayName: 'Publish Extension'
   inputs:
     connectedServiceName: 'Visual Studio Marketplace - MSIX'
-    fileType: 'manifest'
-    rootFolder: '$(tasksRoot)'
-    patternManifest: 'vss-extension.json'
-    publisherId: 'MSIX'
+    fileType: vsix
+    vsixFile: '$(Build.ArtifactStagingDirectory)\MsixPackagingExtension.vsix'
     extensionId: 'msix-ci-automation-task-dev'
     extensionName: 'MSIX Packaging (Preview)'
-    extensionVersion: '$(major).$(minor).$(patch)'
-    updateTasksVersion: false
-    # updateTasksId: true
+    updateTasksId: true
     extensionVisibility: 'privatepreview'


### PR DESCRIPTION
This is the pipeline for building the VSIX for release of the extension. It used to be a classic pipeline; moving it to yaml for better change tracking. This builds and signs the packages, then publishes a private version of it for validation. The actual publishing will be a separate release pipeline.