### PR TITLE
Fix case sensitive includes for `unknwn.h` and `objidl.h`

### DIFF
--- a/src/inc/internal/AppxBlockMapObject.hpp
+++ b/src/inc/internal/AppxBlockMapObject.hpp
@@ -24,8 +24,8 @@
 #ifndef WIN32
 interface IAppxBlockMapInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxBlockMapInternal : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxBundleManifest.hpp
+++ b/src/inc/internal/AppxBundleManifest.hpp
@@ -16,8 +16,8 @@
 #ifndef WIN32
 interface IBundleInfo : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IBundleInfo : public IUnknown
 #endif
 {
@@ -30,8 +30,8 @@ MSIX_INTERFACE(IBundleInfo, 0xff82ffcd,0x747a,0x4df9,0x88,0x79,0x85,0x3a,0xb9,0x
 #ifndef WIN32
 interface IAppxBundleManifestPackageInfoInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxBundleManifestPackageInfoInternal : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxBundleWriter.hpp
+++ b/src/inc/internal/AppxBundleWriter.hpp
@@ -19,8 +19,8 @@
 #ifndef WIN32
 interface IBundleWriter : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IBundleWriter : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxManifestObject.hpp
+++ b/src/inc/internal/AppxManifestObject.hpp
@@ -22,8 +22,8 @@
 #ifndef WIN32
 interface IAppxManifestObject : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxManifestObject : public IUnknown
 #endif
 {
@@ -36,8 +36,8 @@ MSIX_INTERFACE(IAppxManifestObject, 0xeff6d561,0xa236,0x4058,0x9f,0x1d,0x8f,0x93
 #ifndef WIN32
 interface IAppxManifestTargetDeviceFamilyInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxManifestTargetDeviceFamilyInternal : public IUnknown
 #endif
 {
@@ -50,8 +50,8 @@ MSIX_INTERFACE(IAppxManifestTargetDeviceFamilyInternal, 0xdaf72e2b,0x6252,0x4ed3
 #ifndef WIN32
 interface IAppxManifestQualifiedResourceInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxManifestQualifiedResourceInternal : public IUnknown
 #endif
 {
@@ -64,8 +64,8 @@ MSIX_INTERFACE(IAppxManifestQualifiedResourceInternal, 0x9e2fb304,0xcec6,0x4ef0,
 #ifndef WIN32
 interface IAppxManifestMainPackageDependencyInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxManifestMainPackageDependencyInternal : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxPackageInfo.hpp
+++ b/src/inc/internal/AppxPackageInfo.hpp
@@ -19,8 +19,8 @@
 #ifndef WIN32
 interface IAppxManifestPackageIdInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IAppxManifestPackageIdInternal : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxPackageObject.hpp
+++ b/src/inc/internal/AppxPackageObject.hpp
@@ -30,8 +30,8 @@
 #ifndef WIN32
 interface IPackage : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IPackage : public IUnknown
 #endif
 {

--- a/src/inc/internal/AppxPackageWriter.hpp
+++ b/src/inc/internal/AppxPackageWriter.hpp
@@ -20,8 +20,8 @@
 #ifndef WIN32
 interface IPackageWriter : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IPackageWriter : public IUnknown
 #endif
 {

--- a/src/inc/internal/DirectoryObject.hpp
+++ b/src/inc/internal/DirectoryObject.hpp
@@ -20,8 +20,8 @@
 #ifndef WIN32
 interface IDirectoryObject : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IDirectoryObject : public IUnknown
 #endif
 {

--- a/src/inc/internal/IXml.hpp
+++ b/src/inc/internal/IXml.hpp
@@ -84,8 +84,8 @@ enum class XmlAttributeName : std::uint8_t
 #ifndef WIN32
 interface IXmlElement : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IXmlElement : public IUnknown
 #endif
 // An internal interface for XML elements

--- a/src/inc/internal/MSIXFactory.hpp
+++ b/src/inc/internal/MSIXFactory.hpp
@@ -13,8 +13,8 @@
 #ifndef WIN32
 interface IMsixFactory : public IUnknown
 #else
-#include "UnKnwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IMsixFactory : public IUnknown
 #endif
 {

--- a/src/inc/internal/StorageObject.hpp
+++ b/src/inc/internal/StorageObject.hpp
@@ -35,8 +35,8 @@ inline constexpr FileNameOptions operator |(FileNameOptions a, FileNameOptions b
 #ifndef WIN32
 interface IStorageObject : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IStorageObject : public IUnknown
 #endif
 {

--- a/src/inc/internal/VerifierObject.hpp
+++ b/src/inc/internal/VerifierObject.hpp
@@ -15,8 +15,8 @@
 #ifndef WIN32
 interface IVerifierObject : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IVerifierObject : public IUnknown
 #endif
 // An internal interface for objects that are used to verify structured data represented by an underlying stream.

--- a/src/inc/internal/ZipObjectWriter.hpp
+++ b/src/inc/internal/ZipObjectWriter.hpp
@@ -20,8 +20,8 @@
 #ifndef WIN32
 interface IZipWriter : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IZipWriter : public IUnknown
 #endif
 {

--- a/src/inc/shared/StreamBase.hpp
+++ b/src/inc/shared/StreamBase.hpp
@@ -19,8 +19,8 @@
 #ifndef WIN32
 interface IStreamInternal : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IStreamInternal : public IUnknown
 #endif
 {

--- a/src/msix/PAL/XML/msxml6/XmlObject.cpp
+++ b/src/msix/PAL/XML/msxml6/XmlObject.cpp
@@ -22,8 +22,8 @@
 
 #include <msxml6.h>
 
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 // {2730f595-0c80-4f3e-8891-753b2e8c305d}
 class IMSXMLElement : public IUnknown
 // An internal interface for XML document object model

--- a/src/msix/PAL/XML/xerces-c/XmlObject.cpp
+++ b/src/msix/PAL/XML/xerces-c/XmlObject.cpp
@@ -39,8 +39,8 @@ XERCES_CPP_NAMESPACE_USE
 #ifndef WIN32
 interface IXercesElement : public IUnknown
 #else
-#include "Unknwn.h"
-#include "Objidl.h"
+#include "unknwn.h"
+#include "objidl.h"
 class IXercesElement : public IUnknown
 #endif
 {


### PR DESCRIPTION
Windows and MacOS are both case-insensitive, and hence the issue of wrong capitalisation may not have surfaced.

I am forming a recipe for cross-compilation for the Julia BinarBuilder environment, which uses Linux x86_64 as the host system. However, as it uses a sensitive file system, I encountered a linking error that could only be resolved by lowering cases for `unknwn.h` and `objidl.h`.

More on that can be found in the pull request:
https://github.com/JuliaPackaging/Yggdrasil/pull/10944