### PR TITLE
Update ESRP Codesigning task version in ado pipelines

### DIFF
--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -66,7 +66,7 @@ steps:
     publishLocation: 'pipeline'
 
 # Sign the package
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@4
   displayName: 'ESRP CodeSigning'
   inputs:
     ConnectedServiceName: 'ESRP CodeSigning'


### PR DESCRIPTION
## Why is this change being made?
ESRP code signing failure with current ESRP codesigning task version 1.0.
The .NET dependencies installed on the agent machine do not match with the .NET dependencies required for ESRP codesigning earlier task version. 

## What changed?
ESRP Code signing task version is changed to 4.0

## How was the change tested?
Verified ESRP code signing task. 