### PR TITLE
Fix inconsistent zip structure in .appx files created by makemsix.exe

### DIFF
--- a/src/inc/internal/ZipObjectWriter.hpp
+++ b/src/inc/internal/ZipObjectWriter.hpp
@@ -68,5 +68,6 @@ namespace MSIX {
 
         State m_state = State::ReadyForLfhOrClose;
         std::pair<std::uint64_t, LocalFileHeader> m_lastLFH;
+        std::vector<std::string> m_fileNameSequence;
     };
 }


### PR DESCRIPTION
This commit resolves issue #619 by ensuring that the central directory in .appx files created by makemsix.exe is sorted in the same order as MakeAppx.exe. The fix involves tracking the sequence of file names during the creation of the zip file and sorting the central directory entries accordingly before writing them to the stream.

- Add a vector to track the sequence of file names in ZipObjectWriter.
- Sort central directory entries based on the tracked file name sequence before writing them to the zip file.

Resolves: #619

This was tested building via `makewin.cmd x64 --debug --pack`. 
The following files
[test_makemsix.zip](https://github.com/microsoft/msix-packaging/files/14545644/test_makemsix.zip)

were packed with:
`.vs\bin\makemsix pack -d C:\test_makemsix -p C:\test_makemsix_sorted.appx`

The side-by-side zipdump and 7-zip properties show that the central directory is now in the same sequence as the local file header streams in the zip archive.
![image](https://github.com/microsoft/msix-packaging/assets/38470677/be2c00fb-a1d9-4011-9b75-0c7f45555a8c)
