### PR TITLE
Use MS-DOS time in LFH and CDH

### DIFF
--- a/src/inc/shared/TimeHelpers.hpp
+++ b/src/inc/shared/TimeHelpers.hpp
@@ -1,0 +1,28 @@
+//
+//  Copyright (C) 2021 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+// 
+#pragma once
+
+#include <cstdint>
+#include <ctime>
+
+namespace MSIX {
+
+    // The date and time stored in zip headers is in standard MS-DOS format.
+    // This class converts from local system time to MS-DOS date/time format.
+    struct MsDosDateAndTime
+    {
+        MsDosDateAndTime();
+        MsDosDateAndTime(const std::tm* time);
+
+        std::uint16_t GetDosTime() { return m_dosTime; }
+        std::uint16_t GetDosDate() { return m_dosDate; }
+
+    private:
+        std::uint16_t m_dosTime;
+        std::uint16_t m_dosDate;
+
+        void Initialize(const std::tm* time);
+    };
+}

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -111,6 +111,7 @@ list(APPEND MsixSrc
     common/FileNameValidation.cpp
     common/AppxManifestValidation.cpp
     common/IXml.cpp
+    common/TimeHelpers.cpp
 )
 
 # Unpack. Always add

--- a/src/msix/common/TimeHelpers.cpp
+++ b/src/msix/common/TimeHelpers.cpp
@@ -1,0 +1,88 @@
+//
+//  Copyright (C) 2021 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+//
+
+#include "TimeHelpers.hpp"
+
+#include <chrono>
+
+namespace MSIX {
+
+    MsDosDateAndTime::MsDosDateAndTime()
+    {
+        // Convert system time to local time so the zip file item can have the same time of the zip archive when
+        // it is shown in zip utility tools.
+        const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+        const auto localTime = std::localtime(&now);
+        Initialize(localTime);
+    }
+
+    MsDosDateAndTime::MsDosDateAndTime(const std::tm* time)
+    {
+        Initialize(time);
+    }
+
+    void MsDosDateAndTime::Initialize(const std::tm* time)
+    {
+            // tm struct tm_year is the years since 1900, so we add them back to validate.
+        auto year = time->tm_year + 1900;
+
+        // The MS-DOS date format can represent only dates between 1/1/1980 and 12/31/2107;
+        if (year < 1980 || year > 2107)
+        {
+            // We default the time to 12/31/2107, 23:59:58.
+            // Note that MS-DOS time format cannot represent odd seconds. So the nearest time
+            // to 23:59:59 that can be represented in MS-DOS time is 23:59:58.
+            m_dosTime = 0xBF7D;
+            m_dosDate = 0xFF9F;
+        }
+        else
+        {
+            // Windows implementation uses TIME_FIELDS struct to calculate the MS-DOS time.
+            // There are some differences between it and tm.
+            //  | Unit  | TIME_FILES | tm
+            //  |-------|------------|----
+            //  | year  | since 1601 | since 1900
+            //  | month | 1-12       | 0-11
+            //  | day   | 1-31       | 1-31
+            //  | hour  | 0-23       | 0-23
+            //  | min   | 0-59       | 0-59
+            //  | sec   | 0-59       | 0-60 (Range allows for a positive leap second.)
+
+            std::uint16_t toConvertYear = static_cast<std::uint16_t>(year - 1980);
+            std::uint16_t toConvertMonth = static_cast<std::uint16_t>(time->tm_mon + 1);
+            std::uint16_t toConvertDay = static_cast<std::uint16_t>(time->tm_mday);
+            std::uint16_t toConvertHour = static_cast<std::uint16_t>(time->tm_hour);
+            std::uint16_t toConvertMinute = static_cast<std::uint16_t>(time->tm_min);
+            std::uint16_t toConvertSecond = static_cast<std::uint16_t>(time->tm_sec);
+
+            // Ignore leap second.
+            if (toConvertSecond == 60)
+            {
+                toConvertSecond--;
+            }
+
+            // MS-DOS date is a packed value with the following format.
+            //  | Bits | Description
+            //  |------|------------|----
+            //  | 0–4  | Day of the month (1–31)
+            //  | 5–8  | Month (1 = January, 2 = February, etc.)
+            //  | 9-15 | Year offset from 1980 (add 1980 to get actual year)
+            m_dosDate = (toConvertYear << 9) |
+                        (toConvertMonth << 5) |
+                        toConvertDay;
+
+            // MS-DOS time is a packed value with the following format.
+            //  | Bits  | Description
+            //  |-------|------------|----
+            //  | 0–4   | Second divided by 2
+            //  | 5–10  | Minute (0–59)
+            //  | 11-15 | Hour (0–23 on a 24-hour clock)
+            m_dosTime = (toConvertHour << 11) |
+                        (toConvertMinute << 5) |
+                        toConvertSecond / 2;
+        }
+    }
+
+} // namespace MSIX

--- a/src/msix/common/ZipObject.cpp
+++ b/src/msix/common/ZipObject.cpp
@@ -15,6 +15,8 @@
 #include <limits>
 #include <functional>
 #include <algorithm>
