### PR TITLE
Invalid Memory Access in SignatureValidator (#453)

### DIFF
--- a/src/msix/PAL/Signature/OpenSSL/SignatureValidator.cpp
+++ b/src/msix/PAL/Signature/OpenSSL/SignatureValidator.cpp
@@ -130,11 +130,12 @@ namespace MSIX
                         {
                             M_ASN1_OCTET_STRING_print(extbio.get(), ext->value);
                         }
+
                         BUF_MEM *bptr = nullptr;
                         BIO_get_mem_ptr(extbio.get(), &bptr);
-                        
+
                         if (bptr && bptr->data && 
-                            std::string((char*)bptr->data).find(OID::WindowsStore()) != std::string::npos)
+                            std::string((char*)bptr->data, bptr->length).find(OID::WindowsStore()) != std::string::npos)
                         {
                             return true;
                         }


### PR DESCRIPTION
* Invalid Memory Access in SignatureValidator

Problem:
* SignatureValidator::IsStoreOrigin() tries to read X.509 extensions
to determine if the origin of the signature matches the Windows Store OID.
* Extension data is converted from a raw buffer to an std::string for
comparision.
* The raw buffer is not null-terminated, and therefore, running
std::strlen() on it causes invalid memory access.
* This invalid access is caught by ASAN on macOS.

Solution:
* Null-terminate the raw buffer before trying to build an std::string
from it.

Tests:
* Ran app test suite that uses libmsix.dylib with ASAN on. No crashes
were reported.

* Invalid Memory Access in SignatureValidator

Problem:
* As @JohnMcPMS pointed out, writing "" with 1 byte size is null termination.
* A better solution would be to use bptr->length and avoid writing the null
byte altogether.

Tests:
* Ran app test suite that uses libmsix.dylib with ASAN on. No crashes
were reported.

Co-authored-by: Sayan Chaliha <sachalih@microsoft.com>