### PR TITLE
Fixed debug build errors while running from Visual studio for msixmgr project

### DIFF
--- a/MsixCore/msixmgrLib/msixmgrLib.vcxproj
+++ b/MsixCore/msixmgrLib/msixmgrLib.vcxproj
@@ -95,7 +95,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>msixmgrLib_EXPORTS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
-      <AdditionalIncludeDirectories>.;..\msixmgr;inc;..\..\.vs\src\msix;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>.;..\msixmgr;inc;..\..\.vs\src\msix;..\msixmgr\include\rapidjson;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>


### PR DESCRIPTION
Rapid json headers files could not be detected as the include file path was missing in AdditionalIncludeDirectories.