### PR TITLE
Add explicit Use .NET step to Utils build pipeline

### DIFF
--- a/tools/utils/azure-pipelines.yml
+++ b/tools/utils/azure-pipelines.yml
@@ -34,6 +34,10 @@ variables:
   buildConfiguration: 'Release'
 
 steps:
+- task: UseDotNet@2
+  inputs:
+    version: 5.x
+
 - task: NuGetToolInstaller@1
 
 - task: NuGetCommand@2


### PR DESCRIPTION
The pipeline for the Utils package started failing when running the tests with error
```
##[error]Testhost process for source(s) 'D:\a\1\s\tools\utils\UtilsTests\bin\Release\net5.0\UtilsTests.dll' exited with error: You must install or update .NET to run this application.
```

I'm _guessing_ that it is due to the installed version of .NET runtime in the agents changing so I'm trying adding an explicit step to install it. I'll see if the pipeline runs fine with this...