+#include <chrono>
+
 namespace MSIX {
 /* Zip File Structure
 [LocalFileHeader 1]
@@ -61,13 +63,88 @@ enum class HeaderIDs : std::uint16_t
     RESERVED_3        = 0x4690, // POSZIP 4690 (reserved) 
 };
 
-// Hat tip to the people at Facebook.  Timestamp for files in ZIP archive 
-// format held constant to make pack/unpack deterministic
-enum class MagicNumbers : std::uint16_t
+namespace
 {
-    FileTime = 0x6B60,  // kudos to those know this
-    FileDate = 0xA2B1,  // :)
-};
+    // The date and time stored in zip headers is in standard MS-DOS format.
+    // This class converts from local system time to MS-DOS date/time format.
+    struct MsDosDateAndTime
+    {
+        MsDosDateAndTime()
+        {
+            // Convert system time to local time so the zip file item can have the same time of the zip archive when
+            // it is shown in zip utility tools.
+            const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            const auto localTime = std::localtime(&now);
+
+            // tm struct tm_year is the years since 1900, so we add them back to validate.
+            auto year = localTime->tm_year + 1900;
+
+            // The MS-DOS date format can represent only dates between 1/1/1980 and 12/31/2107;
+            if (year < 1980 || year > 2107)
+            {
+                // We default the time to 12/31/2107, 23:59:58.
+                // Note that MS-DOS time format cannot represent odd seconds. So the nearest time
+                // to 23:59:59 that can be represented in MS-DOS time is 23:59:58.
+                m_dosTime = 0xBF7D;
+                m_dosDate = 0xFF9F;
+            }
+            else
+            {
+                // Windows implementation uses TIME_FIELDS struct to calculate the MS-DOS time.
+                // There are some differences between it and tm.
+                //  | Unit  | TIME_FILES | tm
+                //  |-------|------------|----
+                //  | year  | since 1601 | since 1900
+                //  | month | 1-12       | 0-11
+                //  | day   | 1-31       | 1-31
+                //  | hour  | 0-23       | 0-23
+                //  | min   | 0-59       | 0-59
+                //  | sec   | 0-59       | 0-60 (Range allows for a positive leap second.)
+
+                std::uint16_t toConvertYear = static_cast<std::uint16_t>(year - 1980);
+                std::uint16_t toConvertMonth = static_cast<std::uint16_t>(localTime->tm_mon + 1);
+                std::uint16_t toConvertDay = static_cast<std::uint16_t>(localTime->tm_mday);
+                std::uint16_t toConvertHour = static_cast<std::uint16_t>(localTime->tm_hour);
+                std::uint16_t toConvertMinute = static_cast<std::uint16_t>(localTime->tm_min);
+                std::uint16_t toConvertSecond = static_cast<std::uint16_t>(localTime->tm_sec);
+
+                // Ignore leap second.
+                if (toConvertSecond == 60)
+                {
+                    toConvertSecond--;
+                }
+
+                // MS-DOS date is a packed value with the following format.
+                //  | Bits | Description
+                //  |------|------------|----
+                //  | 0–4  | Day of the month (1–31)
+                //  | 5–8  | Month (1 = January, 2 = February, etc.)
+                //  | 9-15 | Year offset from 1980 (add 1980 to get actual year)
+                m_dosDate = (toConvertYear << 9) |
+                            (toConvertMonth << 5) |
+                             toConvertDay;
+
+                // MS-DOS time is a packed value with the following format.
+                //  | Bits  | Description
+                //  |-------|------------|----
+                //  | 0–4   | Second divided by 2
+                //  | 5–10  | Minute (0–59)
+                //  | 11-15 | Hour (0–23 on a 24-hour clock)
+                m_dosTime = (toConvertHour << 11) |
+                            (toConvertMinute << 5) |
+                             toConvertSecond >> 1;
+            }
+        }
+
+        std::uint16_t GetDosTime() { return m_dosTime; }
+        std::uint16_t GetDosDate() { return m_dosDate; }
+
+    private:
+        std::uint16_t m_dosTime;
+        std::uint16_t m_dosDate;
+    };
+}
+
 
 // if any of these are set, then fail.
 constexpr static const GeneralPurposeBitFlags UnsupportedFlagsMask =
@@ -136,8 +213,11 @@ CentralDirectoryFileHeader::CentralDirectoryFileHeader()
     SetVersionMadeBy(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension));
     SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip32DefaultVersion));
     SetGeneralPurposeBitFlags(0);
-    SetLastModFileDate(static_cast<std::uint16_t>(MagicNumbers::FileDate)); // TODO: figure out how to convert to msdos time
-    SetLastModFileTime(static_cast<std::uint16_t>(MagicNumbers::FileTime));
+
+    auto msDosDateAndTime = new MsDosDateAndTime();
+    SetLastModFileDate(msDosDateAndTime->GetDosDate());
+    SetLastModFileTime(msDosDateAndTime->GetDosTime());
+
     SetCompressedSize(0);
     SetUncompressedSize(0);
     SetExtraFieldLength(0);
@@ -251,8 +331,11 @@ LocalFileHeader::LocalFileHeader()
     SetSignature(static_cast<std::uint32_t>(Signatures::LocalFileHeader));
     SetVersionNeededToExtract(static_cast<std::uint16_t>(ZipVersions::Zip64FormatExtension)); // deafult to zip64
     SetGeneralPurposeBitFlags(static_cast<std::uint16_t>(GeneralPurposeBitFlags::DataDescriptor));
-    SetLastModFileTime(static_cast<std::uint16_t>(MagicNumbers::FileTime)); // TODO: figure out how to convert to msdos time
-    SetLastModFileDate(static_cast<std::uint16_t>(MagicNumbers::FileDate));
+
+    auto msDosDateAndTime = new MsDosDateAndTime();
+    SetLastModFileDate(msDosDateAndTime->GetDosDate());
+    SetLastModFileTime(msDosDateAndTime->GetDosTime());
+
     SetCrc(0);
     SetCompressedSize(0);
     SetUncompressedSize(0);

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -20,6 +20,7 @@ add_definitions(-DMSIX_TEST=1)
 
 set(MsixTestFiles)
 
+# Functional tests
 list(APPEND MsixTestFiles
     msixtest.cpp
     unpack.cpp
@@ -70,6 +71,15 @@ else()
     )
 endif()
 
+# Unit tests
+list(APPEND MsixTestFiles
+    TimeHelpers_ut.cpp
+)
+
+list(APPEND MsixTestFiles
+    ${MSIX_PROJECT_ROOT}/src/msix/common/TimeHelpers.cpp
+)
+
 # For mobile, we create a shared library that will be added to the apps to be
 # tested. For non-mobile we create a msixtest executable and we provide our own main
 if (AOSP OR IOS)
@@ -85,7 +95,12 @@ else()
         )
 endif()
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${MSIX_PROJECT_ROOT}/src/inc/public ${MSIX_PROJECT_ROOT}/lib/catch2 ${CMAKE_CURRENT_SOURCE_DIR}/inc ${MSIX_PROJECT_ROOT}/src/inc/shared)
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${MSIX_PROJECT_ROOT}/src/inc/public
+    ${MSIX_PROJECT_ROOT}/lib/catch2
+    ${CMAKE_CURRENT_SOURCE_DIR}/inc
+    ${MSIX_PROJECT_ROOT}/src/inc/shared
+    ${MSIX_PROJECT_ROOT}/src/inc/common)
 
 # Output test binaries into a test directory
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/src/test/msixtest/TimeHelpers_ut.cpp
+++ b/src/test/msixtest/TimeHelpers_ut.cpp
@@ -1,0 +1,53 @@
+//
+//  Copyright (C) 2021 Microsoft.  All rights reserved.
+//  See LICENSE file in the project root for full license information.
+//
+
+#include "catch.hpp"
+#include "TimeHelpers.hpp"
+
+#include <iostream>
+
+using namespace MSIX;
+
+TEST_CASE("TimeHelper_UT", "[unittests]")
+{
+    std::tm time {};
+    time.tm_year = 1991-1900; // 1991
+    time.tm_mon = 11 - 1; // November
+    time.tm_mday = 3;
+    time.tm_hour = 10;
+    time.tm_min = 27;
+    time.tm_sec = 12;
+
+    auto msDosDateAndTime = new MsDosDateAndTime(&time);
+    CHECK(0x1763 == msDosDateAndTime->GetDosDate());
+    CHECK(0x5366 == msDosDateAndTime->GetDosTime());
+}
+
+TEST_CASE("TimeHelper_boundaries_UT", "[unittests]")
+{
+    std::tm future {};
+    future.tm_year = 2117-1900; // 2117
+    future.tm_mon = 11 - 1; // November
+    future.tm_mday = 3;
+    future.tm_hour = 10;
+    future.tm_min = 27;
+    future.tm_sec = 12;
+
+    auto msDosDateAndTimeFuture = new MsDosDateAndTime(&future);
+    CHECK(0xff9f == msDosDateAndTimeFuture->GetDosDate());
+    CHECK(0xbf7d == msDosDateAndTimeFuture->GetDosTime());
+
+    std::tm past {};
+    past.tm_year = 1254-1900; // 1254
+    past.tm_mon = 11 - 1; // November
+    past.tm_mday = 3;
+    past.tm_hour = 10;
+    past.tm_min = 27;
+    past.tm_sec = 12;
+
+    auto msDosDateAndTimePast = new MsDosDateAndTime(&past);
+    CHECK(0xff9f == msDosDateAndTimePast->GetDosDate());
+    CHECK(0xbf7d == msDosDateAndTimePast->GetDosTime());
+}


### PR DESCRIPTION
Fix #393 

For convenience, we use some magic number in the last modify date and time in the LFH and CDH. This produce the behavior described by #393.

This change gets the local system time and convert it to MS-DOS date and time format and add it to the headers. It also follows the makeappx implementation that if getting the time fails the default is 12/31/2107, 23:59:58.

Validated in Windows and macOS.