### PR TITLE
Fix Clang compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ message(STATUS "--------------------------------")
 message(STATUS "CMake version: ${CMAKE_VERSION}")
 
 # specify that this binary is to be built with C++14
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/lib/xerces/CMakeLists.txt
+++ b/lib/xerces/CMakeLists.txt
@@ -34,7 +34,7 @@ endif(POLICY CMP0067)
 
 # Try C++14, then fall back to C++11 and C++98.  Used for feature tests
 # for optional features.
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # Use folders (for IDE project grouping)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
fix compatibility issue with platforms using clang. Due to the difference in standard implementations, a change of the C++ standard from 14 to 17 is required to properly build the project on these platforms. 

compilation errors with clang18:
```
...
/usr/include/unicode/localpointer.h:561:26: error: 'auto' not allowed in template parameter until C++17
...
/usr/include/unicode/uenum.h:69:69: error: value of type 'void (UEnumeration *)' is not implicitly convertible to 'int'
...
```