### PR TITLE
Fix path for copying msix.dll in CMakeLists.txt files

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.8.0 FATAL_ERROR)
 # For windows copy the library to the msix and samples directory
 if(WIN32)
     add_custom_target(samples ALL
-        COMMAND ${CMAKE_COMMAND} -E copy "bin/msix.dll" "samples/msix.dll"
+        COMMAND ${CMAKE_COMMAND} -E copy "${MSIX_BINARY_ROOT}/bin/${CMAKE_CFG_INTDIR}/msix.dll" "samples/msix.dll"
         WORKING_DIRECTORY "${MSIX_BINARY_ROOT}"
         DEPENDS msix)
 else()

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -125,6 +125,5 @@ target_link_libraries(${PROJECT_NAME} ${MsixTestLibs})
 # For windows copy the library
 if(WIN32)
     add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy "bin/msix.dll" "msixtest/msix.dll"
-        WORKING_DIRECTORY "${MSIX_BINARY_ROOT}")
+        COMMAND ${CMAKE_COMMAND} -E copy "${MSIX_BINARY_ROOT}/bin/${CMAKE_CFG_INTDIR}/msix.dll" "${MSIX_TEST_OUTPUT_DIRECTORY}/msixtest/msix.dll")
 endif()


### PR DESCRIPTION
This commit fixes the issue where the incorrect path was used for copying the msix.dll file in the CMakeLists.txt files for samples and msixtest. The updated path correctly considers the build configuration (Release/Debug) when copying the file.

This resolves the build error reported in issue #620.

- In sample/CMakeLists.txt, the copy command now uses ${MSIX_BINARY_ROOT}/bin/${CMAKE_CFG_INTDIR}/msix.dll as the source path.
- In src/test/msixtest/CMakeLists.txt, the copy command now uses ${MSIX_BINARY_ROOT}/bin/${CMAKE_CFG_INTDIR}/msix.dll as the source path and ${MSIX_TEST_OUTPUT_DIRECTORY}/msixtest/msix.dll as the destination path.

The makewin.cmd is confirmed to work as before. Now builds from VSCode also build without an error using MSVC 15.

Fixes #620