### PR TITLE
Add support for adding a payload to a package

### DIFF
--- a/src/inc/internal/AppxBundleWriter.hpp
+++ b/src/inc/internal/AppxBundleWriter.hpp
@@ -63,8 +63,9 @@ namespace MSIX {
             Failed = 3
         }
         WriterState;
-
-        void AddFileToPackage(const std::string& name, IStream* stream, bool toCompress,
+        
+        // Returns the offset of the file in the bundle
+        std::uint64_t AddFileToPackage(const std::string& name, IStream* stream, bool toCompress,
             bool addToBlockMap, const char* contentType, bool forceContentTypeOverride = false);
 
         void AddPackageReferenceInternal(std::string fileName, IStream* packageStream, bool isDefaultApplicablePackage);

--- a/src/inc/internal/ZipObjectWriter.hpp
+++ b/src/inc/internal/ZipObjectWriter.hpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <tuple>
 
 #include <zlib.h>
 
@@ -26,8 +27,8 @@ class IZipWriter : public IUnknown
 #endif
 {
 public:
-    // Writes the lfh header to the stream and return the size of the header
-    virtual std::pair<std::uint32_t, MSIX::ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) = 0;
+    // Writes the lfh header to the stream and return the offset of the header, size of the header and the stream
+    virtual std::tuple<std::uint64_t, std::uint32_t, MSIX::ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) = 0;
 
     // Ends the file, rewrites the LFH or writes data descriptor and adds an entry
     // to the central directories map
@@ -54,7 +55,7 @@ namespace MSIX {
         std::string GetFileName() override { NOTIMPLEMENTED };
 
         // IZipWriter
-        std::pair<std::uint32_t, ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) override;
+        std::tuple<std::uint64_t, std::uint32_t, ComPtr<IStream>> PrepareToAddFile(const std::string& name, bool isCompressed) override;
         void EndFile(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize, bool forceDataDescriptor) override;
         void Close() override;
 

--- a/src/msix/pack/AppxBundleWriter.cpp
+++ b/src/msix/pack/AppxBundleWriter.cpp
@@ -62,6 +62,10 @@ namespace MSIX {
                 {
                     ThrowHrIfFailed(AddPackageReference(utf8_to_wstring(file.second).c_str(), stream.Get(), false));
                 }
+                else
+                {
+                    ThrowHrIfFailed(AddPayloadPackage(utf8_to_wstring(file.second).c_str(), stream.Get(), false));
+                }
             }
         }
 
@@ -91,6 +95,10 @@ namespace MSIX {
                 if (flatBundle)
                 {
                     ThrowHrIfFailed(AddPackageReference(utf8_to_wstring(outputPath).c_str(), stream.Get(), false));
+                }
+                else
+                {
+                    ThrowHrIfFailed(AddPayloadPackage(utf8_to_wstring(outputPath).c_str(), stream.Get(), false));
                 }
             }
         }

