### PR TITLE
Fix compilation on gcc13

### DIFF
--- a/src/inc/internal/Encoding.hpp
+++ b/src/inc/internal/Encoding.hpp
@@ -5,13 +5,15 @@
 #pragma once
 
 #include <string>
+#include <vector>
+#include <cstdint>
 
 namespace MSIX { namespace Encoding {
 
     std::string DecodeFileName(const std::string& fileName);
     std::string EncodeFileName(const std::string& fileName);
 
-    std::string Base32Encoding(const std::vector<uint8_t>& bytes);
+    std::string Base32Encoding(const std::vector<std::uint8_t>& bytes);
     std::vector<std::uint8_t> GetBase64DecodedValue(const std::string& value);
 
 } /*Encoding */ } /* MSIX */

--- a/src/test/msixtest/inc/BlockMapTestData.hpp
+++ b/src/test/msixtest/inc/BlockMapTestData.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace MsixTest { 
 

--- a/src/test/msixtest/inc/UnpackTestData.hpp
+++ b/src/test/msixtest/inc/UnpackTestData.hpp
@@ -5,6 +5,7 @@
 #pragma once
 #include <map>
 #include <string>
+#include <cstdint>
 
 namespace MsixTest {
 


### PR DESCRIPTION
Fairly straightforward. gcc13 cleaned up some headers, so you need to manually include them nowadays.