### PR TITLE
Quote script paths in extension tasks

### DIFF
--- a/tools/pipelines-tasks/AppInstallerFile/package-lock.json
+++ b/tools/pipelines-tasks/AppInstallerFile/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-pC/hkcREG6YfDfui1FBmj8e20jFU5Exjw4NYDm8kEdrW+mOh0T1Zve8DWKnS7ZIZvgncrctcNCXF4Q2I+loyww=="
     },
     "@types/xml2js": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
-      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
       "requires": {
         "@types/node": "*"
       }

--- a/tools/pipelines-tasks/MsixAppAttach/index.ts
+++ b/tools/pipelines-tasks/MsixAppAttach/index.ts
@@ -22,13 +22,7 @@ const run = async () =>
 
     // The script requires the command path to be absolute.
     const fullVhdxPath: string = path.resolve(vhdxPath);
-
-    const powershellRunner: ToolRunner = tl.tool('powershell');
-    powershellRunner.arg('-NoLogo');
-    powershellRunner.arg('-NoProfile');
-    powershellRunner.arg('-NonInteractive');
-    powershellRunner.arg(['-ExecutionPolicy', 'Unrestricted']);
-    powershellRunner.arg(GENERATE_VHDX_SCRIPT_PATH);
+    const powershellRunner: ToolRunner = helpers.getPowershellRunner(GENERATE_VHDX_SCRIPT_PATH);
     powershellRunner.arg(['-vhdxPath', fullVhdxPath]);
     powershellRunner.arg(['-vhdxSize', vhdxSize]);
     powershellRunner.arg(['-msixPackagePath', packagePath]);

--- a/tools/pipelines-tasks/MsixAppAttach/package-lock.json
+++ b/tools/pipelines-tasks/MsixAppAttach/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
     },
     "@types/xml2js": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
-      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
       "requires": {
         "@types/node": "*"
       }

--- a/tools/pipelines-tasks/MsixPackaging/msbuild.ts
+++ b/tools/pipelines-tasks/MsixPackaging/msbuild.ts
@@ -69,12 +69,7 @@ const getMSBuildPathFromVersion = async (msbuildVersion: string, msbuildArchitec
         // The Powershell helper only works on Windows;
         // it looks in the Global Assembly Cache to find the right version.
         // We use a wrapper script to call the right function from the helper.
-        const powershellRunner = tl.tool('powershell');
-        powershellRunner.arg('-NoLogo');
-        powershellRunner.arg('-NoProfile');
-        powershellRunner.arg('-NonInteractive');
-        powershellRunner.arg(['-ExecutionPolicy', 'Unrestricted']);
-        powershellRunner.arg(MSBUILD_PATH_HELPER_SCRIPT);
+        const powershellRunner: ToolRunner = helpers.getPowershellRunner(MSBUILD_PATH_HELPER_SCRIPT);
         powershellRunner.arg(['-PreferredVersion', msbuildVersion]);
         powershellRunner.arg(['-Architecture', msbuildArchitecture]);
 

--- a/tools/pipelines-tasks/MsixPackaging/package-lock.json
+++ b/tools/pipelines-tasks/MsixPackaging/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
     },
     "@types/xml2js": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
-      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
       "requires": {
         "@types/node": "*"
       }

--- a/tools/pipelines-tasks/MsixSigning/package-lock.json
+++ b/tools/pipelines-tasks/MsixSigning/package-lock.json
@@ -16,9 +16,9 @@
       "dev": true
     },
     "@types/xml2js": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
-      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.8.tgz",
+      "integrity": "sha512-EyvT83ezOdec7BhDaEcsklWy7RSIdi6CNe95tmOAK0yx/Lm30C9K75snT3fYayK59ApC2oyW+rcHErdG05FHJA==",
       "requires": {
         "@types/node": "*"
       }

--- a/tools/pipelines-tasks/common/helpers.ts
+++ b/tools/pipelines-tasks/common/helpers.ts
@@ -35,6 +35,25 @@ export const getInputWithErrorCheck = (variableName: string, errorMessage: strin
 }
 
 /**
+ * Gets a ToolRunner for running a Powershell script.
+ * Script arguments can be added later by the caller.
+ * @param scriptPath Script to run.
+ */
+export const getPowershellRunner = (scriptPath: string): ToolRunner =>
+{
+    const powershellRunner: ToolRunner = tl.tool('powershell')
+        .arg('-NoLogo')
+        .arg('-NoProfile')
+        .arg('-NonInteractive')
+        .arg(['-ExecutionPolicy', 'Unrestricted']);
+
+    // Quote the script path to allow for spaces.
+    // Existing quotes need to be escaped.
+    powershellRunner.arg(`& '${scriptPath.replace("'", "''")}'`);
+    return powershellRunner;
+}
+
+/**
  * Increment the current version given by the method specified. A version
  * is in the form of (major).(minor).(build).(revision). The incremental
  * method specifies which part of the version to increment. For example,


### PR DESCRIPTION
Some tasks in the packaging extension call PowerShell scripts using unquoted strings, which fails in environments where the paths include spaces. This change adds quotes to the string paths to fix that.

This should fix #410 