### PR TITLE
Migration of Azure Pipelines

### DIFF
--- a/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
+++ b/tools/pipelines-tasks/azure-pipelines/build-vsix.yml
@@ -66,7 +66,7 @@ extends:
           - output: adoExtension
             displayName: 'Publish Extension'
             targetPath: $(buildOutRoot)
-            connectedServiceName: 'Visual Studio Marketplace - MSIX'
+            connectedServiceName: 'Visual Studio Marketplace - Msix-Packaging'
             fileType: vsix
             vsixFile: '$(buildOutRoot)\MsixPackagingExtension.vsix'
             extensionId: 'msix-ci-automation-task-dev'
@@ -112,17 +112,22 @@ extends:
             ValidateSignature: true
 
         # Sign the package
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@4
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
           displayName: 'ESRP CodeSigning'
           inputs:
-            ConnectedServiceName: 'ESRP CodeSigning'
+            ConnectedServiceName: $(ConnectedServiceName)
+            AppRegistrationClientId: $(AppRegistrationClientId)
+            AppRegistrationTenantId: $(AppRegistrationTenantId)
+            AuthAKVName: $(AuthAKVName) 
+            AuthCertName: $(AuthCertName)
+            AuthSignCertName: $(AuthSignCertName)
             FolderPath: '$(buildOutRoot)'
             Pattern: MsixPackagingExtension.vsix
             signConfigType: inlineSignParams
             inlineOperation: |
               [
                {
-                   "KeyCode" : "CP-233016",
+                   "KeyCode" : "CP-401405",
                    "OperationCode" : "OpcSign",
                    "Parameters" : {
                        "FileDigest" : "/fd SHA256"
@@ -131,7 +136,7 @@ extends:
                    "ToolVersion" : "1.0"
                },
                {
-                   "KeyCode" : "CP-233016",
+                   "KeyCode" : "CP-401405",
                    "OperationCode" : "OpcVerify",
                    "Parameters" : {},
                    "ToolName" : "sign",

--- a/tools/pipelines-tasks/azure-pipelines/ci-build.yml
+++ b/tools/pipelines-tasks/azure-pipelines/ci-build.yml
@@ -14,7 +14,7 @@ pr:
   paths:
     include:
     - tools/pipelines-tasks
-
+ 
 # Schedule weekly build
 # Cron syntax: "mm HH DD MM DW" = minutes, hours, days, months, day of week (UTC time)
 schedules:
@@ -26,9 +26,6 @@ schedules:
     - master
   always: true
 
-pool:
-  name: 'msix-packaging-pool'
-
 # Set the variables to run AVD publish tests on required azure subscription service connection containing AVD resources:
 # subscriptionId, emailId, clientId, clientSecret, tenantId, resourceGroupName, storageAccountName, fileShareName, hostPoolName, workSpaceName, applicationGroupName
 # Not setting these variables will leave running AVD publish test cases and will not fail the pipeline
@@ -36,5 +33,36 @@ variables:
   tasksRoot: 'tools/pipelines-tasks'
   buildOutRoot: '$(Build.ArtifactStagingDirectory)/buildOutput'
 
-steps:
-- template: templates/build-steps.yml
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+
+  parameters:
+    sdl:
+      git:
+        submodules: disable
+      baseline:
+        baselineFile: $(Build.SourcesDirectory)\tools\pipelines-tasks\azure-pipelines\.gdnbaselines
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\tools\pipelines-tasks\azure-pipelines\.gdnsuppress
+
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2019
+      os: windows
+
+    customBuildTags:
+    - ES365AIMigrationTooling
+
+    stages:
+    - stage: stage
+      jobs:
+      - job: job
+        steps:
+        - template: /tools/pipelines-tasks/azure-pipelines/templates/build-steps.yml@self

--- a/tools/pipelines-tasks/azure-pipelines/templates/build-steps.yml
+++ b/tools/pipelines-tasks/azure-pipelines/templates/build-steps.yml
@@ -46,23 +46,6 @@ steps:
   env:
     SYSTEM_CULTURE: 'en-US'
 
-# Code analysis tasks required by policy
-# Note that CodeQL is a heavy task that is recommended to run in a separate pipeline
-# and only weekly. We include it here as the project is small enough as to not
-# make much of a difference, but we may need to separate it in the future.
-- task: Semmle@1
-  displayName: 'Run CodeQL (Semmle) scan'
-  inputs:
-    sourceCodeDirectory: '$(tasksRoot)'
-    language: 'tsandjs'
-    querySuite: 'Recommended'
-    timeout: '1800'
-    ram: '16384'
-    addProjectDirToScanningExclusionList: true
-  env:
-    # Required to publish the result
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-
 - task: PublishSecurityAnalysisLogs@3
   inputs:
     ArtifactName: 'CodeAnalysisLogs'


### PR DESCRIPTION
**Why is this change being made?**
As the current ADO project is getting decommissioned, the existing msix-packaging pipelines of that project need to be migrated to a new ADO project. 

**What changed?**
- Updated `tools/pipelines-tasks/azure-pipelines/build-vsix.yml` for ESRP Code Signing
- Migrated `msix-packaging AzDO tasks CI` pipeline to 1ESPT
- Remove deprecated Semmle  Guardin Task from `tools/pipelines-tasks/azure-pipelines/templates/build-steps.yml`

**How was the change tested?**
Tested the pipeline by running the build for this branch. 