### PR TITLE
Added option to AppxFactory to create package writer with file hash enabled

### DIFF
--- a/src/inc/internal/AppxBlockMapWriter.hpp
+++ b/src/inc/internal/AppxBlockMapWriter.hpp
@@ -19,6 +19,7 @@ namespace MSIX {
     public:
         BlockMapWriter();
 
+        void EnableFileHash();
         void AddFile(const std::string& name, std::uint64_t uncompressedSize, std::uint32_t lfh);
         void AddBlock(const std::vector<std::uint8_t>& block, ULONG size, bool isCompressed);
         void CloseFile();
@@ -30,6 +31,7 @@ namespace MSIX {
 
     private:
         MSIX::SHA256 m_fileHashEngine;
+        bool m_enableFileHash = false;
         bool m_addFileHash = false;
     };
 }

--- a/src/inc/internal/AppxFactory.hpp
+++ b/src/inc/internal/AppxFactory.hpp
@@ -42,8 +42,9 @@ namespace MSIX {
     class AppxFactory final : public ComClass<AppxFactory, IMsixFactory, IAppxFactory, IXmlFactory, IAppxBundleFactory, IMsixFactoryOverrides, IAppxFactoryUtf8>
     {
     public:
-        AppxFactory(MSIX_VALIDATION_OPTION validationOptions, MSIX_APPLICABILITY_OPTIONS applicability, COTASKMEMALLOC* memalloc, COTASKMEMFREE* memfree ) : 
-            m_validationOptions(validationOptions), m_applicabilityFlags(applicability), m_memalloc(memalloc), m_memfree(memfree)
+        AppxFactory(MSIX_VALIDATION_OPTION validationOptions, MSIX_APPLICABILITY_OPTIONS applicability, MSIX_FACTORY_OPTIONS factoryOptions, 
+            COTASKMEMALLOC* memalloc, COTASKMEMFREE* memfree ) :
+            m_validationOptions(validationOptions), m_applicabilityFlags(applicability), m_factoryOptions(factoryOptions), m_memalloc(memalloc), m_memfree(memfree)
         {
             ThrowErrorIf(Error::InvalidParameter, (m_memalloc == nullptr || m_memfree == nullptr), "allocator/deallocator pair not specified.")
             ComPtr<IMsixFactory> self;
@@ -90,6 +91,7 @@ namespace MSIX {
         COTASKMEMALLOC* m_memalloc;
         COTASKMEMFREE*  m_memfree;
         MSIX_VALIDATION_OPTION m_validationOptions;
+        MSIX_FACTORY_OPTIONS m_factoryOptions;
         ComPtr<IStorageObject> m_resourcezip;
         std::vector<std::uint8_t> m_resourcesVector;
         MSIX_APPLICABILITY_OPTIONS m_applicabilityFlags;

--- a/src/inc/internal/AppxPackageWriter.hpp
+++ b/src/inc/internal/AppxPackageWriter.hpp
@@ -36,7 +36,7 @@ namespace MSIX {
         IAppxPackageWriterUtf8, IAppxPackageWriter3, IAppxPackageWriter3Utf8>
     {
     public:
-        AppxPackageWriter(IMsixFactory* factory, const ComPtr<IZipWriter>& zip);
+        AppxPackageWriter(IMsixFactory* factory, const ComPtr<IZipWriter>& zip, bool enableFileHash);
         ~AppxPackageWriter() {};
 
         // IPackageWriter

--- a/src/inc/public/AppxPackaging.hpp
+++ b/src/inc/public/AppxPackaging.hpp
@@ -1199,6 +1199,7 @@ interface IMsixElementEnumerator;
 interface IMsixFactoryOverrides;
 interface IMsixStreamFactory;
 interface IMsixApplicabilityLanguagesEnumerator;
+interface IMsixPackageWriterFactory;
 
 #ifndef __IMsixDocumentElement_INTERFACE_DEFINED__
 #define __IMsixDocumentElement_INTERFACE_DEFINED__
@@ -1705,6 +1706,13 @@ enum MSIX_BUNDLE_OPTIONS
         MSIX_BUNDLE_OPTION_BUNDLEMANIFESTONLY = 0x20,
     }   MSIX_BUNDLE_OPTIONS;
 
+typedef /* [v1_enum] */
+enum MSIX_FACTORY_OPTIONS
+{
+    MSIX_FACTORY_OPTION_NONE = 0x0,
+    MSIX_FACTORY_OPTION_WRITER_ENABLE_FILE_HASH = 0x1,  // The package writer will compute full file hash and add <FileHash> element in block map xml
+}   MSIX_FACTORY_OPTIONS;
+
 #define MSIX_PLATFORM_ALL MSIX_PLATFORM_WINDOWS10      | \
                           MSIX_PLATFORM_WINDOWS10      | \
                           MSIX_PLATFORM_WINDOWS8       | \
@@ -1803,10 +1811,22 @@ MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxFactory(
     MSIX_VALIDATION_OPTION validationOption,
     IAppxFactory** appxFactory) noexcept;
 
+MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxFactoryWithOptions(
+    MSIX_VALIDATION_OPTION validationOption,
+    MSIX_FACTORY_OPTIONS factoryOptions,
+    IAppxFactory** appxFactory) noexcept;
+
 MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxFactoryWithHeap(
     COTASKMEMALLOC* memalloc,
     COTASKMEMFREE* memfree,
     MSIX_VALIDATION_OPTION validationOption,
+    IAppxFactory** appxFactory) noexcept;
+
+MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxFactoryWithHeapAndOptions(
+    COTASKMEMALLOC* memalloc,
+    COTASKMEMFREE* memfree,
+    MSIX_VALIDATION_OPTION validationOption,
+    MSIX_FACTORY_OPTIONS factoryOptions,
     IAppxFactory** appxFactory) noexcept;
 
 MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxBundleFactory(

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -26,6 +26,8 @@ endif()
 list(APPEND MSIX_EXPORTS
     "CoCreateAppxFactory"
     "CoCreateAppxFactoryWithHeap"
+    "CoCreateAppxFactoryWithOptions"
+    "CoCreateAppxFactoryWithHeapAndOptions"
     "CreateStreamOnFile"
     "CreateStreamOnFileUTF16"
     "MsixGetLogTextUTF8"

--- a/src/msix/common/AppxFactory.cpp
+++ b/src/msix/common/AppxFactory.cpp
@@ -33,7 +33,8 @@ namespace MSIX {
         ComPtr<IMsixFactory> self;
         ThrowHrIfFailed(QueryInterface(UuidOfImpl<IMsixFactory>::iid, reinterpret_cast<void**>(&self)));
         auto zip = ComPtr<IZipWriter>::Make<ZipObjectWriter>(outputStream);
-        auto result = ComPtr<IAppxPackageWriter>::Make<AppxPackageWriter>(self.Get(), zip);
+        bool enableFileHash = m_factoryOptions & MSIX_FACTORY_OPTION_WRITER_ENABLE_FILE_HASH;
+        auto result = ComPtr<IAppxPackageWriter>::Make<AppxPackageWriter>(self.Get(), zip, enableFileHash);
         *packageWriter = result.Detach();
         #endif
         return static_cast<HRESULT>(Error::OK);

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -23,8 +23,12 @@
 
 namespace MSIX {
 
-    AppxPackageWriter::AppxPackageWriter(IMsixFactory* factory, const ComPtr<IZipWriter>& zip) : m_factory(factory), m_zipWriter(zip)
+    AppxPackageWriter::AppxPackageWriter(IMsixFactory* factory, const ComPtr<IZipWriter>& zip, bool enableFileHash) : m_factory(factory), m_zipWriter(zip)
     {
+        if (enableFileHash)
+        {
+            m_blockMapWriter.EnableFileHash();
+        }
         m_state = WriterState::Open;
     }
 

--- a/src/test/msixtest/api_packagewriter.cpp
+++ b/src/test/msixtest/api_packagewriter.cpp
@@ -35,7 +35,7 @@ void InitializePackageWriter(IStream* outputStream, IAppxPackageWriter** package
     return;
 }
 
-void TestAppxPackageWriter_good(PCSTR outputFileName, bool enableFileHash)
+void TestAppxPackageWriter_good(LPCSTR outputFileName, bool enableFileHash)
 {
     auto outputStream = MsixTest::StreamFile(outputFileName, false, true);
 

--- a/src/test/msixtest/api_packagewriter.cpp
+++ b/src/test/msixtest/api_packagewriter.cpp
@@ -16,15 +16,62 @@ using namespace MsixTest::Pack;
 
 constexpr std::uint32_t DefaultBlockSize = 65536;
 
-void InitializePackageWriter(IStream* outputStream, IAppxPackageWriter** packageWriter)
+void InitializePackageWriter(IStream* outputStream, IAppxPackageWriter** packageWriter, bool enableFileHash = false)
 {
     *packageWriter = nullptr;
 
     MsixTest::ComPtr<IAppxFactory> appxFactory;
-    REQUIRE_SUCCEEDED(CoCreateAppxFactoryWithHeap(MsixTest::Allocators::Allocate, MsixTest::Allocators::Free,
-        MSIX_VALIDATION_OPTION_SKIPSIGNATURE, &appxFactory));
+    if (enableFileHash)
+    {
+        REQUIRE_SUCCEEDED(CoCreateAppxFactoryWithHeapAndOptions(MsixTest::Allocators::Allocate, MsixTest::Allocators::Free,
+            MSIX_VALIDATION_OPTION_SKIPSIGNATURE, MSIX_FACTORY_OPTION_WRITER_ENABLE_FILE_HASH, &appxFactory));
+    }
+    else
+    {
+        REQUIRE_SUCCEEDED(CoCreateAppxFactoryWithHeap(MsixTest::Allocators::Allocate, MsixTest::Allocators::Free,
+            MSIX_VALIDATION_OPTION_SKIPSIGNATURE, &appxFactory));
+    }
     REQUIRE_SUCCEEDED(appxFactory->CreatePackageWriter(outputStream, nullptr, packageWriter));
     return;
+}
+
+void TestAppxPackageWriter_good(PCSTR outputFileName, bool enableFileHash)
+{
+    auto outputStream = MsixTest::StreamFile(outputFileName, false, true);
+
+    MsixTest::ComPtr<IAppxPackageWriter> packageWriter;
+    InitializePackageWriter(outputStream.Get(), &packageWriter, enableFileHash);
+
+    // These values are set so that the files added to the package have increasingly
+    // larger sizes, with the first file having a small size < DefaultBlockSize, and
+    // the last file having a large size > 10x DefaultBlockSize.
+    const std::uint32_t contentSizeIncrement = DefaultBlockSize * 10 / static_cast<uint32_t>(TestConstants::GoodFileNames.size()) + 1;
+    std::uint32_t contentSize = 10;
+
+    for (const auto& fileName : TestConstants::GoodFileNames)
+    {
+        // Create file and write random data to it
+        auto fileStream = MsixTest::StreamFile(fileName.first, false, true);
+        WriteContentToStream(contentSize, fileStream.Get());
+        REQUIRE_SUCCEEDED(packageWriter->AddPayloadFile(
+            fileName.second.c_str(),
+            TestConstants::ContentType.c_str(),
+            APPX_COMPRESSION_OPTION_NORMAL,
+            fileStream.Get()));
+        contentSize += contentSizeIncrement;
+    }
+
+    // Finalize package, create manifest stream
+    MsixTest::ComPtr<IStream> manifestStream;
+    MakeManifestStream(&manifestStream);
+    REQUIRE_SUCCEEDED(packageWriter->Close(manifestStream.Get()));
+
+    // Reopen the package, validates that the written package is readable
+    // return to the beginning
+    LARGE_INTEGER zero = { 0 };
+    REQUIRE_SUCCEEDED(outputStream.Get()->Seek(zero, STREAM_SEEK_SET, nullptr));
+    MsixTest::ComPtr<IAppxPackageReader> packageReader;
+    MsixTest::InitializePackageReader(outputStream.Get(), &packageReader);
 }
 
 // Test creating instances of package writer
@@ -50,41 +97,13 @@ TEST_CASE("Api_AppxPackageWriter_create", "[api]")
 // Test creating a valid msix package via IAppxPackageWriter with different file sizes
 TEST_CASE("Api_AppxPackageWriter_good", "[api]")
 {
-    auto outputStream = MsixTest::StreamFile("test_package.msix", false, true);
+    TestAppxPackageWriter_good("test_package.msix", false /* enableFileHash */);
+}
 
-    MsixTest::ComPtr<IAppxPackageWriter> packageWriter;
-    InitializePackageWriter(outputStream.Get(), &packageWriter);
-
-    // These values are set so that the files added to the package have increasingly
-    // larger sizes, with the first file having a small size < DefaultBlockSize, and
-    // the last file having a large size > 10x DefaultBlockSize.
-    const std::uint32_t contentSizeIncrement = DefaultBlockSize * 10 / static_cast<uint32_t>(TestConstants::GoodFileNames.size()) + 1;
-    std::uint32_t contentSize = 10;
-
-    for(const auto& fileName : TestConstants::GoodFileNames)
-    {
-        // Create file and write random data to it
-        auto fileStream = MsixTest::StreamFile(fileName.first, false, true);
-        WriteContentToStream(contentSize, fileStream.Get());
-        REQUIRE_SUCCEEDED(packageWriter->AddPayloadFile(
-            fileName.second.c_str(),
-            TestConstants::ContentType.c_str(),
-            APPX_COMPRESSION_OPTION_NORMAL,
-            fileStream.Get()));
-        contentSize += contentSizeIncrement;
-    }
-
-    // Finalize package, create manifest stream
-    MsixTest::ComPtr<IStream> manifestStream;
-    MakeManifestStream(&manifestStream);
-    REQUIRE_SUCCEEDED(packageWriter->Close(manifestStream.Get()));
-
-    // Reopen the package, validates that the written package is readable
-    // return to the beginning
-    LARGE_INTEGER zero = { 0 };
-    REQUIRE_SUCCEEDED(outputStream.Get()->Seek(zero, STREAM_SEEK_SET, nullptr));
-    MsixTest::ComPtr<IAppxPackageReader> packageReader;
-    MsixTest::InitializePackageReader(outputStream.Get(), &packageReader);
+// Test creating a valid msix package with file hash enabled in block map via IAppxPackageWriter with different file sizes
+TEST_CASE("Api_AppxPackageWriter_FileHashEnabled_good", "[api]")
+{
+    TestAppxPackageWriter_good("test_package_with_filehash.msix", true /* enableFileHash */);
 }
 
 // Test creating a valid msix package via IAppxPackageWriter.

--- a/src/test/msixtest/testData/PackTestData.cpp
+++ b/src/test/msixtest/testData/PackTestData.cpp
@@ -82,7 +82,7 @@ namespace MsixTest { namespace Pack {
     {
         static const std::map<std::string, std::uint64_t> files = 
         {
-            { "AppxBlockMap.xml", 2021 },
+            { "AppxBlockMap.xml", 1871 },
             { "AppxManifest.xml", 3203 }, // This file is marked as LF for git. If you see size = 3251, then it changed to CRLF.
             { "resources.pri", 3760 },
             { "TestAppxPackage.exe", 186368 },


### PR DESCRIPTION
Since the open source MSIX SDK used to validate schema of the block map xml, the last change to add <FileHash> to the block map xml will break older version of the MSIX SDK if the users haven't updated to the latest version. In order not to break those older MSIX SDKs and give users options to transition to the latest SDK, this change will add an option to IAppxFactory creation to enable file hash for the package writer and by default NOT creating <FileHash> to be aligned with old behavior. To enable file hash in block map, the code should call a new method CoCreateAppxFactoryWithHeapAndOptions, which passes in a new MSIX_FACTORY_OPTIONS flag MSIX_FACTORY_OPTION_WRITER_ENABLE_FILE_HASH to create an IAppxFactory object. From it, the created package writer will use the new block map xml schema to create <FileHash> in the block map.

```
        REQUIRE_SUCCEEDED(CoCreateAppxFactoryWithHeapAndOptions(MsixTest::Allocators::Allocate, MsixTest::Allocators::Free,
            MSIX_VALIDATION_OPTION_SKIPSIGNATURE, MSIX_FACTORY_OPTION_WRITER_ENABLE_FILE_HASH, &appxFactory));

```
Also added test (Api_AppxPackageWriter_FileHashEnabled_good) to call the new API and verified the created package can be opened by the reader API.