### PR TITLE
Msix.Utils - Make reading of bundle optional packages happen only when needed

### DIFF
--- a/tools/utils/UtilsTests/ProcessRunnerTests/ProcessRunnerTests.cs
+++ b/tools/utils/UtilsTests/ProcessRunnerTests/ProcessRunnerTests.cs
@@ -155,7 +155,7 @@ namespace UtilsTests
                 thread.Start();
 
                 // Give some time for the process to start and validate output
-                Thread.Sleep(2000);
+                Thread.Sleep(4000);
                 string stdOut = string.Join(string.Empty, processRunner.StandardOutput);
                 Assert.IsTrue(stdOut.Contains("Process Starting"), "Verifying process start message");
 
@@ -227,7 +227,7 @@ namespace UtilsTests
                 thread.Start();
 
                 // Give some time for the process to start and validate output
-                Thread.Sleep(2000);
+                Thread.Sleep(4000);
                 string stdOut = string.Join(string.Empty, processRunner.StandardOutput);
                 Assert.IsTrue(stdOut.Contains("Process Starting"), "Verifying process start message");
 


### PR DESCRIPTION
When reading the metadata from a bundle we would also read its references to optional packages. The API for this was added in version 1703, so creating the metadata object would fail older OS versions.
Changed to populate this information only when it is requested. Accessing to these properties on older OS versions would still fail, but construction and the remaining properties work.