### PR TITLE
Get code building under c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,11 @@ message(STATUS "--------------------------------")
 
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
-# specify that this binary is to be built with C++14
-set(CMAKE_CXX_STANDARD 14)
+
+if(NOT ${CMAKE_CXX_STANDARD})
+    # if not otherwise set, specify that this binary is to be built with C++14
+    set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/makelinux.sh
+++ b/makelinux.sh
@@ -16,6 +16,7 @@ usage()
     echo $'\t' "--pack                  Include packaging features. Sets validation parser on."
     echo $'\t' "--skip-samples          Skip building samples."
     echo $'\t' "--skip-tests            Skip building tests."
+    echo $'\t' "--extra                 Extra flags to CMake."
 }
 
 printsetup()
@@ -27,6 +28,8 @@ printsetup()
     echo "Build samples:" $samples
     echo "Build tests:" $tests
 }
+
+extraArgs=""
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -48,6 +51,9 @@ while [ "$1" != "" ]; do
         --skip-samples ) samples=off
                 ;;
         --skip-tests ) tests=off
+                ;;
+        --extra )   shift
+                extraArgs="$extraArgs $1"
                 ;;
         * )     usage
                 exit 1
@@ -71,5 +77,6 @@ cmake -DCMAKE_BUILD_TYPE=$build \
       -DMSIX_PACK=$pack \
       -DMSIX_SAMPLES=$samples \
       -DMSIX_TESTS=$tests \
-      -DLINUX=on ..
+      -DLINUX=on .. \
+      $extraArgs
 make

--- a/pipelines/templates/build-linux.yml
+++ b/pipelines/templates/build-linux.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: Linux
   pool:
-    vmImage: ubuntu-18.04
+    vmImage: ubuntu-20.04
   strategy:
     # TODO: add builds using xerces if needed.
     matrix:
@@ -23,6 +23,8 @@ jobs:
       debug_pack:
         _arguments: -b Debug --pack
         _artifact: LINUXchk-pack
+      debug_pack_cxx20:
+        _arguments: -b Debug --pack --extra -DCMAKE_CXX_STANDARD=20
 
   steps:
   - task: Bash@3

--- a/src/msix/common/AppxManifestObject.cpp
+++ b/src/msix/common/AppxManifestObject.cpp
@@ -11,69 +11,77 @@
 #include "AppxPackageInfo.hpp"
 
 #include <array>
