### PR TITLE
Bring changes from office over

### DIFF
--- a/src/inc/internal/AppxBlockMapObject.hpp
+++ b/src/inc/internal/AppxBlockMapObject.hpp
@@ -123,7 +123,7 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE ValidateFileHash(IStream *fileStream, BOOL *isValid) noexcept override
+        HRESULT STDMETHODCALLTYPE ValidateFileHash(IStream */*fileStream*/, BOOL */*isValid*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }

--- a/src/inc/internal/AppxBundleManifest.hpp
+++ b/src/inc/internal/AppxBundleManifest.hpp
@@ -53,7 +53,7 @@ namespace MSIX {
          // IVerifierObject
         bool HasStream() override { return !!m_stream; }
         ComPtr<IStream> GetStream() override { return m_stream; }
-        ComPtr<IStream> GetValidationStream(const std::string& part, const ComPtr<IStream>&) override { NOTSUPPORTED; }
+        ComPtr<IStream> GetValidationStream(const std::string& /*part*/, const ComPtr<IStream>&) override { NOTSUPPORTED; }
         const std::string& GetPublisher() override { NOTSUPPORTED; }
 
         // IAppxBundleManifestReader
@@ -91,7 +91,7 @@ namespace MSIX {
             return S_OK;
         }
 
-        HRESULT STDMETHODCALLTYPE GetDXFeatureLevel(DX_FEATURE_LEVEL *dxFeatureLevel) noexcept override
+        HRESULT STDMETHODCALLTYPE GetDXFeatureLevel(DX_FEATURE_LEVEL */*dxFeatureLevel*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }

--- a/src/inc/internal/AppxFile.hpp
+++ b/src/inc/internal/AppxFile.hpp
@@ -43,7 +43,7 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         }
 
-        virtual HRESULT STDMETHODCALLTYPE GetContentType(LPWSTR* contentType) noexcept override
+        virtual HRESULT STDMETHODCALLTYPE GetContentType(LPWSTR* /*contentType*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }
@@ -72,7 +72,7 @@ namespace MSIX {
         } CATCH_RETURN();
 
         // IAppxFileUtf8
-        virtual HRESULT STDMETHODCALLTYPE GetContentType(LPSTR* contentType) noexcept override
+        virtual HRESULT STDMETHODCALLTYPE GetContentType(LPSTR* /*contentType*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }

--- a/src/inc/internal/AppxManifestObject.hpp
+++ b/src/inc/internal/AppxManifestObject.hpp
@@ -135,7 +135,7 @@ namespace MSIX {
         {}
 
         // IAppxManifestApplication
-        HRESULT STDMETHODCALLTYPE GetStringValue(LPCWSTR name, LPWSTR* value) noexcept override
+        HRESULT STDMETHODCALLTYPE GetStringValue(LPCWSTR /*name*/, LPWSTR* /*value*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }
@@ -146,7 +146,7 @@ namespace MSIX {
         } CATCH_RETURN();
 
         // IAppxManifestApplicationUtf8
-        HRESULT STDMETHODCALLTYPE GetStringValue(LPCSTR name, LPSTR* value) noexcept override
+        HRESULT STDMETHODCALLTYPE GetStringValue(LPCSTR /*name*/, LPSTR* /*value*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }
@@ -368,7 +368,7 @@ namespace MSIX {
     class AppxManifestQualifiedResource final : public ComClass<AppxManifestQualifiedResource, IAppxManifestQualifiedResource, IAppxManifestQualifiedResourceUtf8, IAppxManifestQualifiedResourceInternal>
     {
     public:
-        AppxManifestQualifiedResource(IMsixFactory* factory, std::string& language, std::string& scale, std::string& DXFeatureLevel) :
+        AppxManifestQualifiedResource(IMsixFactory* factory, std::string& language, std::string& /*scale*/, std::string& /*DXFeatureLevel*/) :
             m_factory(factory), m_language(language)
         {
             //TODO: Process and assign scale and DXFeatureLevel
@@ -381,12 +381,12 @@ namespace MSIX {
             return m_factory->MarshalOutString(m_language, language);
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE GetScale(UINT32 *scale) noexcept override try
+        HRESULT STDMETHODCALLTYPE GetScale(UINT32 */*scale*/) noexcept override try
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE GetDXFeatureLevel(DX_FEATURE_LEVEL *dxFeatureLevel) noexcept override try
+        HRESULT STDMETHODCALLTYPE GetDXFeatureLevel(DX_FEATURE_LEVEL */*dxFeatureLevel*/) noexcept override try
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         } CATCH_RETURN();
@@ -446,7 +446,7 @@ namespace MSIX {
         // IVerifierObject
         bool HasStream() override { return !!m_stream; }
         ComPtr<IStream> GetStream() override { return m_stream; }
-        ComPtr<IStream> GetValidationStream(const std::string& part, const ComPtr<IStream>&) override { NOTSUPPORTED; }
+        ComPtr<IStream> GetValidationStream(const std::string& /*part*/, const ComPtr<IStream>&) override { NOTSUPPORTED; }
         const std::string& GetPublisher() override { NOTSUPPORTED; }
 
         // IAppxManifestObject

--- a/src/inc/internal/BlockMapStream.hpp
+++ b/src/inc/internal/BlockMapStream.hpp
@@ -3,7 +3,10 @@
 //  See LICENSE file in the project root for full license information.
 // 
 #pragma once
+#ifndef NOMINMAX
 #define NOMINMAX /* windows.h, or more correctly windef.h, defines min as a macro... */
+#endif
+
 #include "MSIXWindows.hpp"
 #include "Exceptions.hpp"
 #include "StreamBase.hpp"

--- a/src/inc/internal/BlockMapStream.hpp
+++ b/src/inc/internal/BlockMapStream.hpp
@@ -59,7 +59,7 @@ namespace MSIX {
             // Build a vector of all HashStream->RangeStream's for the blocks in the blockmap
             std::uint64_t offset = 0;
             std::uint64_t sizeRemaining = m_streamSize;
-            for (auto block = blocks.begin(); ((sizeRemaining != 0) && (block != blocks.end())); block++)
+            for (auto block = blocks.begin(); ((sizeRemaining != 0) && (block != blocks.end())); ++block)
             {
                 auto rangeStream = ComPtr<IStream>::Make<RangeStream>(offset, std::min(sizeRemaining, BLOCKMAP_BLOCK_SIZE), stream.Get());                
                 auto hashStream = ComPtr<IStream>::Make<HashStream>(rangeStream, block->hash);
@@ -104,7 +104,7 @@ namespace MSIX {
             return S_OK;
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* actualRead) noexcept override try
+        HRESULT STDMETHODCALLTYPE Read(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* actualRead) noexcept override try
         {
             std::uint32_t bytesRead = 0;
             if (m_relativePosition < m_streamSize)
@@ -114,7 +114,7 @@ namespace MSIX {
                 {
                     if ((m_currentBlock->offset + m_currentBlock->size) <= m_relativePosition)
                     {
-                        m_currentBlock++;
+                        ++m_currentBlock;
                     }
                     else if (m_currentBlock->offset <= m_relativePosition)
                     {

--- a/src/inc/internal/Encoding.hpp
+++ b/src/inc/internal/Encoding.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <string>
-#include <cstdint>
 
 namespace MSIX { namespace Encoding {
 
@@ -13,6 +12,6 @@ namespace MSIX { namespace Encoding {
     std::string EncodeFileName(const std::string& fileName);
 
     std::string Base32Encoding(const std::vector<uint8_t>& bytes);
-    std::vector<std::uint8_t> GetBase64DecodedValue(const std::string& value);
+    std::vector<uint8_t> GetBase64DecodedValue(const std::string& value);
 
 } /*Encoding */ } /* MSIX */

--- a/src/inc/internal/FileStream.hpp
+++ b/src/inc/internal/FileStream.hpp
@@ -85,7 +85,7 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
+        HRESULT STDMETHODCALLTYPE Read(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
         {
             if (bytesRead) { *bytesRead = 0; }
             ULONG result = static_cast<ULONG>(std::fread(buffer, sizeof(std::uint8_t), countBytes, m_file));

--- a/src/inc/internal/HashStream.hpp
+++ b/src/inc/internal/HashStream.hpp
@@ -3,7 +3,10 @@
 //  See LICENSE file in the project root for full license information.
 // 
 #pragma once
+#ifndef NOMINMAX
 #define NOMINMAX /* windows.h, or more correctly windef.h, defines min as a macro... */
+#endif
+
 #include "MSIXWindows.hpp"
 #include "Exceptions.hpp"
 #include "StreamBase.hpp"

--- a/src/inc/internal/HashStream.hpp
+++ b/src/inc/internal/HashStream.hpp
@@ -98,7 +98,7 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         } CATCH_RETURN();
 
-        void CacheRead(void* buffer, ULONG countBytes, ULONG* actualRead)
+        void CacheRead(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* actualRead)
         {
             ThrowErrorIf(Error::Stg_E_Invalidpointer, (buffer == nullptr), "bad input");
             ULONG bytesToRead = std::min((std::uint32_t)countBytes, static_cast<std::uint32_t>((std::uint64_t)m_cacheBuffer->size() - m_relativePosition));
@@ -112,7 +112,7 @@ namespace MSIX {
             if (actualRead) { *actualRead = bytesToRead; }
         }
 
-        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* actualRead) noexcept override try
+        HRESULT STDMETHODCALLTYPE Read(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* actualRead) noexcept override try
         {
             Validate();
             if (m_cacheBuffer.get() == nullptr)

--- a/src/inc/internal/InflateStream.hpp
+++ b/src/inc/internal/InflateStream.hpp
@@ -26,7 +26,7 @@ namespace MSIX {
 
         HRESULT STDMETHODCALLTYPE Seek(LARGE_INTEGER move, DWORD origin, ULARGE_INTEGER *newPosition) noexcept override;
         HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override;
-        HRESULT STDMETHODCALLTYPE Write(void const *buffer, ULONG countBytes, ULONG *bytesWritten) noexcept override
+        HRESULT STDMETHODCALLTYPE Write(void const */*buffer*/, ULONG /*countBytes*/, ULONG */*bytesWritten*/) noexcept override
         {
             return static_cast<HRESULT>(Error::NotImplemented);
         }

--- a/src/inc/internal/MappingFileParser.hpp
+++ b/src/inc/internal/MappingFileParser.hpp
@@ -9,13 +9,13 @@
 
 namespace MSIX {
 
-    typedef enum : UINT32
+    enum HandlerState : UINT32
     {
         Continue = 0,
         Stop,
         SkipSection,
         Fail
-    } HandlerState;
+    };
 
     enum SectionID
     {

--- a/src/inc/internal/ObjectBase.hpp
+++ b/src/inc/internal/ObjectBase.hpp
@@ -176,7 +176,7 @@ public:
     std::tuple<Types...> fields;
 
     template<std::size_t index = 0, typename FuncT, class... Args>
-    inline typename std::enable_if<index == last_index, void>::type for_each(FuncT, Args&&... args) { }
+    inline typename std::enable_if<index == last_index, void>::type for_each(FuncT, Args&&... /*args*/) { }
 
     template<std::size_t index = 0, typename FuncT, class... Args>
     inline typename std::enable_if<index < last_index, void>::type for_each(FuncT f, Args&&... args)
@@ -202,7 +202,7 @@ public:
     size_t Size()
     {
         size_t result = 0;
-        this->for_each([](auto& field, std::size_t index, size_t& result)
+        this->for_each([](auto& field, std::size_t /*index*/, size_t& result)
         {
             result += field.Size();
         }, result);
@@ -213,7 +213,7 @@ public:
     {
         THROW_IF_PACK_NOT_ENABLED
         std::vector<std::uint8_t> bytes;
-        this->for_each([](auto& field, std::size_t index, std::vector<std::uint8_t>& bytes)
+        this->for_each([](auto& field, std::size_t /*index*/, std::vector<std::uint8_t>& bytes)
         {
             field.GetBytes(bytes);
         }, bytes);

--- a/src/inc/internal/RangeStream.hpp
+++ b/src/inc/internal/RangeStream.hpp
@@ -73,7 +73,7 @@ namespace MSIX {
             return static_cast<HRESULT>(Error::OK);
         } CATCH_RETURN();
 
-        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
+        HRESULT STDMETHODCALLTYPE Read(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
         {
             LARGE_INTEGER offset = {0};
             offset.QuadPart = m_relativePosition + m_offset;

--- a/src/inc/internal/VectorStream.hpp
+++ b/src/inc/internal/VectorStream.hpp
@@ -18,7 +18,7 @@ namespace MSIX {
     public:
         VectorStream(std::vector<std::uint8_t>* data) : m_data(data) {}
 
-        HRESULT STDMETHODCALLTYPE Read(void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
+        HRESULT STDMETHODCALLTYPE Read(_Out_cap_(countBytes) void* buffer, ULONG countBytes, ULONG* bytesRead) noexcept override try
         {
             ULONG amountToRead = std::min(countBytes, static_cast<ULONG>(m_data->size() - m_offset));
             if (amountToRead > 0) { memcpy(buffer, &(m_data->at(m_offset)), amountToRead); }                

--- a/src/inc/internal/ZipObject.hpp
+++ b/src/inc/internal/ZipObject.hpp
@@ -455,7 +455,6 @@ namespace MSIX {
     {
     public:
         ZipObject(const ComPtr<IStream>& stream) : m_stream(stream) {}
-        ZipObject(const ComPtr<IStorageObject>& storageObject);
 
     protected:
         EndCentralDirectoryRecord m_endCentralDirectoryRecord;

--- a/src/inc/internal/ZipObjectWriter.hpp
+++ b/src/inc/internal/ZipObjectWriter.hpp
@@ -46,8 +46,6 @@ namespace MSIX {
     public:
         ZipObjectWriter(const ComPtr<IStream>& stream);
 
-        ZipObjectWriter(const ComPtr<IStorageObject>& storageObject);
-
         // IStorage methods
         std::vector<std::string> GetFileNames(FileNameOptions options) override;
         ComPtr<IStream> GetFile(const std::string& fileName) override;

--- a/src/inc/public/MSIXWindows.hpp
+++ b/src/inc/public/MSIXWindows.hpp
@@ -21,7 +21,9 @@
     #endif
 
     #define UNICODE
+#ifndef NOMINMAX
     #define NOMINMAX
+#endif
     #include <windows.h>
     // Windows.h defines max and min, which does NOT play nice at all with std::min / std::max usage from <algorithm>
     #undef max

--- a/src/inc/public/MsixErrors.hpp
+++ b/src/inc/public/MsixErrors.hpp
@@ -6,6 +6,8 @@
 #ifndef MSIX_MSIX_ERRORS__H
 #define MSIX_MSIX_ERRORS__H
 
+#include <cstdint>
+
 namespace MSIX {
 
     static const std::uint32_t ERROR_FACILITY = 0x8BAD0000;              // Facility 2989

--- a/src/inc/public/MsixErrors.hpp
+++ b/src/inc/public/MsixErrors.hpp
@@ -6,7 +6,10 @@
 #ifndef MSIX_MSIX_ERRORS__H
 #define MSIX_MSIX_ERRORS__H
 
+#ifdef WIN32
 #include <cstdint>
+#endif
+
 
 namespace MSIX {
 

--- a/src/inc/shared/StreamBase.hpp
+++ b/src/inc/shared/StreamBase.hpp
@@ -135,7 +135,7 @@ namespace MSIX {
         virtual std::string GetName() override { NOTIMPLEMENTED; }
 
         template <class T>
-        static ULONG Read(const ComPtr<IStream>& stream, T* value)
+        static ULONG Read(const ComPtr<IStream>& stream, _Out_cap_(sizeof(T)) T* value)
         {
             ULONG result = 0;
             ThrowHrIfFailed(stream->Read(value, static_cast<ULONG>(sizeof(T)), &result));

--- a/src/makemsix/main.cpp
+++ b/src/makemsix/main.cpp
@@ -656,6 +656,7 @@ Command CreateBundleCommand()
 #pragma endregion
 
 // Defines the grammar of commands and each command's associated options,
+#pragma warning(suppress: 4007) // Suppress 'main': must be '__cdecl'
 int main(int argc, char* argv[])
 {
     std::cout << "Microsoft (R) makemsix version " << SDK_VERSION << std::endl;

--- a/src/msix/PAL/Applicability/Win32/Applicability.cpp
+++ b/src/msix/PAL/Applicability/Win32/Applicability.cpp
@@ -4,8 +4,8 @@
 //
 #include <windows.h>
 #include <VersionHelpers.h>
-#include <wrl\wrappers\corewrappers.h>
-#include <wrl\client.h>
+#include <wrl/wrappers/corewrappers.h>
+#include <wrl/client.h>
 #include <windows.system.userprofile.h>
 
 #include "Applicability.hpp"

--- a/src/msix/PAL/Crypto/Win32/Crypto.cpp
+++ b/src/msix/PAL/Crypto/Win32/Crypto.cpp
@@ -14,6 +14,7 @@
 
 #include <memory>
 #include <vector>
+#include <wincrypt.h>
 
 struct unique_hash_handle_deleter {
     void operator()(BCRYPT_HASH_HANDLE h) const {

--- a/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
+++ b/src/msix/PAL/FileSystem/Win32/DirectoryObject.cpp
@@ -41,7 +41,7 @@ namespace MSIX
         }
 
         template <class Lambda>
-        void WalkDirectory(const std::string& root, WalkOptions options, Lambda& visitor)
+        void WalkDirectory(const std::string& root, WalkOptions options, Lambda visitor)
         {
             static std::string dot(".");
             static std::string dotdot("..");
@@ -323,7 +323,7 @@ namespace MSIX
         auto rootSize = m_root.size() + 1; // plus separator
         WalkDirectory(m_root, WalkOptions::Recursive | WalkOptions::Files, [&](
                 std::string root,
-                WalkOptions option,
+                WalkOptions /*option*/,
                 std::string&& name,
                 std::uint64_t lastWrite)
             {

--- a/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
+++ b/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
@@ -346,7 +346,7 @@ namespace MSIX
                 &cbDecoded))
         {
             unique_local_alloc_handle basicConstraints(basicConstraintsT);
-            return basicConstraintsT->fCA ? true : false;
+            return basicConstraintsT->fCA;
         }
         return false;
     }
@@ -495,6 +495,7 @@ namespace MSIX
 
     bool SignatureValidator::Validate(
         IMsixFactory* factory,
+        IMsixFactory* /*factory*/,
         MSIX_VALIDATION_OPTION option,
         const ComPtr<IStream>& stream,
         AppxSignatureObject* signatureObject,

--- a/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
+++ b/src/msix/PAL/Signature/Win32/SignatureValidator.cpp
@@ -494,7 +494,6 @@ namespace MSIX
 
 
     bool SignatureValidator::Validate(
-        IMsixFactory* factory,
         IMsixFactory* /*factory*/,
         MSIX_VALIDATION_OPTION option,
         const ComPtr<IStream>& stream,

--- a/src/msix/PAL/XML/msxml6/XmlObject.cpp
+++ b/src/msix/PAL/XML/msxml6/XmlObject.cpp
@@ -121,7 +121,7 @@ public:
 
     VARIANT* AddressOf()
     {
-        VariantClear(&m_variant);
+        (void)VariantClear(&m_variant);
         return &m_variant;
     }
 
@@ -220,10 +220,10 @@ public:
         Bstr xPath(xpath);
         ThrowHrIfFailed(m_element->selectNodes(xPath, &list));
 
-        long count = 0;
+        LONG count = 0;
         ThrowHrIfFailed(list->get_length(&count));
         std::vector<ComPtr<IMsixElement>> elementsEnum;
-        for(long index=0; index < count; index++)
+        for(LONG index=0; index < count; index++)
         {
             ComPtr<IXMLDOMNode> node;
             ThrowHrIfFailed(list->get_item(index, &node));
@@ -286,10 +286,10 @@ protected:
         Bstr xPath(xpath);
         ThrowHrIfFailed(m_element->selectNodes(xPath, &list));
 
-        long count = 0;
+        LONG count = 0;
         ThrowHrIfFailed(list->get_length(&count));
         std::vector<ComPtr<IMsixElement>> elementsEnum;
-        for(long index=0; index < count; index++)
+        for(LONG index=0; index < count; index++)
         {
             ComPtr<IXMLDOMNode> node;
             ThrowHrIfFailed(list->get_item(index, &node));
@@ -351,7 +351,7 @@ public:
                 ComPtr<IStream> resource(m_factory->GetResource(item.schema));
                 auto schema = ComPtr<IMSXMLDom>::Make<MSXMLDom>(resource, emptyManager)->GetDomDocument();
 
-                long readyState = 0;
+                LONG readyState = 0;
                 ThrowHrIfFailed(schema->get_readyState(&readyState));
                 ThrowErrorIfNot(Error::Unexpected, (4 == readyState), "The document has not been completely loaded.");
 
@@ -412,12 +412,12 @@ public:
                 ComPtr<IXMLDOMNodeList> namespaceAliasesToStrip;
                 Bstr ignorableNamespaces(L"@IgnorableNamespaces");
                 ThrowHrIfFailed(element->selectNodes(ignorableNamespaces, &namespaceAliasesToStrip));
-                long count = 0;
+                LONG count = 0;
                 ThrowHrIfFailed(namespaceAliasesToStrip->get_length(&count));
                 ThrowErrorIf(Error::XmlError, (count > 1), "Only one IgnorableNamespaces attribute allowed");
 
                 std::vector<std::wstring> aliasesToLookup;
-                for(long index=0; index < count; index++)
+                for(LONG index=0; index < count; index++)
                 {   // get the list of ignorable namespace aliases
                     ComPtr<IXMLDOMNode> node;
                     ThrowHrIfFailed(namespaceAliasesToStrip->get_item(index, &node));
@@ -450,15 +450,15 @@ public:
                     Variant attributeValue;
                     ThrowHrIfFailed(attribute->get_nodeValue(attributeValue.AddressOf()));
                     ThrowErrorIf(Error::XmlError, (VT_NULL == attributeValue.Get().vt), "ignorable namespace alias has empty target namespace URI.");
-                    std::wstring uri(reinterpret_cast<WCHAR*>(attributeValue.Get().bstrVal));
+                    std::wstring uri(attributeValue.Get().bstrVal);
                     std::transform(uri.begin(), uri.end(), uri.begin(), ::tolower);
                     // next we look for that uri against our namespace manager
                     const auto& result = std::find(namespaces.begin(), namespaces.end(), uri.c_str());
                     if (result == namespaces.end())
                     {   // the namespace specified is unknown to us.  remove everything with the specified alias!
                         std::wostringstream xPath;
-                        xPath << L"//*[namespace-uri()='"       << reinterpret_cast<WCHAR*>(attributeValue.Get().bstrVal)
-                              << L"' or //@*[namespace-uri()='" << reinterpret_cast<WCHAR*>(attributeValue.Get().bstrVal)
+                        xPath << L"//*[namespace-uri()='"       << attributeValue.Get().bstrVal
+                              << L"' or //@*[namespace-uri()='" << attributeValue.Get().bstrVal
                               << L"']]";
                         Bstr query(xPath.str());
                         ComPtr<IXMLDOMNodeList> ignorableNodes;
@@ -479,7 +479,7 @@ public:
         if (VARIANT_FALSE == success) { ThrowHrIfFailed(m_xmlDocument->get_parseError(&error)); }
         if (stripIgnorableNamespaces && nullptr == error.Get())
         {
-            long readyState = 0;
+            LONG readyState = 0;
             ThrowHrIfFailed(m_xmlDocument->get_readyState(&readyState));
             ThrowErrorIfNot(Error::Unexpected, (4 == readyState), "The document has not been completely loaded.");
             ThrowHrIfFailed(m_xmlDocument->validate(&error));
@@ -487,7 +487,7 @@ public:
 
         if(error)
         {
-            long errorCode = 0, lineNumber = 0, columnNumber = 0;
+            LONG errorCode = 0, lineNumber = 0, columnNumber = 0;
             ThrowHrIfFailed(error->get_errorCode(&errorCode));
             if (0 != errorCode)
             {
@@ -504,13 +504,13 @@ public:
                 // XML into generic Xml errors and leave the full details in the log.
                 if (UNDECLAREDPREFIX == errorCode || DECLARATION_NOTFOUND == errorCode)
                 {   // file is either invalid XML, or it's valid, but no schema was found for it.
-                    errorCode = static_cast<long>(Error::XmlFatal);
+                    errorCode = static_cast<LONG>(Error::XmlFatal);
                 }
                 else if (ELEMENT_EMPTY == errorCode || INVALID_CONTENT == errorCode)
                 {   // file is valid XML, but it failed according to the schema provided.
-                    errorCode = static_cast<long>(Error::XmlError);
+                    errorCode = static_cast<LONG>(Error::XmlError);
                 }
-                ThrowErrorIf(errorCode, (true), message.str().c_str());
+                ThrowErrorAndLog(errorCode, message.str().c_str());
             }
         }
     }
@@ -536,9 +536,9 @@ public:
         ComPtr<IMSXMLElement> element = root.As<IMSXMLElement>();
         ComPtr<IXMLDOMNodeList> list = element->SelectNodes(query);
 
-        long count = 0;
+        LONG count = 0;
         ThrowHrIfFailed(list->get_length(&count));
-        for(long index=0; index < count; index++)
+        for(LONG index=0; index < count; index++)
         {
             ComPtr<IXMLDOMNode> node;
             ThrowHrIfFailed(list->get_item(index, &node));
@@ -571,7 +571,7 @@ public:
 
     ~MSXMLFactory() { if (m_CoInitialized) { CoUninitialize(); m_CoInitialized = false; } }
 
-    ComPtr<IXmlDom> CreateDomFromStream(XmlContentType footPrintType, const ComPtr<IStream>& stream) override
+    ComPtr<IXmlDom> CreateDomFromStream(XmlContentType /*footPrintType*/, const ComPtr<IStream>& stream) override
     {
         NamespaceManager emptyManager;
 

--- a/src/msix/common/AppxFactory.cpp
+++ b/src/msix/common/AppxFactory.cpp
@@ -97,6 +97,8 @@ namespace MSIX {
         auto zip = ComPtr<IZipWriter>::Make<ZipObjectWriter>(outputStream);
         auto result = ComPtr<IAppxBundleWriter>::Make<AppxBundleWriter>(self.Get(), zip, bundleVersion);
         *bundleWriter = result.Detach();
+        #else
+        (void) bundleVersion;
         #endif
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -119,6 +121,8 @@ namespace MSIX {
         ComPtr<IStream> input(inputStream);
         auto result = ComPtr<IAppxBundleManifestReader>::Make<AppxBundleManifestObject>(this, input);
         *manifestReader = result.Detach();
+        #else
+        (void) inputStream;
         #endif
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
@@ -175,7 +179,7 @@ namespace MSIX {
     ComPtr<IStream> AppxFactory::GetResource(const std::string& resource)
     {
         // Short-circuit the case where there were no resources and throw not found immediately.
-        if (Resource::resourceLength <= 1)
+        if constexpr (Resource::resourceLength <= 1)
         {
             ThrowErrorAndLog(Error::FileNotFound, resource.c_str());
         }

--- a/src/msix/common/AppxManifestObject.cpp
+++ b/src/msix/common/AppxManifestObject.cpp
@@ -29,51 +29,51 @@ namespace MSIX {
 
     // ALL THE TargetDeviceFamily ENTRIES MUST BE LOWER-CASE
     static const Entry<MSIX_PLATFORMS> targetDeviceFamilyList[] = {
-        Entry<MSIX_PLATFORMS>(u8"windows.universal",      MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.mobile",         MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.desktop",        MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.xbox",           MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.team",           MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.holographic",    MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.iot",            MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"windows.server",         MSIX_PLATFORM_WINDOWS10),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.all",          MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.phone",        MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.tablet",       MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.tv",           MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.ios.watch",        MSIX_PLATFORM_IOS),
-        Entry<MSIX_PLATFORMS>(u8"apple.macos.all",        MSIX_PLATFORM_MACOS),
-        Entry<MSIX_PLATFORMS>(u8"google.android.all",     MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.phone",   MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.tablet",  MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.desktop", MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.tv",      MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"google.android.watch",   MSIX_PLATFORM_AOSP),
-        Entry<MSIX_PLATFORMS>(u8"msixcore.desktop",       MSIX_PLATFORM_CORE),
-        Entry<MSIX_PLATFORMS>(u8"msixcore.server",        MSIX_PLATFORM_CORE),
-        Entry<MSIX_PLATFORMS>(u8"linux.all",              MSIX_PLATFORM_LINUX),
-        Entry<MSIX_PLATFORMS>(u8"web.edge.all",           MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.blink.all",          MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.chromium.all",       MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.webkit.all",         MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.safari.all",         MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"web.all",                MSIX_PLATFORM_WEB),
-        Entry<MSIX_PLATFORMS>(u8"platform.all",           static_cast<MSIX_PLATFORMS>(MSIX_PLATFORM_ALL)),
+        Entry<MSIX_PLATFORMS>("windows.universal",      MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.mobile",         MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.desktop",        MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.xbox",           MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.team",           MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.holographic",    MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.iot",            MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("windows.server",         MSIX_PLATFORM_WINDOWS10),
+        Entry<MSIX_PLATFORMS>("apple.ios.all",          MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.phone",        MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.tablet",       MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.tv",           MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.ios.watch",        MSIX_PLATFORM_IOS),
+        Entry<MSIX_PLATFORMS>("apple.macos.all",        MSIX_PLATFORM_MACOS),
+        Entry<MSIX_PLATFORMS>("google.android.all",     MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.phone",   MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.tablet",  MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.desktop", MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.tv",      MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("google.android.watch",   MSIX_PLATFORM_AOSP),
+        Entry<MSIX_PLATFORMS>("msixcore.desktop",       MSIX_PLATFORM_CORE),
+        Entry<MSIX_PLATFORMS>("msixcore.server",        MSIX_PLATFORM_CORE),
+        Entry<MSIX_PLATFORMS>("linux.all",              MSIX_PLATFORM_LINUX),
+        Entry<MSIX_PLATFORMS>("web.edge.all",           MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.blink.all",          MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.chromium.all",       MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.webkit.all",         MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.safari.all",         MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("web.all",                MSIX_PLATFORM_WEB),
+        Entry<MSIX_PLATFORMS>("platform.all",           static_cast<MSIX_PLATFORMS>(MSIX_PLATFORM_ALL)),
     };
 
     static const Entry<APPX_CAPABILITIES> capabilitiesList[] = {
-        Entry<APPX_CAPABILITIES>(u8"internetClient",             APPX_CAPABILITY_INTERNET_CLIENT),
-        Entry<APPX_CAPABILITIES>(u8"internetClientServer",       APPX_CAPABILITY_INTERNET_CLIENT_SERVER),
-        Entry<APPX_CAPABILITIES>(u8"privateNetworkClientServer", APPX_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER),
-        Entry<APPX_CAPABILITIES>(u8"documentsLibrary",           APPX_CAPABILITY_DOCUMENTS_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"picturesLibrary",            APPX_CAPABILITY_PICTURES_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"videosLibrary",              APPX_CAPABILITY_VIDEOS_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"musicLibrary",               APPX_CAPABILITY_MUSIC_LIBRARY),
-        Entry<APPX_CAPABILITIES>(u8"enterpriseAuthentication",   APPX_CAPABILITY_ENTERPRISE_AUTHENTICATION),
-        Entry<APPX_CAPABILITIES>(u8"sharedUserCertificates",     APPX_CAPABILITY_SHARED_USER_CERTIFICATES),
-        Entry<APPX_CAPABILITIES>(u8"removableStorage",           APPX_CAPABILITY_REMOVABLE_STORAGE),
-        Entry<APPX_CAPABILITIES>(u8"appointments",               APPX_CAPABILITY_APPOINTMENTS),
-        Entry<APPX_CAPABILITIES>(u8"contacts",                   APPX_CAPABILITY_CONTACTS),
+        Entry<APPX_CAPABILITIES>("internetClient",             APPX_CAPABILITY_INTERNET_CLIENT),
+        Entry<APPX_CAPABILITIES>("internetClientServer",       APPX_CAPABILITY_INTERNET_CLIENT_SERVER),
+        Entry<APPX_CAPABILITIES>("privateNetworkClientServer", APPX_CAPABILITY_PRIVATE_NETWORK_CLIENT_SERVER),
+        Entry<APPX_CAPABILITIES>("documentsLibrary",           APPX_CAPABILITY_DOCUMENTS_LIBRARY),
+        Entry<APPX_CAPABILITIES>("picturesLibrary",            APPX_CAPABILITY_PICTURES_LIBRARY),
+        Entry<APPX_CAPABILITIES>("videosLibrary",              APPX_CAPABILITY_VIDEOS_LIBRARY),
+        Entry<APPX_CAPABILITIES>("musicLibrary",               APPX_CAPABILITY_MUSIC_LIBRARY),
+        Entry<APPX_CAPABILITIES>("enterpriseAuthentication",   APPX_CAPABILITY_ENTERPRISE_AUTHENTICATION),
+        Entry<APPX_CAPABILITIES>("sharedUserCertificates",     APPX_CAPABILITY_SHARED_USER_CERTIFICATES),
+        Entry<APPX_CAPABILITIES>("removableStorage",           APPX_CAPABILITY_REMOVABLE_STORAGE),
+        Entry<APPX_CAPABILITIES>("appointments",               APPX_CAPABILITY_APPOINTMENTS),
+        Entry<APPX_CAPABILITIES>("contacts",                   APPX_CAPABILITY_CONTACTS),
     };
 
     AppxManifestObject::AppxManifestObject(IMsixFactory* factory, const ComPtr<IStream>& stream) : m_factory(factory), m_stream(stream)
@@ -304,13 +304,13 @@ namespace MSIX {
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE AppxManifestObject::GetDeviceCapabilities(IAppxManifestDeviceCapabilitiesEnumerator **deviceCapabilities) noexcept
+    HRESULT STDMETHODCALLTYPE AppxManifestObject::GetDeviceCapabilities(IAppxManifestDeviceCapabilitiesEnumerator **/*deviceCapabilities*/) noexcept
     {
         return static_cast<HRESULT>(Error::NotImplemented);
     }
 
     // This method became deprecated as of Windows 8.1, use GetTargetDeviceFamilies instead.
-    HRESULT STDMETHODCALLTYPE AppxManifestObject::GetPrerequisite(LPCWSTR name, UINT64 *value) noexcept
+    HRESULT STDMETHODCALLTYPE AppxManifestObject::GetPrerequisite(LPCWSTR /*name*/, UINT64 */*value*/) noexcept
     {
         return static_cast<HRESULT>(Error::NotImplemented);
     }

--- a/src/msix/common/AppxManifestValidation.cpp
+++ b/src/msix/common/AppxManifestValidation.cpp
@@ -47,7 +47,7 @@ namespace MSIX {
         {
             bool result = false;
             XmlVisitor visitor{ &result,
-                [](void* c, const MSIX::ComPtr<IXmlElement>& element)
+                [](void* c, const MSIX::ComPtr<IXmlElement>& /*element*/)
             {
                 *reinterpret_cast<bool*>(c) = true;
                 return false;

--- a/src/msix/common/Encoding.cpp
+++ b/src/msix/common/Encoding.cpp
@@ -186,7 +186,7 @@ namespace MSIX { namespace Encoding {
     //    where wwww = uuuuu - 1
     //
     //-----------------------------------------------------------------------------
-    void ValidateCodepoint(std::uint32_t codepoint, std::uint32_t sequenceSize)
+    void ValidateCodepoint(std::uint32_t codepoint, std::uint32_t /*sequenceSize*/)
     {
         // The valid range of Unicode code points is [U+0000, U+10FFFF]. DecodeFileName cannot generate a value larger
         // than 0x10FFFF: The "4 Byte sequence" section of code is responsible for the most significant change to the
@@ -315,7 +315,7 @@ namespace MSIX { namespace Encoding {
                     }
                     ValidateCodepoint(codepoint, sequenceSize);
 
-                    if (codepoint <= 0xFFFF) { result.push_back(codepoint); }
+                    if (codepoint <= 0xFFFF) { result.push_back(static_cast<wchar_t>(codepoint)); }
                     else
                     {   // Because of the expected range of codepoints [0x010000, 0x10FFFF], the
                         // subtraction never underflows.  What you end up with is the 11 bits after
@@ -323,9 +323,9 @@ namespace MSIX { namespace Encoding {
                         // max for the codepoint is 0x10FFFF, the max for the 11 bits minus 0x1000
                         // is 0x3FF (and the minimum is 0). OR'ed with D800 gives the range
                         // [0xD800, 0xDBFF] which is the range of the high surrogate.
-                        wchar_t ch1 = ((codepoint & 0x00FC00) >> 10) |
+                        wchar_t ch1 = static_cast<wchar_t>(((codepoint & 0x00FC00) >> 10) |
                                       (((codepoint & 0x1F0000) - 0x010000) >> 10) |
-                                      0x00D800;
+                                      0x00D800);
                         result.push_back(ch1);
                         // Since the codepoint is AND'ed with 0x3FF (the bottom 10 bits of the
                         // codepoint) and OR'ed with 0xDC00, the possible range is 0xDC00 through

--- a/src/msix/common/Encoding.cpp
+++ b/src/msix/common/Encoding.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <vector>
 #include <array>
-#include <cstdint>
 
 #include "Encoding.hpp"
 #include "Exceptions.hpp"

--- a/src/msix/common/Exceptions.cpp
+++ b/src/msix/common/Exceptions.cpp
@@ -24,7 +24,7 @@ FARPROC WINAPI MsixDelayLoadFailureHandler(unsigned /*dliNotify*/, PDelayLoadInf
     }
     ThrowErrorAndLog(HRESULT_FROM_WIN32(ERROR_PROC_NOT_FOUND), "Failed delayloading");
 }
-const PfnDliHook __pfnDliFailureHook2 = MsixDelayLoadFailureHandler;
+PfnDliHook __pfnDliFailureHook2 = MsixDelayLoadFailureHandler;
 #endif
 
 namespace MSIX {

--- a/src/msix/common/TimeHelpers.cpp
+++ b/src/msix/common/TimeHelpers.cpp
@@ -6,6 +6,7 @@
 #include "TimeHelpers.hpp"
 
 #include <chrono>
+#include <time.h>
 
 namespace MSIX {
 
@@ -13,9 +14,11 @@ namespace MSIX {
     {
         // Convert system time to local time so the zip file item can have the same time of the zip archive when
         // it is shown in zip utility tools.
+
         const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-        const auto localTime = std::localtime(&now);
-        Initialize(localTime);
+        struct tm localTime;
+        localtime_s(&localTime, &now);
+        Initialize(&localTime);
     }
 
     MsDosDateAndTime::MsDosDateAndTime(const std::tm* time)

--- a/src/msix/common/TimeHelpers.cpp
+++ b/src/msix/common/TimeHelpers.cpp
@@ -6,7 +6,7 @@
 #include "TimeHelpers.hpp"
 
 #include <chrono>
-#include <time.h>
+#include <ctime>
 
 namespace MSIX {
 
@@ -17,7 +17,11 @@ namespace MSIX {
 
         const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
         struct tm localTime;
+#ifdef WIN32
         localtime_s(&localTime, &now);
+#else
+        localtime_r(&now, &localTime);
+#endif
         Initialize(&localTime);
     }
 

--- a/src/msix/common/ZipObject.cpp
+++ b/src/msix/common/ZipObject.cpp
@@ -497,15 +497,4 @@ void EndCentralDirectoryRecord::Read(const ComPtr<IStream>& stream)
     }
 }
 
-// Use for editing a package
-ZipObject::ZipObject(const ComPtr<IStorageObject>& storageObject)
-{
-    auto other = reinterpret_cast<ZipObject*>(storageObject.Get());
-    m_endCentralDirectoryRecord = other->m_endCentralDirectoryRecord;
-    m_zip64Locator = other->m_zip64Locator;
-    m_zip64EndOfCentralDirectory = other->m_zip64EndOfCentralDirectory;
-    m_centralDirectories = std::move(other->m_centralDirectories);
-    m_stream = std::move(m_stream);
-}
-
 } // namespace MSIX

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -147,9 +147,9 @@ MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxBundleFactory(
     #if defined(WIN32) && defined(BUNDLE_SUPPORT)
         return CoCreateAppxBundleFactoryWithHeap(CoTaskMemAlloc, CoTaskMemFree, validationOption, applicabilityOptions, appxBundleFactory);
     #else
-        (VOID) applicabilityOptions;
-        (VOID) appxBundleFactory;
-        (VOID) validationOption;
+        (void) applicabilityOptions;
+        (void) appxBundleFactory;
+        (void) validationOption;
         return static_cast<HRESULT>(MSIX::Error::NotSupported);
     #endif
 }

--- a/src/msix/msix.cpp
+++ b/src/msix/msix.cpp
@@ -147,6 +147,9 @@ MSIX_API HRESULT STDMETHODCALLTYPE CoCreateAppxBundleFactory(
     #if defined(WIN32) && defined(BUNDLE_SUPPORT)
         return CoCreateAppxBundleFactoryWithHeap(CoTaskMemAlloc, CoTaskMemFree, validationOption, applicabilityOptions, appxBundleFactory);
     #else
+        (VOID) applicabilityOptions;
+        (VOID) appxBundleFactory;
+        (VOID) validationOption;
         return static_cast<HRESULT>(MSIX::Error::NotSupported);
     #endif
 }

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -115,7 +115,7 @@ namespace MSIX {
 
     // IAppxPackageWriter3
     HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFiles(UINT32 fileCount,
-        APPX_PACKAGE_WRITER_PAYLOAD_STREAM* payloadFiles, UINT64 memoryLimit) noexcept try
+        APPX_PACKAGE_WRITER_PAYLOAD_STREAM* payloadFiles, UINT64 /*memoryLimit*/) noexcept try
     {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
             auto failState = MSIX::scope_exit([this]
@@ -136,7 +136,7 @@ namespace MSIX {
 
     // IAppxPackageWriter3Utf8
     HRESULT STDMETHODCALLTYPE AppxPackageWriter::AddPayloadFiles(UINT32 fileCount,
-        APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8* payloadFiles, UINT64 memoryLimit) noexcept try
+        APPX_PACKAGE_WRITER_PAYLOAD_STREAM_UTF8* payloadFiles, UINT64 /*memoryLimit*/) noexcept try
     {
         ThrowErrorIf(Error::InvalidState, m_state != WriterState::Open, "Invalid package writer state");
         auto failState = MSIX::scope_exit([this]

--- a/src/msix/pack/XmlWriter.cpp
+++ b/src/msix/pack/XmlWriter.cpp
@@ -98,7 +98,7 @@ namespace MSIX {
         //  and all #xD characters are replaced by &#xD; 
         void XmlWriter::WriteTextValue(const std::string& value)
         {
-            for(int i = 0; i < value.size(); i++)
+            for(size_t i = 0; i < value.size(); i++)
             {
                 if (value[i] == '&')
                 {

--- a/src/msix/pack/ZipObjectWriter.cpp
+++ b/src/msix/pack/ZipObjectWriter.cpp
@@ -37,28 +37,14 @@ namespace MSIX {
     {
     }
 
-    // This is used for editing a package (aka signing)
-    ZipObjectWriter::ZipObjectWriter(const ComPtr<IStorageObject>& storageObject) : ZipObject(storageObject)
-    {
-        // The storage object provided should had already initialize all the data.
-        ThrowErrorIfNot(Error::Zip64EOCDRecord, m_endCentralDirectoryRecord.GetIsZip64(),
-            "Editing non zip64 packages not supported");
-
-        // Move the stream at the start of central directory record so we can start overwritting.
-        // Central directory data in already in m_centralDirectories.
-        LARGE_INTEGER pos = {0};
-        pos.QuadPart = m_zip64EndOfCentralDirectory.GetOffsetStartOfCD();
-        ThrowHrIfFailed(m_stream->Seek(pos, StreamBase::Reference::START, nullptr));
-    }
-
     // IStorage
-    std::vector<std::string> ZipObjectWriter::GetFileNames(FileNameOptions options)
+    std::vector<std::string> ZipObjectWriter::GetFileNames(FileNameOptions /*options*/)
     {
         // TODO: implement
         NOTIMPLEMENTED;
     }
 
-    ComPtr<IStream> ZipObjectWriter::GetFile(const std::string& fileName)
+    ComPtr<IStream> ZipObjectWriter::GetFile(const std::string& /*fileName*/)
     {
         // TODO: implement
         NOTIMPLEMENTED;

--- a/src/msix/unpack/ApplicabilityCommon.cpp
+++ b/src/msix/unpack/ApplicabilityCommon.cpp
@@ -27,9 +27,9 @@ namespace MSIX {
     // We've seen cases were uloc_toLanguageTag returns zh-CN. Add here any inconsistencies.
     // Some AppxBundleManifests have zh-CN, zh-TW, zh-HK as languages.
     static const Bcp47Entry bcp47List[] = {
-        Bcp47Entry(u8"zh-cn", u8"zh-Hans-CN"),
-        Bcp47Entry(u8"zh-hk", u8"zh-Hant-HK"),
-        Bcp47Entry(u8"zh-tw", u8"zh-Hant-TW"),
+        Bcp47Entry("zh-cn", "zh-Hans-CN"),
+        Bcp47Entry("zh-hk", "zh-Hant-HK"),
+        Bcp47Entry("zh-tw", "zh-Hant-TW"),
     };
 
     Bcp47Tag::Bcp47Tag(const std::string& fullTag, bool allowPseudoLocale)

--- a/src/msix/unpack/ApplicabilityCommon.cpp
+++ b/src/msix/unpack/ApplicabilityCommon.cpp
@@ -57,8 +57,8 @@ namespace MSIX {
             auto position = found+1;
             found = bcp47Tag.find(delimiter, position);
             auto tag = bcp47Tag.substr(position, found - position);
-            auto maxTagLength = allowPseudoLocale ? 5 : 4;
-            ThrowErrorIf(Error::Unexpected, (tag.size() < 2 || tag.size() > maxTagLength), "Malformed Bcp47 tag");
+            auto maxTagLength = allowPseudoLocale ? 5u : 4u;
+            ThrowErrorIf(Error::Unexpected, (tag.size() < 2u || tag.size() > maxTagLength), "Malformed Bcp47 tag");
             if (tag.size() == 4)
             {   // Script tag size is always 4
                 m_script = tag;

--- a/src/msix/unpack/AppxBlockMapObject.cpp
+++ b/src/msix/unpack/AppxBlockMapObject.cpp
@@ -34,8 +34,8 @@ namespace MSIX {
     static Block GetBlock(const ComPtr<IXmlElement>& element, std::uint64_t fallbackSize)
     {
         Block result {0};
-        auto sizeAttr = GetNumber<std::uint64_t>(element, XmlAttributeName::Size, -1);
-        if (sizeAttr == -1)
+        auto sizeAttr = GetNumber<std::uint64_t>(element, XmlAttributeName::Size, UINT64_MAX);
+        if (sizeAttr == UINT64_MAX)
         {
             result.blockSize = BLOCKMAP_BLOCK_SIZE;
             result.compressedSize = fallbackSize;
@@ -140,7 +140,7 @@ namespace MSIX {
         return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
 
-    HRESULT STDMETHODCALLTYPE AppxBlockMapObject::GetHashMethod(IUri **hashMethod) noexcept
+    HRESULT STDMETHODCALLTYPE AppxBlockMapObject::GetHashMethod(IUri **/*hashMethod*/) noexcept
     {   // Ultimately, this IUri object represents the HashMethod attribute in the blockmap:
         return static_cast<HRESULT>(Error::NotImplemented);
     }

--- a/src/msix/unpack/AppxPackageObject.cpp
+++ b/src/msix/unpack/AppxPackageObject.cpp
@@ -36,7 +36,7 @@
 namespace MSIX {
 
     AppxPackageObject::AppxPackageObject(IMsixFactory* factory, MSIX_VALIDATION_OPTION validation,
-        MSIX_APPLICABILITY_OPTIONS applicabilityFlags, const ComPtr<IStorageObject>& container) :
+        MSIX_APPLICABILITY_OPTIONS /*applicabilityFlags*/, const ComPtr<IStorageObject>& container) :
         m_factory(factory),
         m_validation(validation),
         m_container(container)

--- a/src/msix/unpack/InflateStream.cpp
+++ b/src/msix/unpack/InflateStream.cpp
@@ -63,7 +63,7 @@ namespace MSIX {
             {
             case CompressionStatus::Error:
                 self->Cleanup();
-                ThrowErrorIfNot(Error::InflateCorruptData, false, "inflate failed unexpectedly.");
+                ThrowErrorAndLog(Error::InflateCorruptData, "inflate failed unexpectedly.");
                 break;
             case CompressionStatus::Ok:
             case CompressionStatus::End:
@@ -74,7 +74,7 @@ namespace MSIX {
         }), // State::READY_TO_INFLATE
 
         // State::READY_TO_COPY
-        InflateHandler([](InflateStream* self, void* buffer, ULONG countBytes)
+        InflateHandler([](InflateStream* self, _Out_cap_(countBytes) void* buffer, ULONG countBytes)
         {
             // Check if we're actually at the end of stream.
             if (self->m_fileCurrentPosition >= self->m_uncompressedSize)
@@ -184,7 +184,7 @@ namespace MSIX {
         // Can't seek beyond the end of the uncompressed stream
         seekPosition.QuadPart = std::min(seekPosition.QuadPart, static_cast<LONGLONG>(m_uncompressedSize));
 
-        if (seekPosition.QuadPart != m_seekPosition)
+        if (seekPosition.QuadPart != static_cast<LONGLONG>(m_seekPosition))
         {
             m_seekPosition = seekPosition.QuadPart;
             // If the caller is trying to seek back to an earlier


### PR DESCRIPTION
This brings over changes Office needs to build so we can more easily migrate changes in the future.

1. Comment out a bunch of unreferenced parameters.
2. Explicitly cast in comparisons
3. A few optimizations
4. Some SAL annotations
5. Remove typedef from enums. Specify default storage type for enums.
6. Remove problmatic unused ZipObject and ZipObjectWriter ctors
7. Remove u8 from char* definitions. This is incompatible with C++20 which would need to us char8_t*
8. Use localtime_s over localtime. This ctor doesn't set m_localTime so I'm not sure if this even matters.
9. Use LONG instead of long. These have different types on cross platforms