--- a/src/msix/pack/AppxBundleWriter.cpp
+++ b/src/msix/pack/AppxBundleWriter.cpp
@@ -116,8 +116,7 @@ namespace MSIX {
     // IAppxBundleWriter
     HRESULT STDMETHODCALLTYPE AppxBundleWriter::AddPayloadPackage(LPCWSTR fileName, IStream* packageStream) noexcept try
     {
-        // TODO: implement
-        NOTIMPLEMENTED;
+        return AddPayloadPackage(fileName, packageStream, FALSE);
     } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE AppxBundleWriter::Close() noexcept try
@@ -176,8 +175,20 @@ namespace MSIX {
     HRESULT STDMETHODCALLTYPE AppxBundleWriter::AddPayloadPackage(LPCWSTR fileName, IStream* packageStream, 
         BOOL isDefaultApplicablePackage) noexcept try
     {
-        // TODO: implement
-        NOTIMPLEMENTED;
+        auto appxFactory = m_factory.As<IAppxFactory>();
+        ComPtr<IAppxPackageReader> reader;
+        ThrowHrIfFailed(appxFactory->CreatePackageReader(packageStream, &reader));
+
+        std::string name = wstring_to_utf8(fileName);
+        std::uint64_t offset = AddFileToPackage(name, packageStream, false, true, nullptr);
+
+        // Reset stream for reader safety
+        LARGE_INTEGER start = { 0 };
+        ThrowHrIfFailed(packageStream->Seek(start, StreamBase::Reference::START, nullptr));
+
+        std::uint64_t size = m_bundleWriterHelper.GetStreamSize(packageStream);
+        m_bundleWriterHelper.AddPackage(name, reader.Get(), offset, size, !!isDefaultApplicablePackage);
+        return static_cast<HRESULT>(Error::OK);
     } CATCH_RETURN();
 
     HRESULT STDMETHODCALLTYPE AppxBundleWriter::AddExternalPackageReference(LPCWSTR fileName,
@@ -222,7 +233,7 @@ namespace MSIX {
         AddFileToPackage(name, stream, compressionOpt != APPX_COMPRESSION_OPTION_NONE, true, contentType);
     }
 
-    void AppxBundleWriter::AddFileToPackage(const std::string& name, IStream* stream, bool toCompress,
+    std::uint64_t AppxBundleWriter::AddFileToPackage(const std::string& name, IStream* stream, bool toCompress,
         bool addToBlockMap, const char* contentType, bool forceContentTypeOverride)
     {
         std::string opcFileName;
@@ -253,10 +264,10 @@ namespace MSIX {
         // Add file to block map.
         if (addToBlockMap)
         {
-            m_blockMapWriter.AddFile(name, uncompressedSize, fileInfo.first);
+            m_blockMapWriter.AddFile(name, uncompressedSize, std::get<1>(fileInfo));
         }
 
-        auto& zipFileStream = fileInfo.second;
+        auto& zipFileStream = std::get<2>(fileInfo);
 
         std::uint64_t bytesToRead = uncompressedSize;
         std::uint32_t crc = 0;
@@ -303,6 +314,7 @@ namespace MSIX {
         // This could be the compressed or uncompressed size
         auto streamSize = zipFileStream.As<IStreamInternal>()->GetSize();
         m_zipWriter->EndFile(crc, streamSize, uncompressedSize, true);
+        return std::get<0>(fileInfo);
     }
 
     void AppxBundleWriter::ValidateCompressionOption(APPX_COMPRESSION_OPTION compressionOpt)

--- a/src/msix/pack/AppxPackageWriter.cpp
+++ b/src/msix/pack/AppxPackageWriter.cpp
@@ -194,10 +194,10 @@ namespace MSIX {
         // Add file to block map.
         if (addToBlockMap)
         {
-            m_blockMapWriter.AddFile(name, uncompressedSize, fileInfo.first);
+            m_blockMapWriter.AddFile(name, uncompressedSize, std::get<1>(fileInfo));
         }
 
-        auto& zipFileStream = fileInfo.second;
+        auto& zipFileStream = std::get<2>(fileInfo);
 
         std::uint64_t bytesToRead = uncompressedSize;
         std::uint32_t crc = 0;

--- a/src/msix/pack/BundleManifestWriter.cpp
+++ b/src/msix/pack/BundleManifestWriter.cpp
@@ -26,6 +26,8 @@ namespace MSIX {
     static const char* packageArchitectureAttribute = "Architecture";
     static const char* packageResourceIdAttribute = "ResourceId";
     static const char* fileNameAttribute = "FileName";
+    static const char* offsetAttribute = "Offset";
+    static const char* sizeAttribute = "Size";
     static const char* resourcesManifestElement = "Resources";
     static const char* resourceManifestElement = "Resource";
     static const char* resourceLanguageAttribute = "Language";
@@ -133,19 +135,17 @@ namespace MSIX {
             m_xmlWriter.AddAttribute(packageResourceIdAttribute, packageInfo.resourceId);
         }
 
-        if(!packageInfo.fileName.empty())
+        if(packageInfo.fileName.empty())
         {
-            m_xmlWriter.AddAttribute(fileNameAttribute, packageInfo.fileName);
+             // If the file name is empty, we shouldn't be here.
+             ThrowError(Error::Unexpected);
         }
+        m_xmlWriter.AddAttribute(fileNameAttribute, packageInfo.fileName);
 
-        if(packageInfo.offset > 0)
+        if(packageInfo.size > 0)
         {
-            //TODO: not applicable for flat bundle
-        }
-
-        if (packageInfo.size > 0 && packageInfo.offset > 0)
-        {
-            //TODO: not applicable for flat bundles
+            m_xmlWriter.AddAttribute(offsetAttribute, std::to_string(packageInfo.offset));
+            m_xmlWriter.AddAttribute(sizeAttribute, std::to_string(packageInfo.size));
         }
 
         //WriteResourcesElement

--- a/src/msix/pack/BundleWriterHelper.cpp
+++ b/src/msix/pack/BundleWriterHelper.cpp
@@ -147,7 +147,7 @@ namespace MSIX {
     {
         packagesVector.push_back(packageInfo);
 
-        if (packageInfo.offset == 0)
+        if (packageInfo.offset == 0 && packageInfo.size == 0)
         {
             this->hasExternalPackages = true;
         }

--- a/src/msix/pack/ZipObjectWriter.cpp
+++ b/src/msix/pack/ZipObjectWriter.cpp
@@ -65,7 +65,7 @@ namespace MSIX {
     }
 
     // IZipWriter
-    std::pair<std::uint32_t, ComPtr<IStream>> ZipObjectWriter::PrepareToAddFile(const std::string& name, bool isCompressed)
+    std::tuple<std::uint64_t, std::uint32_t, ComPtr<IStream>> ZipObjectWriter::PrepareToAddFile(const std::string& name, bool isCompressed)
     {
         ThrowErrorIf(Error::InvalidState, m_state != ZipObjectWriter::State::ReadyForLfhOrClose, "Invalid zip writer state");
 
@@ -97,7 +97,7 @@ namespace MSIX {
             zipStream = ComPtr<IStream>::Make<DeflateStream>(zipStream);
         }
 
-        return std::make_pair(static_cast<std::uint32_t>(m_lastLFH.second.Size()), std::move(zipStream));
+        return std::make_tuple(m_lastLFH.first, static_cast<std::uint32_t>(m_lastLFH.second.Size()), std::move(zipStream));
     }
 
     void ZipObjectWriter::EndFile(std::uint32_t crc, std::uint64_t compressedSize, std::uint64_t uncompressedSize, bool forceDataDescriptor)


### PR DESCRIPTION
Here is a summary of the changes:

1. Modified IZipWriter interface: Updated PrepareToAddFile in src/inc/internal/ZipObjectWriter.hpp to return a std::tuple<std::uint64_t, std::uint32_t, MSIX::ComPtr<IStream>>. This allows obtaining the file offset within the zip archive, which is needed for the bundle manifest.
2. Updated ZipObjectWriter implementation: Updated src/msix/pack/ZipObjectWriter.cpp to return the offset, header size, and stream.
3. Updated AppxPackageWriter: Adapted src/msix/pack/AppxPackageWriter.cpp to handle the new std::tuple return type.
4. Updated AppxBundleWriter:

* Modified AddFileToPackage in src/msix/pack/AppxBundleWriter.cpp (and header) to return std::uint64_t (the file offset).
* Implemented AddPayloadPackage to:
     * Create an IAppxPackageReader to validate the input stream.
     * Call AddFileToPackage to add the package file to the bundle zip and get its offset.
     * Reset the stream position.
     * Call m_bundleWriterHelper.AddPackage with the correct offset and size to register the package in the bundle manifest.

The implementation ensures that payload packages are correctly added to the bundle file and referenced in the bundle manifest with their physical offset.

    HRESULT STDMETHODCALLTYPE AppxBundleWriter::AddPayloadPackage(LPCWSTR fileName, IStream* packageStream, 
        BOOL isDefaultApplicablePackage) noexcept try
    {
        auto appxFactory = m_factory.As<IAppxFactory>();
        ComPtr<IAppxPackageReader> reader;
        ThrowHrIfFailed(appxFactory->CreatePackageReader(packageStream, &reader));

        std::string name = wstring_to_utf8(fileName);
        std::uint64_t offset = AddFileToPackage(name, packageStream, false, true, nullptr);

        // Reset stream for reader safety
        LARGE_INTEGER start = { 0 };
        ThrowHrIfFailed(packageStream->Seek(start, StreamBase::Reference::START, nullptr));

        std::uint64_t size = m_bundleWriterHelper.GetStreamSize(packageStream);
        m_bundleWriterHelper.AddPackage(name, reader.Get(), offset, size, !!isDefaultApplicablePackage);
        return static_cast<HRESULT>(Error::OK);
    } CATCH_RETURN();