### PR TITLE
Update Utils test project to .NET6

### DIFF
--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -6,7 +6,7 @@ published as a Nuget package and consumed by sources in other projects.
 
 * MSBuild
 * .NET Standard 2.0
-* .NET 5.0 (for test project)
+* .NET 6.0 (for test project)
 This should be available in a standard installation of Visual Studio.
 
 ## Build

--- a/tools/utils/README.md
+++ b/tools/utils/README.md
@@ -23,7 +23,7 @@ MSTest is used as the testing framework and can be run through Visual Studio's T
 To run the tests from the command line, go to `msix-packaging/tools/utils/` and call `vstest.console.exe` on `UtilsTests.dll` produced by the build. E.g.
 ```
 cd msix-packaging/tools/utils/
-vstest.console.exe UtilsTests\bin\Debug\net5.0\UtilsTests.dll
+vstest.console.exe UtilsTests\bin\Debug\net6.0\UtilsTests.dll
 ```
 
 MakeAppx.exe and related binaries under `msix-packaging/tools/utils/TestData/MakeAppx` are taken from the redistributable binaries available in the [MSIX Toolkit](https://github.com/microsoft/msix-toolkit).

--- a/tools/utils/UtilsTestExe/UtilsTestExe.csproj
+++ b/tools/utils/UtilsTestExe/UtilsTestExe.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>UtilsTestExe</RootNamespace>
     <AssemblyName>UtilsTestExe</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/tools/utils/UtilsTests/UtilsTests.csproj
+++ b/tools/utils/UtilsTests/UtilsTests.csproj
@@ -7,7 +7,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UtilsTests</RootNamespace>
     <AssemblyName>UtilsTests</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <FileAlignment>512</FileAlignment>
     <PlatformTarget>x86</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/tools/utils/azure-pipelines.yml
+++ b/tools/utils/azure-pipelines.yml
@@ -53,7 +53,7 @@ steps:
   displayName: 'Run tests'
   inputs:
     testSelector: 'testAssemblies'
-    testAssemblyVer2: 'UtilsTests\bin\Release\net5.0\UtilsTests.dll'
+    testAssemblyVer2: 'UtilsTests\bin\Release\net6.0\UtilsTests.dll'
     searchFolder: '$(utilsRoot)'
 
 - task: ComponentGovernanceComponentDetection@0


### PR DESCRIPTION
The pipeline for the Utils package started failing when running the tests with error
```
##[error]Testhost process for source(s) 'D:\a\1\s\tools\utils\UtilsTests\bin\Release\net5.0\UtilsTests.dll' exited with error: You must install or update .NET to run this application.
```

The ultimate reason seems to be that since .NET 5 is no longer supported, the pipelines don't like it anymore. The solution was to update the test project to .NET 6; luckily no changes were required.

Replaces #550. This time I could actually confirm that the pipeline works correctly by making the branch in the official repo...