+#include <type_traits>
+#include <string>
 
 namespace MSIX {
 
     template<typename T>
     struct Entry
     {
-        const char* tdf;
+        // Change the string constant type here to match that of the Entry constants
+        // in targetDeviceFamilyList and capabilitiesList - that is, u8"" if those
+        // strings regain the u8 prefix.
+        typedef std::remove_const<std::remove_reference<decltype(""[0])>::type>::type u8char;
+        const u8char* tdf;
+        const size_t len;
         const T value;
 
-        Entry(const char* t, const T p) : tdf(t), value(p) {}
+        template<size_t new_len>
+        Entry(const u8char (&t)[new_len], const T p) : tdf(t), len(new_len), value(p) {}
 
-        inline bool operator==(const char* otherTdf) const {
-            return 0 == strcmp(tdf, otherTdf);
+        inline bool operator==(const u8char *otherTdf) const {
+            return 0 == std::char_traits<u8char>::compare(tdf, otherTdf, len);
         }
     };
 
     // ALL THE TargetDeviceFamily ENTRIES MUST BE LOWER-CASE
     static const Entry<MSIX_PLATFORMS> targetDeviceFamilyList[] = {
-        Entry<MSIX_PLATFORMS>(u8"windows.universal",      MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.mobile",         MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.desktop",        MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.xbox",           MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.team",           MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.holographic",    MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.iot",            MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.server",         MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.all",          MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.phone",        MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.tablet",       MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.tv",           MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.watch",        MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.macos.all",        MSIX_PLATFORM_MACOS),
-        Entry<MSIX_PLATFORMS>(u8"google.android.all",     MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.phone",   MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.tablet",  MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.desktop", MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.tv",      MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.watch",   MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"msixcore.desktop",       MSIX_PLATFORM_CORE),
-        Entry<MSIX_PLATFORMS>(u8"msixcore.server",        MSIX_PLATFORM_CORE),
-        Entry<MSIX_PLATFORMS>(u8"linux.all",              MSIX_PLATFORM_LINUX),
-        Entry<MSIX_PLATFORMS>(u8"web.edge.all",           MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.blink.all",          MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.chromium.all",       MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.webkit.all",         MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.safari.all",         MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.all",                MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"platform.all",           static_cast<MSIX_PLATFORMS>(MSIX_PLATFORM_ALL)),
+        Entry<MSIX_PLATFORMS>("windows.universal",      MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.mobile",         MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.desktop",        MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.xbox",           MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.team",           MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.holographic",    MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.iot",            MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.server",         MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("apple.ios.all",          MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.phone",        MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.tablet",       MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.tv",           MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.watch",        MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.macos.all",        MSIX_PLATFORM_MACOS),
+        Entry<MSIX_PLATFORMS>("google.android.all",     MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.phone",   MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.tablet",  MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.desktop", MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.tv",      MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.watch",   MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("msixcore.desktop",       MSIX_PLATFORM_CORE),
+        Entry<MSIX_PLATFORMS>("msixcore.server",        MSIX_PLATFORM_CORE),
+        Entry<MSIX_PLATFORMS>("linux.all",              MSIX_PLATFORM_LINUX),
+        Entry<MSIX_PLATFORMS>("web.edge.all",           MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.blink.all",          MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.chromium.all",       MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.webkit.all",         MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.safari.all",         MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.all",                MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("platform.all",           static_cast<MSIX_PLATFORMS>(MSIX_PLATFORM_ALL)),
     };
 
     static const Entry<APPX_CAPABILITIES> capabilitiesList[] = {
-        Entry<APPX_CAPABILITIES>(u8"internetClient",             APPX_CAPABILITY_INTERNET_CLIENT),
-        Entry<APPX_CAPABILITIES>(u8"internetClientServer",       APPX_CAPABILITY_INTERNET_CLIENT_SERVER),
-        Entry<APPX_CAPABILITIES>(u8"privateNetworkClientServer", APPX_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER),
-        Entry<APPX_CAPABILITIES>(u8"documentsLibrary",           APPX_CAPABILITY_DOCUMENTS_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"picturesLibrary",            APPX_CAPABILITY_PICTURES_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"videosLibrary",              APPX_CAPABILITY_VIDEOS_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"musicLibrary",               APPX_CAPABILITY_MUSIC_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"enterpriseAuthentication",   APPX_CAPABILITY_ENTERPRISE_AUTHENTICATION),
-        Entry<APPX_CAPABILITIES>(u8"sharedUserCertificates",     APPX_CAPABILITY_SHARED_USER_CERTIFICATES),
-        Entry<APPX_CAPABILITIES>(u8"removableStorage",           APPX_CAPABILITY_REMOVABLE_STORAGE),
-        Entry<APPX_CAPABILITIES>(u8"appointments",               APPX_CAPABILITY_APPOINTMENTS),
-        Entry<APPX_CAPABILITIES>(u8"contacts",                   APPX_CAPABILITY_CONTACTS),
+        Entry<APPX_CAPABILITIES>("internetClient",             APPX_CAPABILITY_INTERNET_CLIENT),
+        Entry<APPX_CAPABILITIES>("internetClientServer",       APPX_CAPABILITY_INTERNET_CLIENT_SERVER),
+        Entry<APPX_CAPABILITIES>("privateNetworkClientServer", APPX_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER),
+        Entry<APPX_CAPABILITIES>("documentsLibrary",           APPX_CAPABILITY_DOCUMENTS_LIBRARY),
+        Entry<APPX_CAPABILITIES>("picturesLibrary",            APPX_CAPABILITY_PICTURES_LIBRARY),
+        Entry<APPX_CAPABILITIES>("videosLibrary",              APPX_CAPABILITY_VIDEOS_LIBRARY),
+        Entry<APPX_CAPABILITIES>("musicLibrary",               APPX_CAPABILITY_MUSIC_LIBRARY),
+        Entry<APPX_CAPABILITIES>("enterpriseAuthentication",   APPX_CAPABILITY_ENTERPRISE_AUTHENTICATION),
+        Entry<APPX_CAPABILITIES>("sharedUserCertificates",     APPX_CAPABILITY_SHARED_USER_CERTIFICATES),
+        Entry<APPX_CAPABILITIES>("removableStorage",           APPX_CAPABILITY_REMOVABLE_STORAGE),
+        Entry<APPX_CAPABILITIES>("appointments",               APPX_CAPABILITY_APPOINTMENTS),
+        Entry<APPX_CAPABILITIES>("contacts",                   APPX_CAPABILITY_CONTACTS),
     };
 
     AppxManifestObject::AppxManifestObject(IMsixFactory* factory, const ComPtr<IStream>& stream) : m_factory(factory), m_stream(stream)


### PR DESCRIPTION
The only thing that seems to break when building under c++20 is that the u8-string literals change to char8_ts. However, we're not using any character in these literals that would require the support, and the rest of the code isn't using the right functions to have robust unicode support anyway, so I swapped to just classic char-string-literals.

I did a drive-by improvement to allow for some automatic determination of the right functions to use for these lists, if someone does want to change the types back to u8-literals (so, char under c++14 and char8_t under c++20), but there's issues further throughout the code that uses these values that building under c++20 reveals; I suspect that we're not universally using the right string comparison functions.