### PR TITLE
Add logic to allow pseudo locales in AppxBundleManifest.xml file of .msixbundle packages

### DIFF
--- a/src/inc/internal/Applicability.hpp
+++ b/src/inc/internal/Applicability.hpp
@@ -30,7 +30,7 @@ namespace MSIX {
     class Bcp47Tag final
     {
     public:
-        Bcp47Tag(const std::string& fullTag);
+        Bcp47Tag(const std::string& fullTag, bool allowPseudoLocale = false);
         Bcp47Tag(const std::string& language, const std::string& script, const std::string& region) : 
             m_language(language), m_script(script), m_region(region) {} 
 

--- a/src/msix/unpack/ApplicabilityCommon.cpp
+++ b/src/msix/unpack/ApplicabilityCommon.cpp
@@ -32,7 +32,7 @@ namespace MSIX {
         Bcp47Entry(u8"zh-tw", u8"zh-Hant-TW"),
     };
 
-    Bcp47Tag::Bcp47Tag(const std::string& fullTag)
+    Bcp47Tag::Bcp47Tag(const std::string& fullTag, bool allowPseudoLocale)
     {
         std::string fullTagLower;
         fullTagLower.resize(fullTag.size());
@@ -57,7 +57,8 @@ namespace MSIX {
             auto position = found+1;
             found = bcp47Tag.find(delimiter, position);
             auto tag = bcp47Tag.substr(position, found - position);
-            ThrowErrorIf(Error::Unexpected, (tag.size() < 2 || tag.size() > 4), "Malformed Bcp47 tag");
+            auto maxTagLength = allowPseudoLocale ? 5 : 4;
+            ThrowErrorIf(Error::Unexpected, (tag.size() < 2 || tag.size() > maxTagLength), "Malformed Bcp47 tag");
             if (tag.size() == 4)
             {   // Script tag size is always 4
                 m_script = tag;

--- a/src/msix/unpack/AppxBundleManifest.cpp
+++ b/src/msix/unpack/AppxBundleManifest.cpp
@@ -77,7 +77,7 @@ namespace MSIX {
             {
                 _resourcesContext* resourcesContext = reinterpret_cast<_resourcesContext*>(c);
                 const auto& language = resourceNode->GetAttributeValue(XmlAttributeName::Language);
-                if (!language.empty()) { resourcesContext->languages.push_back(Bcp47Tag(language)); }
+                if (!language.empty()) { resourcesContext->languages.push_back(Bcp47Tag(language, true)); }
 
                 const auto& scale = resourceNode->GetAttributeValue(XmlAttributeName::Scale);
                 if (!scale.empty()) 


### PR DESCRIPTION
**ISSUE :** https://github.com/microsoft/msix-packaging/issues/516

**ROOT CAUSE :** 
In "AppxBundleManifest.xml" of "WindowsTerminal.msixbundle", there are pseudo locales present in "Resource" tag.
<img width="263" alt="image" src="https://user-images.githubusercontent.com/113883879/219028719-a39b902f-5741-4704-a147-3b8e4e9246ff.png">
Parsing of AppxBundleManifest.xml file is failing during unpack because of above mentioned pseudo locales as the max length limit for "Region" in "Language" is set to 4 and length of "Region" in pseudo locales "QPS-PLOCA" and "QPS-PLOCM" is 5.

**FIX :**
Allow pseudo locales in constructor of class "Bcp47Tag" by using a flag "allowPseudoLocale". So, when "AppxBundleManifest.xml" is parsed in "AppxBundleManifest.cpp", "allowPseudoLocale" is passed as "true" in constructor of class "Bcp47Tag".