### PR TITLE
Update Microsoft.NET.Test.Sdk NuGet dependency on MSIX.Utils tests

### DIFF
--- a/tools/utils/UtilsTests/UtilsTests.csproj
+++ b/tools/utils/UtilsTests/UtilsTests.csproj
@@ -38,9 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220707-01" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION

Per https://github.com/advisories/GHSA-5crp-9r3c-p9vr, we should update the dependency we had on Newtonsoft to at least v13.0.1. We had it as a transitive dependency from Microsoft.NET.Test.Sdk; so we had to update that. The new version of Newtonsoft is used starting on the latest v17.4 of Microsoft.NET.Test.Sdk.

This was only present in the test code, so we won't need to make a new release of the Utils.