### PR TITLE
Remove TELEMETRYEVENTSOURCE_PUBLIC flag to resolve namespace conflict with external TelemetryEventSource.cs

### DIFF
--- a/tools/utils/Utils/Telemetry/TelemetryEventSource.cs
+++ b/tools/utils/Utils/Telemetry/TelemetryEventSource.cs
@@ -40,13 +40,7 @@ namespace Microsoft.Diagnostics.Telemetry
     /// of internal.
     /// </para>
     /// </summary>
-#if TELEMETRYEVENTSOURCE_PUBLIC
-    public
-#else
-    internal
-#endif
-        class TelemetryEventSource
-        : EventSource
+    internal class TelemetryEventSource : EventSource
     {
         /// <summary>
         /// Keyword 0x0000100000000000 is reserved for future definition. Do

--- a/tools/utils/Utils/Telemetry/TelemetryEventSource.cs
+++ b/tools/utils/Utils/Telemetry/TelemetryEventSource.cs
@@ -40,7 +40,13 @@ namespace Microsoft.Diagnostics.Telemetry
     /// of internal.
     /// </para>
     /// </summary>
-    internal class TelemetryEventSource : EventSource
+#if TELEMETRYEVENTSOURCE_PUBLIC
+    public
+#else
+    internal
+#endif
+        class TelemetryEventSource
+        : EventSource
     {
         /// <summary>
         /// Keyword 0x0000100000000000 is reserved for future definition. Do

--- a/tools/utils/Utils/Utils.csproj
+++ b/tools/utils/Utils/Utils.csproj
@@ -23,7 +23,6 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <!--TELEMETRYEVENTSOURCE_PUBLIC is used internally in TelemetryEventSource to make the class public-->
     <DefineConstants>TRACE;DEBUG;TELEMETRYEVENTSOURCE_USE_NUGET</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -33,7 +32,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;TELEMETRYEVENTSOURCE_USE_NUGET;TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>
+    <DefineConstants>TRACE;TELEMETRYEVENTSOURCE_USE_NUGET</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/tools/utils/Utils/Utils.csproj
+++ b/tools/utils/Utils/Utils.csproj
@@ -24,7 +24,7 @@
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <!--TELEMETRYEVENTSOURCE_PUBLIC is used internally in TelemetryEventSource to make the class public-->
-    <DefineConstants>TRACE;DEBUG;TELEMETRYEVENTSOURCE_USE_NUGET;TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;TELEMETRYEVENTSOURCE_USE_NUGET</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
The TelemetryEventSource from the Msix-packaging library causes a namespace conflict with other projects that want to implement their own managed-code telemetry. By removing this flag and making this class internal, it allows us to create our own telemetry implementation without a namespace conflict.