### PR TITLE
Add scheduled weekly builds for MSIX SDK, MSIX.Utils, and the AzDO tasks extension

### DIFF
--- a/pipelines/azure-pipelines-aosp.yml
+++ b/pipelines/azure-pipelines-aosp.yml
@@ -26,5 +26,16 @@ pr:
     - makewin.cmd
     - manifest.cmakein
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: templates/build-aosp.yml

--- a/pipelines/azure-pipelines-ios.yml
+++ b/pipelines/azure-pipelines-ios.yml
@@ -26,5 +26,16 @@ pr:
     - makewin.cmd
     - manifest.cmakein
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: templates/build-ios.yml

--- a/pipelines/azure-pipelines-linux.yml
+++ b/pipelines/azure-pipelines-linux.yml
@@ -26,5 +26,16 @@ pr:
     - makewin.cmd
     - manifest.cmakein
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: templates/build-linux.yml

--- a/pipelines/azure-pipelines-macos.yml
+++ b/pipelines/azure-pipelines-macos.yml
@@ -26,5 +26,16 @@ pr:
     - makewin.cmd
     - manifest.cmakein
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: templates/build-macos.yml

--- a/pipelines/azure-pipelines-windows.yml
+++ b/pipelines/azure-pipelines-windows.yml
@@ -26,5 +26,16 @@ pr:
     - makewin.cmd
     - manifest.cmakein
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 jobs:
 - template: templates/build-windows.yml

--- a/pipelines/templates/build-windows.yml
+++ b/pipelines/templates/build-windows.yml
@@ -49,6 +49,10 @@ jobs:
         _artifact: WIN32-x64chk-pack
 
   steps:
+  - task: ComponentGovernanceComponentDetection@0
+    inputs:
+      sourceScanPath: $(Build.SourcesDirectory)
+
   - task: BatchScript@1
     displayName: Build $(_artifact)
     inputs:

--- a/pipelines/templates/build-windows.yml
+++ b/pipelines/templates/build-windows.yml
@@ -49,10 +49,6 @@ jobs:
         _artifact: WIN32-x64chk-pack
 
   steps:
-  - task: ComponentGovernanceComponentDetection@0
-    inputs:
-      sourceScanPath: $(Build.SourcesDirectory)
-
   - task: BatchScript@1
     displayName: Build $(_artifact)
     inputs:

--- a/tools/pipelines-tasks/azure-pipelines/ci-build.yml
+++ b/tools/pipelines-tasks/azure-pipelines/ci-build.yml
@@ -15,9 +15,19 @@ pr:
     include:
     - tools/pipelines-tasks
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 pool:
   name: 'msix-packaging-pool'
-
 
 variables:
   tasksRoot: 'tools/pipelines-tasks'

--- a/tools/utils/azure-pipelines.yml
+++ b/tools/utils/azure-pipelines.yml
@@ -13,6 +13,17 @@ pr:
     include:
     - tools/utils
 
+# Schedule weekly build
+# Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
+schedules:
+# "0 8" = 8AM UTC = 12AM PST
+- cron: "0 8 * * Sun"
+  displayName: Weekly build
+  branches:
+    include:
+    - master
+  always: true
+
 pool:
   vmImage: 'windows-latest'
 


### PR DESCRIPTION
Adding weekly builds so that we can run static code analysis and get new detections even if there are no code changes.