### PR TITLE
Fix static CRT compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project(msix-sdk)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/cmake/msix_options.cmake
+++ b/cmake/msix_options.cmake
@@ -31,13 +31,7 @@ if(USE_STATIC_MSVC)
     if(NOT WIN32)
         message(FATAL_ERROR "-DUSE_STATIC_MSVC=on can only be used for Windows")
     endif()
-    # By default these flags have /MD set. Modified it to use /MT instead.
-    foreach(buildType RELEASE MINSIZEREL RELWITHDEBINFO)
-        set(cxxFlag "CMAKE_CXX_FLAGS_${buildType}")
-        string(REPLACE "/MD" "/MT" ${cxxFlag} "${${cxxFlag}}")
-    endforeach()
-    set(cxxFlagDebug "CMAKE_CXX_FLAGS_DEBUG")
-    string(REPLACE "/MDd" "/MTd" ${cxxFlagDebug} "${${cxxFlagDebug}}")
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
 # Set xml parser if not set

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,7 +1,7 @@
 # MSIX\lib
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 add_custom_target(LIBS)
 

--- a/lib/xerces/CMakeLists.txt
+++ b/lib/xerces/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 # Run "cmake" to generate the build files for your platform
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 # Use new variable expansion policy.
 if (POLICY CMP0053)

--- a/sample/BundleSample/CMakeLists.txt
+++ b/sample/BundleSample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (BundleSample)
 
 if(WIN32)

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 # For windows copy the library to the msix and samples directory
 if(WIN32)

--- a/sample/ExtractContentsSample/CMakeLists.txt
+++ b/sample/ExtractContentsSample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (ExtractContentsSample)
 
 if(WIN32)

--- a/sample/OverrideLanguageSample/CMakeLists.txt
+++ b/sample/OverrideLanguageSample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (OverrideLanguageSample)
 
 if(WIN32)

--- a/sample/OverrideStreamSample/CMakeLists.txt
+++ b/sample/OverrideStreamSample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (OverrideStreamSample)
 
 if(WIN32)

--- a/sample/PackSample/CMakeLists.txt
+++ b/sample/PackSample/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2019 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (PackSample)
 
 if(WIN32)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 add_subdirectory(msix)
 add_subdirectory(makemsix)

--- a/src/makemsix/CMakeLists.txt
+++ b/src/makemsix/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (makemsix)
 
 if(MSIX_PACK)

--- a/src/msix/CMakeLists.txt
+++ b/src/msix/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 project(msix)
 
@@ -271,13 +271,6 @@ if(WIN32)
     string(REPLACE ";" " " DELAYFLAGS "${DELAYFLAGS}")
     set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS "${DELAYFLAGS} /LTCG")
     set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /DEF:${CMAKE_CURRENT_BINARY_DIR}/windowsexports.def")
-    if(USE_STATIC_MSVC)
-        if(CMAKE_BUILD_TYPE MATCHES Debug)
-            set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /NODEFAULTLIB:MSVCRTD")
-        else()
-            set_property(TARGET ${PROJECT_NAME} APPEND_STRING PROPERTY LINK_FLAGS " /NODEFAULTLIB:MSVCRT")
-        endif()
-    endif()
     target_link_libraries(${PROJECT_NAME} PRIVATE bcrypt crypt32 wintrust runtimeobject.lib delayimp.lib)
 endif()
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 set(MSIX_TEST_OUTPUT_DIRECTORY "${MSIX_BINARY_ROOT}/msixtest")
 

--- a/src/test/mobile/AndroidBVT/app/CMakeLists.txt
+++ b/src/test/mobile/AndroidBVT/app/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2017 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 
 include_directories(
     ${include_directories}

--- a/src/test/msixtest/CMakeLists.txt
+++ b/src/test/msixtest/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (C) 2019 Microsoft.  All rights reserved.
 # See LICENSE file in the project root for full license information.
 
-cmake_minimum_required(VERSION 3.29.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.28.0 FATAL_ERROR)
 project (msixtest)
 
 if(WIN32)


### PR DESCRIPTION
Currently, static CRT compilation doesn't work, because `/NODEFAULTLIB:MSVCRT(D)` simply leaves a number of unresolved external references behind.

#628 has upgraded CMake to version 3.29 which enables the use of `CMAKE_MSVC_RUNTIME_LIBRARY`. That makes static CRT use much easier, so we can take advantage of this.

I've also downgraded CMake slightly to version 3.28 so that it can be compiled with the version shipped with Visual C++ Build Tools 17.10 LTS.

/cc @msftrubengu 