### PR TITLE
Bring modifications made during MSFT repoman project

### DIFF
--- a/src/inc/internal/ZipObject.hpp
+++ b/src/inc/internal/ZipObject.hpp
@@ -108,7 +108,7 @@ namespace MSIX {
 
         // The incoming values are those from the central directory record. Their value there determines
         // whether we attempt to read them here.
-        void Read(const ComPtr<IStream>& stream, ULARGE_INTEGER start, uint32_t uncompressedSize, uint32_t compressedSize, uint32_t offset, uint16_t disk);
+        void Read(const ComPtr<IStream>& stream, uint64_t start, uint32_t uncompressedSize, uint32_t compressedSize, uint32_t offset, uint16_t disk);
 
         std::uint64_t GetUncompressedSize() const               { return Field<2>(); }
         std::uint64_t GetCompressedSize() const                 { return Field<3>(); }
@@ -166,7 +166,7 @@ namespace MSIX {
         void SetData(const std::string& name, std::uint32_t crc, std::uint64_t compressedSize,
             std::uint64_t uncompressedSize, std::uint64_t relativeOffset,  std::uint16_t compressionMethod, bool forceDataDescriptor);
 
-        void Read(const ComPtr<IStream>& stream, bool isZip64);
+        void Read(const ComPtr<IStream>& stream, uint64_t baseOffset, bool isZip64);
 
         GeneralPurposeBitFlags GetGeneralPurposeBitFlags() const noexcept { return static_cast<GeneralPurposeBitFlags>(Field<3>().get()); }
 

--- a/src/inc/shared/StreamBase.hpp
+++ b/src/inc/shared/StreamBase.hpp
@@ -143,6 +143,20 @@ namespace MSIX {
             return result;
         }
 
+        static void ReadData(const ComPtr<IStream>& stream, std::vector<std::uint8_t>& data)
+        {
+            ULONG size = 0;
+            ThrowHrIfFailed(stream->Read(reinterpret_cast<void*>(data.data()), static_cast<ULONG>(data.size()), &size));
+            ThrowErrorIfNot(Error::FileRead, size == data.size(), "entire vector not read!");
+        }
+
+        static uint64_t Pos(const ComPtr<IStream>& stream)
+        {
+            ULARGE_INTEGER uPos{0};
+            ThrowHrIfFailed(stream->Seek({0}, Reference::CURRENT, &uPos));
+            return uPos.QuadPart;
+        }
+
         template <class T>
         static void Write(const ComPtr<IStream>& stream, T* value)
         {

--- a/src/msix/common/Encoding.cpp
+++ b/src/msix/common/Encoding.cpp
@@ -345,7 +345,7 @@ namespace MSIX { namespace Encoding {
     // Douglas Crockford's base 32 alphabet variant is 0-9, A-Z except for i, l, o, and u.
     const char base32DigitList[] = "0123456789abcdefghjkmnpqrstvwxyz";
 
-    std::string Base32Encoding(const std::vector<std::uint8_t>& bytes)
+    std::string Base32Encoding(const std::vector<uint8_t>& bytes)
     {
         const size_t publisherIdSize = 13;
         const size_t byteCount = 8;

--- a/src/msix/unpack/AppxPackageObject.cpp
+++ b/src/msix/unpack/AppxPackageObject.cpp
@@ -343,9 +343,6 @@ namespace MSIX {
                         }
                         return result;
                     });
-
-                    auto blockMapStream = m_appxBlockMap->GetValidationStream(fileName, fileStream);
-                    m_files[opcFileName] = MSIX::ComPtr<IAppxFile>::Make<MSIX::AppxFile>(m_factory.Get(), fileName, std::move(blockMapStream));
                     filesToProcess.erase(std::remove(filesToProcess.begin(), filesToProcess.end(), opcFileName), filesToProcess.end());
                 }
             }
@@ -557,10 +554,6 @@ namespace MSIX {
         for (const auto& fileName : GetFileNames(FileNameOptions::PayloadOnly))
         {
             auto file = GetAppxFile(fileName);
-            // Clients expect the stream's pointer to be at the start of the file!
-            ComPtr<IStream> stream;
-            ThrowHrIfFailed(file->GetStream(&stream));
-            ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::START, nullptr));
             files.push_back(std::move(file));
         }
         *filesEnumerator = ComPtr<IAppxFilesEnumerator>::
@@ -634,10 +627,6 @@ namespace MSIX {
         ThrowErrorIf(Error::InvalidParameter, (fileName == nullptr || file == nullptr || *file != nullptr), "bad pointer");
         auto result = GetAppxFile(Encoding::EncodeFileName(fileName));
         ThrowErrorIfNot(Error::FileNotFound, result, "requested file not in package")
-        // Clients expect the stream's pointer to be at the start of the file!
-        ComPtr<IStream> stream;
-        ThrowHrIfFailed(result->GetStream(&stream));
-        ThrowHrIfFailed(stream->Seek({0}, StreamBase::Reference::START, nullptr));
         *file = result.Detach();
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();

--- a/src/msix/unpack/ZipObjectReader.cpp
+++ b/src/msix/unpack/ZipObjectReader.cpp
@@ -72,10 +72,10 @@ namespace MSIX {
         std::vector<std::string> ZipObjectReader::GetFileNames(FileNameOptions)
     {
         std::vector<std::string> result;
-        std::for_each(m_centralDirectories.begin(), m_centralDirectories.end(), [&result](auto it)
+        for (auto& dir : m_centralDirectories)
         {
-            result.push_back(it.first);
-        });
+            result.push_back(dir.first);
+        }
         return result;
     }
 


### PR DESCRIPTION
### Change 1:
Defer evaluation IAppxFile's underlying stream

During the client MSIX scenario, when deploying via the DO transport, we were seeing that effectively the whole client MSIX file was being streamed to the local device. After a bunch of debugging, we figured out that the culprit to this is that the MSIX SDK is validating that every file (whether read or not) that's specified within the central directory is also covered by the blockmap, AND that the size recorded in the blockmap is the size recorded in the underlying OPC structures. This sounds great and all, but there's two problems, 1) in order to properly validate the OPC's metadata w.r.t. a file, a structure at the beginning of each file must be read from the OPC stream before the zip interface can answer how big a particular part of the file is. and 2) we end up doing this validation for EVERY file, whether its actually required for the deployment or not; which is HUGELY inefficient w.r.t. not only memory, but I/O.

The fix then, is to lazily perform this sort of validation, delaying it until the caller actually requests the underlying stream for a corresponding IAppxFile. This ensures that before a file's contents are accessed, it's metadata aligns with what's specified in the blockmap, but also, it ensures that the I/O on the underlying file's metadata in the OPC structure (which sequentially comes just before the file) is done right before the file's contents are most likely to be read.

### Change 2:
Http transport usage is terrible

The change reduces the rather verbose/chatty usage of the underlying stream in the zip reader layer of the MSIX SDK to being a little bit smarter. Basically, when we know how big a structure is, rather than reading it piecemeal (e.g. 2, 4, or 8 bytes at a time), we calculate the whole structure's size, and read those bytes all at once into a stack-local buffer, and then use that in-memory copy to perform the remaining serialization.

The biggest part of the change is when it comes to reading the zip central directory. Since each and every one of those structs are variable size, but they all MUST come sequentially, one after the other, from the start of the 1st instance all the way to the zip footer, we can read that entire sequence into memory and use the existing "small read/chatty/verbose" pattern, as that's going to consume what's in-memory as opposed to dozens of small reads times potentially hundreds to thousands of files.