### PR TITLE
Handle long file paths during CIM creation

### DIFF
--- a/MsixCore/msixmgr/msixmgr.cpp
+++ b/MsixCore/msixmgr/msixmgr.cpp
@@ -334,10 +334,11 @@ int main(int argc, char * argv[])
                 }
 
                 // Create a temporary directory to unpack package(s) since we cannot unpack to the CIM directly.
+                // Append long path prefix to temporary directory path to handle paths that exceed the maximum path length limit
                 std::wstring currentDirectory = std::filesystem::current_path();
                 std::wstring uniqueIdString;
                 RETURN_IF_FAILED(CreateGUIDString(&uniqueIdString));
-                std::wstring tempDirPathString = currentDirectory + L"\\" + uniqueIdString;
+                std::wstring tempDirPathString = L"\\\\?\\" + currentDirectory + L"\\" + uniqueIdString;
                 std::filesystem::path tempDirPath(tempDirPathString);
 
                 std::error_code createDirectoryErrorCode;


### PR DESCRIPTION
**Problem**
During the CIM creation process, the given package or directory first gets unpacked to a temporary directory under the working directory. Some files within these packages end up having absolute file paths whose lengths exceed the maximum path length. This causes problems down the road for components that call APIs that take these paths as a parameter but are unable to handle them.

**Fix:**
When creating the temporary directory, use a path name with the long path prefix appended.

**Validated**

- Confirmed that the CIM creation failure no longer repros after the change is applied.
- Executed automated tests to confirm no regressions were caused.
- Stefan independently validated the fix as well. 
 