### PR TITLE
Fix typo in author name in `package.json`

### DIFF
--- a/tools/pipelines-tasks/AppInstallerFile/package.json
+++ b/tools/pipelines-tasks/AppInstallerFile/package.json
@@ -7,7 +7,7 @@
     "url": "git+github.com/microsoft/msix-packaging.git"
   },
   "scripts": {},
-  "author": "Microsoft Coporation",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "azure-devops-node-api": "^10.2.2",

--- a/tools/pipelines-tasks/MsixAppAttach/package.json
+++ b/tools/pipelines-tasks/MsixAppAttach/package.json
@@ -7,7 +7,7 @@
     "url": "git+github.com/microsoft/msix-packaging.git"
   },
   "scripts": {},
-  "author": "Microsoft Coporation",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "azure-devops-node-api": "^10.2.2",

--- a/tools/pipelines-tasks/MsixPackaging/package.json
+++ b/tools/pipelines-tasks/MsixPackaging/package.json
@@ -7,7 +7,7 @@
     "url": "git+github.com/microsoft/msix-packaging.git"
   },
   "scripts": {},
-  "author": "Microsoft Coporation",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "azure-devops-node-api": "^10.2.2",

--- a/tools/pipelines-tasks/MsixSigning/package.json
+++ b/tools/pipelines-tasks/MsixSigning/package.json
@@ -7,7 +7,7 @@
     "url": "git+github.com/microsoft/msix-packaging.git"
   },
   "scripts": {},
-  "author": "Microsoft Coporation",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "azure-devops-node-api": "^10.2.2",

--- a/tools/pipelines-tasks/common/package.json
+++ b/tools/pipelines-tasks/common/package.json
@@ -7,7 +7,7 @@
     "url": "git+github.com/microsoft/msix-packaging.git"
   },
   "scripts": {},
-  "author": "Microsoft Coporation",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
     "@types/xml2js": "^0.4.8",


### PR DESCRIPTION
This fixes some typos in the author listed in the `package.json` for the Node modules that make up the AzDO tasks. The actual author used for the task is defined in the `task.json`, where it is spelled correctly.

Fixes #521