### PR TITLE
Adding property on bundle object containing metadata about child packages

### DIFF
--- a/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
@@ -137,10 +137,11 @@ namespace Microsoft.Msix.Utils.AppxPackaging
                 else
                 {
                     var childPackageMetadata = new ChildPackageMetadata(
+                        this,
+                        subPackageId.GetPackageFullName(),
                         filePath,
                         subPackageInfo.GetPackageType(),
                         subPackageInfo.GetSize(),
-                        subPackageId.GetPackageFullName(),
                         subPackageId.GetVersion(),
                         subPackageId.GetResourceId());
 

--- a/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/AppxBundleMetadata.cs
@@ -57,7 +57,13 @@ namespace Microsoft.Msix.Utils.AppxPackaging
         /// <summary>
         /// Gets the list of all the internal msix packages bundled in this bundle
         /// </summary>
+        [Obsolete]
         public IList<string> InternalAppxPackagesRelativePaths { get; private set; } = new List<string>();
+
+        /// <summary>
+        /// Gets the list of all the internal msix packages bundled in this bundle
+        /// </summary>
+        public IList<ChildPackageMetadata> ChildAppxPackages { get; private set; } = new List<ChildPackageMetadata>();
 
         /// <summary>
         /// Gets the list of all the physical optional msix packages referenced by this bundle, which don't belong to
@@ -114,6 +120,8 @@ namespace Microsoft.Msix.Utils.AppxPackaging
             while (subPackagesEnumerator.GetHasCurrent())
             {
                 IAppxBundleManifestPackageInfo subPackageInfo = subPackagesEnumerator.GetCurrent();
+                IAppxManifestPackageId subPackageId = subPackageInfo.GetPackageId();
+                string filePath = subPackageInfo.GetFileName();
 
                 // If the package is not contained within the bundle, the corresponding package element in the bundle manifest
                 // would not have an offset field. In such a case and only in that case, the AppxPackaging APIs would return 0
@@ -122,13 +130,25 @@ namespace Microsoft.Msix.Utils.AppxPackaging
                 {
                     this.ExternalAppxPackages.Add(new ExternalPackageReference(
                         this,
-                        subPackageInfo.GetPackageId().GetPackageFullName(),
-                        subPackageInfo.GetFileName(),
+                        subPackageId.GetPackageFullName(),
+                        filePath,
                         isOptional: false));
                 }
                 else
                 {
-                    this.InternalAppxPackagesRelativePaths.Add(subPackageInfo.GetFileName());
+                    var childPackageMetadata = new ChildPackageMetadata(
+                        filePath,
+                        subPackageInfo.GetPackageType(),
+                        subPackageInfo.GetSize(),
+                        subPackageId.GetPackageFullName(),
+                        subPackageId.GetVersion(),
+                        subPackageId.GetResourceId());
+
+                    this.ChildAppxPackages.Add(childPackageMetadata);
+
+#pragma warning disable CS0612 // Type or member is obsolete
+                    this.InternalAppxPackagesRelativePaths.Add(filePath);
+#pragma warning restore CS0612 // Type or member is obsolete
                 }
 
                 subPackagesEnumerator.MoveNext();

--- a/tools/utils/Utils/AppxPackaging/AppxMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/AppxMetadata.cs
@@ -97,12 +97,10 @@ namespace Microsoft.Msix.Utils.AppxPackaging
             this.Version = new VersionInfo(packageId.GetVersion());
 
             IAppxManifestProperties packageProperties = appxManifestReader.GetProperties();
-            string displayName;
-            packageProperties.GetStringValue("DisplayName", out displayName);
+            packageProperties.GetStringValue("DisplayName", out string displayName);
             this.DisplayName = displayName;
 
-            string publisherDisplayName;
-            packageProperties.GetStringValue("PublisherDisplayName", out publisherDisplayName);
+            packageProperties.GetStringValue("PublisherDisplayName", out string publisherDisplayName);
             this.PublisherDisplayName = publisherDisplayName;
 
             // Get the min versions

--- a/tools/utils/Utils/AppxPackaging/ChildPackageMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/ChildPackageMetadata.cs
@@ -26,21 +26,27 @@ namespace Microsoft.Msix.Utils.AppxPackaging
     /// </summary>
     public class ChildPackageMetadata
     {
-        public ChildPackageMetadata(string filePath, APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE packageType, ulong packageSize, string packageFullName, ulong packageVersion, string packageResourceId)
+        public ChildPackageMetadata(AppxBundleMetadata parentBundle, string packageFullName, string relativePath, APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE packageType, ulong packageSize, ulong packageVersion, string packageResourceId)
         {
-            this.FilePath = filePath;
+            this.ParentBundle = parentBundle;
+            this.RelativeFilePath = relativePath;
             this.PackageType = (PackageType)packageType;
-            this.PackageSize = packageSize;
+            this.Size = packageSize;
             this.PackageFullName = packageFullName;
-            this.PackageArchitecture = PackagingUtils.GetPackageArchitectureFromFullName(packageFullName);
-            this.PackageVersion = new VersionInfo(packageVersion);
-            this.PackageResourceId = packageResourceId;
+            this.Architecture = PackagingUtils.GetPackageArchitectureFromFullName(packageFullName);
+            this.Version = new VersionInfo(packageVersion);
+            this.ResourceId = packageResourceId;
         }
 
         /// <summary>
-        /// Gets the path the package.
+        /// Gets the information of the parent bundle which contains this reference
         /// </summary>
-        public string FilePath { get; }
+        public AppxBundleMetadata ParentBundle { get; private set; }
+
+        /// <summary>
+        /// Gets the relative path the package.
+        /// </summary>
+        public string RelativeFilePath { get; }
 
         /// <summary>
         /// Gets the package type.
@@ -50,12 +56,12 @@ namespace Microsoft.Msix.Utils.AppxPackaging
         /// <summary>
         /// Gets the package architecure.
         /// </summary>
-        public string PackageArchitecture { get; }
+        public string Architecture { get; }
 
         /// <summary>
         /// Gets the package size in bytes.
         /// </summary>
-        public ulong PackageSize { get; }
+        public ulong Size { get; }
 
         /// <summary>
         /// Gets the package full name.
@@ -65,11 +71,11 @@ namespace Microsoft.Msix.Utils.AppxPackaging
         /// <summary>
         /// Gets the package version.
         /// </summary>
-        public VersionInfo PackageVersion { get; }
+        public VersionInfo Version { get; }
 
         /// <summary>
         /// Gets the package ResourceId, if any.
         /// </summary>
-        public string PackageResourceId { get; }
+        public string ResourceId { get; }
     }
 }

--- a/tools/utils/Utils/AppxPackaging/ChildPackageMetadata.cs
+++ b/tools/utils/Utils/AppxPackaging/ChildPackageMetadata.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Msix.Utils.AppxPackaging
+{
+    using Microsoft.Msix.Utils.AppxPackagingInterop;
+
+    /// <summary>
+    /// The type of the package in a bundle.
+    /// </summary>
+    public enum PackageType
+    {
+        /// <summary>
+        /// A package containing executable code.
+        /// </summary>
+        Application = 0,
+
+        /// <summary>
+        /// A resource package.
+        /// </summary>
+        Resource = 1,
+    }
+
+    /// <summary>
+    /// Class that represents the information of a bundled child package.
+    /// </summary>
+    public class ChildPackageMetadata
+    {
+        public ChildPackageMetadata(string filePath, APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE packageType, ulong packageSize, string packageFullName, ulong packageVersion, string packageResourceId)
+        {
+            this.FilePath = filePath;
+            this.PackageType = (PackageType)packageType;
+            this.PackageSize = packageSize;
+            this.PackageFullName = packageFullName;
+            this.PackageArchitecture = PackagingUtils.GetPackageArchitectureFromFullName(packageFullName);
+            this.PackageVersion = new VersionInfo(packageVersion);
+            this.PackageResourceId = packageResourceId;
+        }
+
+        /// <summary>
+        /// Gets the path the package.
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Gets the package type.
+        /// </summary>
+        public PackageType PackageType { get; }
+
+        /// <summary>
+        /// Gets the package architecure.
+        /// </summary>
+        public string PackageArchitecture { get; }
+
+        /// <summary>
+        /// Gets the package size in bytes.
+        /// </summary>
+        public ulong PackageSize { get; }
+
+        /// <summary>
+        /// Gets the package full name.
+        /// </summary>
+        public string PackageFullName { get; }
+
+        /// <summary>
+        /// Gets the package version.
+        /// </summary>
+        public VersionInfo PackageVersion { get; }
+
+        /// <summary>
+        /// Gets the package ResourceId, if any.
+        /// </summary>
+        public string PackageResourceId { get; }
+    }
+}


### PR DESCRIPTION
Adds new property on `AppxBundleMetadata: ChildAppxPackages`. This replaces the now `[Obsolete]` InternalAppxPackagesRelativePaths, as it has the file paths but also the metadata unique to each child package.