### PR TITLE
Fix new delete mismatch.

### DIFF
--- a/lib/xerces/src/xercesc/internal/MemoryManagerImpl.cpp
+++ b/lib/xerces/src/xercesc/internal/MemoryManagerImpl.cpp
@@ -26,6 +26,9 @@
 #include <xercesc/internal/MemoryManagerImpl.hpp>
 #include <xercesc/util/OutOfMemoryException.hpp>
 
+#include <cstdint>
+#include <new>
+
 XERCES_CPP_NAMESPACE_BEGIN
 
 MemoryManager* MemoryManagerImpl::getExceptionMemoryManager()
@@ -35,13 +38,7 @@ MemoryManager* MemoryManagerImpl::getExceptionMemoryManager()
 
 void* MemoryManagerImpl::allocate(XMLSize_t size)
 {
-    void* memptr;
-    try {
-        memptr = ::operator new(size);
-    }
-    catch(...) {
-        throw OutOfMemoryException();
-    }
+    void* memptr = new(std::nothrow) uint8_t[size];
     if(memptr==NULL && size!=0)
         throw OutOfMemoryException();
     return memptr;
@@ -49,8 +46,7 @@ void* MemoryManagerImpl::allocate(XMLSize_t size)
 
 void MemoryManagerImpl::deallocate(void* p)
 {
-    if (p)
-        ::operator delete(p);
+    delete[] static_cast<uint8_t*>(p);
 }
 
 XERCES_CPP_NAMESPACE_END

--- a/lib/xerces/src/xercesc/util/Base64.cpp
+++ b/lib/xerces/src/xercesc/util/Base64.cpp
@@ -24,6 +24,8 @@
 #include <xercesc/internal/XMLReader.hpp>
 #include <xercesc/framework/MemoryManager.hpp>
 
+#include <cstddef>
+
 XERCES_CPP_NAMESPACE_BEGIN
 
 // ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ static void* getExternalMemory(  MemoryManager* const allocator
                                , XMLSize_t const   sizeToAllocate)
 {
    return allocator ? allocator->allocate(sizeToAllocate)
-       : ::operator new(sizeToAllocate);
+       : new uint8_t[sizeToAllocate];
 }
 
 /***
@@ -107,7 +109,7 @@ static void returnExternalMemory(  MemoryManager* const allocator
                                  , void*                buffer)
 {
     allocator ? allocator->deallocate(buffer)
-        : ::operator delete(buffer);
+        : delete[] static_cast<uint8_t*>(buffer);
 }
 
 /**

--- a/lib/xerces/tests/src/MemHandlerTest/MemoryMonitor.cpp
+++ b/lib/xerces/tests/src/MemHandlerTest/MemoryMonitor.cpp
@@ -43,7 +43,7 @@ MemoryManager* MemoryMonitor::getExceptionMemoryManager()
 
 void* MemoryMonitor::allocate(XMLSize_t size)
 {
-    void *key = ::operator new(size);
+    void *key = new uint8_t[size];
     fHashTable->put(key, (unsigned int)size);
     return key;
 }
@@ -56,7 +56,7 @@ void MemoryMonitor::deallocate(void* p)
     if (p != 0)
     {
         fHashTable->removeKey(p);
-        ::operator delete(p);
+        delete[] static_cast<uint8_t*>(p);
     }
 }
 

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -223,7 +223,7 @@ public:
     }  
 
     void InternalRelease()
-    {   delete(m_ptr);
+    {   delete[] m_ptr;
         m_ptr = nullptr;
     }
 


### PR DESCRIPTION
The adapter for Xerces was using new and delete as if they were malloc and free. This resulted in `new`'ing objects with size N, and `delete`'ing them with size 1. This PR fixes it by using new `uint8_t[size]`, and `delete[]`;

Fixes #648